### PR TITLE
fix(hub): prune orphaned hub sources on collection URL rename

### DIFF
--- a/apps/vscode-extension/resources/skills/prompt-registry-helper/references/author-guide/adding-profile-source-to-hub.md
+++ b/apps/vscode-extension/resources/skills/prompt-registry-helper/references/author-guide/adding-profile-source-to-hub.md
@@ -20,7 +20,7 @@ Add a new source to the `sources` array:
 sources:
   # Existing sources...
   
-  - id: "my-new-source"                    # Unique identifier
+  - id: "my-new-source"                    # Stable identity — keep unchanged once published
     type: "github"                         # Source type
     repository: "myorg/new-prompt-bundles" # Repository location
     name: "My New Source"                  # Display name
@@ -51,6 +51,30 @@ Set priority based on source importance:
 - **50-69**: Community sources
 - **10-49**: Experimental sources
 - **1-9**: Deprecated sources
+
+## Renaming a Source URL
+
+A source's `id` is its stable identity. Keep the `id` value unchanged and change only the URL — `repository` for `github` and `awesome-copilot` sources, `url` for `apm` sources:
+
+```yaml
+sources:
+  - id: "ml-prompts"                              # Unchanged — this is the identity
+    type: "github"
+    repository: "myorg/ml-prompt-collection-v2"   # Changed — the new location
+    name: "ML Prompt Collection"
+    enabled: true
+    priority: 80
+```
+
+Because the `id` stayed the same, users who already installed bundles from this source keep them attached: on the next hub sync, their installed bundles migrate to the renamed repository and stay updatable.
+
+Changing an `id` means something different. It is read as removing one source and adding an unrelated one. The removed source is kept — not deleted — while installed bundles still reference it, so nothing is lost, but those bundles stay pointed at the old location and stop receiving updates from the new one.
+
+Changing an `id` also breaks profiles, with or without a URL change. A profile bundle's `source` field names a source `id`, so every profile entry referencing the old `id` no longer resolves. That constraint already exists today; keeping the `id` stable is how you avoid it.
+
+### Backfill Window
+
+The registry remembers which hub declaration each installed source came from. Sources that users stored before this tracking existed do not carry that link yet — it is written on the next successful sync of the hub that owns them. If a rename lands before that sync, the pre-rename source is kept alive instead of migrated, and users see a warning in the logs naming the reason. Publish the rename in a separate commit from any other source change so users get one sync to backfill first.
 
 ## Adding a Profile
 
@@ -225,6 +249,12 @@ profiles:
 - Confirm bundle IDs exist in specified sources
 - Check version availability
 - Verify source is enabled and synced
+
+### Installed Bundles Did Not Migrate After a Repository Rename
+- Confirm the source's `id` is byte-identical to what you published before the rename — a changed `id` is read as remove-plus-add, so the old source is kept and its bundles stay on the old location
+- Confirm exactly one source declaration carries that `id`; an ambiguous match is never guessed
+- If users synced the hub for the first time only after the rename, the pre-rename source has no recorded link yet (see [Backfill Window](#backfill-window)); reverting the URL, letting users sync once, then re-applying the rename restores the migration path
+- Ask users to check the extension logs: each kept-alive source is reported with the source id, how many installed bundles reference it, and the reason
 
 ### Permission Issues
 - Ensure you have write access to the hub repository

--- a/apps/vscode-extension/resources/skills/prompt-registry-helper/references/reference/hub-schema.md
+++ b/apps/vscode-extension/resources/skills/prompt-registry-helper/references/reference/hub-schema.md
@@ -82,10 +82,22 @@ The `sources` array defines bundle sources available in the hub.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `id` | string | Unique identifier (alphanumeric, hyphens, underscores; 1-50 chars) |
+| `id` | string | Stable identity of the source, unique within the hub (alphanumeric, hyphens, underscores; 1-50 chars). Stays unchanged once the hub configuration is published — see [Source Identity](#source-identity) |
 | `type` | string | Source type (see below) |
 | `enabled` | boolean | Whether this source is currently active |
 | `priority` | number | Priority order for source resolution (0-100, higher = higher priority) |
+
+### Source Identity
+
+A source's `id` is its identity, not a label. Once a hub configuration is published, that value stays unchanged for the lifetime of the source.
+
+**Renaming a source URL.** Keep the `id` value unchanged and change only the location — `repository` for `github` and `awesome-copilot` sources, `url` for `apm` sources. Because the `id` stayed the same, users who already installed bundles from that source have those bundles migrated to the new location on the next hub sync, so they stay updatable.
+
+**Changing an `id` is a different edit.** It is read as removing one source and adding an unrelated one. The removed source is kept rather than deleted while installed bundles still reference it, so nothing is lost, but those bundles stay pointed at the old location and stop receiving updates from the new one.
+
+**Changing an `id` also breaks profiles**, with or without a URL change. A profile bundle's `source` field names a source `id` (see [Bundle Object](#bundle-object-within-profile)), so every profile entry referencing the old `id` no longer resolves. That consequence is independent of installed-bundle migration.
+
+See [Renaming a Source URL](../author-guide/adding-profile-source-to-hub.md#renaming-a-source-url) in the author guide for the full workflow and its troubleshooting entries.
 
 ### Source Types
 
@@ -184,7 +196,7 @@ The `profiles` array defines predefined bundle collections.
 |-------|------|----------|-------------|
 | `id` | string | Yes | Bundle identifier (1-50 chars) |
 | `version` | string | Yes | Bundle version (semver or `"latest"`) |
-| `source` | string | Yes | Source ID where this bundle is available |
+| `source` | string | Yes | The `id` of a source declared in this hub's `sources` array (see [Source Identity](#source-identity)) |
 | `required` | boolean | Yes | Whether this bundle is mandatory for the profile |
 
 ### Example
@@ -328,5 +340,6 @@ Validation errors are displayed in VS Code notifications and logged to the outpu
 ## See Also
 
 - [Profiles and Hubs Guide](../user-guide/profiles-and-hubs.md) — User guide for working with hubs
+- [Adding Profiles and Sources to Existing Hubs](../author-guide/adding-profile-source-to-hub.md) — Editing `sources[]`, including renaming a source URL
 - [Collection Schema](../author-guide/collection-schema.md) — Schema for collection YAML files
 - [Settings Reference](./settings.md) — Extension configuration options

--- a/apps/vscode-extension/resources/skills/prompt-registry-helper/references/user-guide/troubleshooting.md
+++ b/apps/vscode-extension/resources/skills/prompt-registry-helper/references/user-guide/troubleshooting.md
@@ -55,6 +55,17 @@ If you selected a hub but it doesn't appear in the Registry Explorer:
 3. Run `AI Primitives Hub: Sync Hub` from the Command Palette
 4. If the hub still doesn't appear, run `AI Primitives Hub: Reset First Run`, then reload VS Code (`Ctrl+R`)
 
+### Bundles Stopped Updating After a Hub Renamed a Repository
+
+When a hub changes the URL of one of its sources, installed bundles normally follow the source to its new URL automatically. If they stopped receiving updates instead, the extension could not prove which new source replaced the old one.
+
+Nothing is lost: the pre-rename source is kept rather than deleted, so your installed bundles stay intact and keep working from where they were installed.
+
+1. Check the logs (`View → Output → AI Primitives Hub`) — a warning names the kept source and the reason its replacement could not be determined
+2. Run `AI Primitives Hub: Sync Hub` from the Command Palette to retry the migration
+3. If the bundles still don't update, reinstall them from the renamed source in the Registry Explorer — run `AI Primitives Hub: List Sources` to see both the kept source and its replacement
+4. Report the reason from the log to the hub author: keeping a source `id` stable while changing its `url` lets installed bundles migrate on their own
+
 ### Hub Selector Not Shown on First Launch
 
 If you installed the extension but were never prompted to select a hub:

--- a/apps/vscode-extension/src/services/hub-manager.ts
+++ b/apps/vscode-extension/src/services/hub-manager.ts
@@ -353,7 +353,10 @@ export class HubManager {
       {
         listSources: () => this.registryManager.listSources(),
         addSource: (s) => this.registryManager.addSource(s),
-        updateSource: (id, u) => this.registryManager.updateSource(id, u)
+        updateSource: (id, u) => this.registryManager.updateSource(id, u),
+        removeSource: (id) => this.registryManager.removeSource(id),
+        listInstalledBundles: () => this.registryManager.listInstalledBundles(),
+        remapBundleSource: (oldSourceId, newSourceId) => this.registryManager.remapBundleSource(oldSourceId, newSourceId)
       },
       this.translateLogEvent,
       {
@@ -605,7 +608,10 @@ export class HubManager {
           {
             listSources: () => this.registryManager.listSources(),
             addSource: (s) => this.registryManager.addSource(s),
-            updateSource: (id, u) => this.registryManager.updateSource(id, u)
+            updateSource: (id, u) => this.registryManager.updateSource(id, u),
+            removeSource: (id) => this.registryManager.removeSource(id),
+            listInstalledBundles: () => this.registryManager.listInstalledBundles(),
+            remapBundleSource: (oldSourceId, newSourceId) => this.registryManager.remapBundleSource(oldSourceId, newSourceId)
           },
           this.translateLogEvent,
           {
@@ -664,7 +670,10 @@ export class HubManager {
         {
           listSources: () => this.registryManager.listSources(),
           addSource: (source) => this.registryManager.addSource(source),
-          updateSource: (sourceId, updates) => this.registryManager.updateSource(sourceId, updates)
+          updateSource: (sourceId, updates) => this.registryManager.updateSource(sourceId, updates),
+          removeSource: (sourceId) => this.registryManager.removeSource(sourceId),
+          listInstalledBundles: () => this.registryManager.listInstalledBundles(),
+          remapBundleSource: (oldSourceId, newSourceId) => this.registryManager.remapBundleSource(oldSourceId, newSourceId)
         },
         this.translateLogEvent,
         options

--- a/apps/vscode-extension/src/services/lockfile-manager.ts
+++ b/apps/vscode-extension/src/services/lockfile-manager.ts
@@ -17,6 +17,7 @@ import * as path from 'node:path';
 import {
   cleanupOrphanedSource,
   readLockfile,
+  remapSourceId,
   removeBundleEntry,
   upsertBundleEntry,
   upsertSource,
@@ -950,6 +951,41 @@ export class LockfileManager {
 
     // Emit event with the target lockfile
     this._onLockfileUpdated.fire(updatedTargetLockfile);
+  }
+
+  /**
+   * Remap all bundle entries referencing oldSourceId to newSourceId in both
+   * lockfiles (commit + local-only). Used when a hub collection URL is renamed
+   * so that existing installations track the new source seamlessly.
+   * @param oldSourceId - Source id being retired.
+   * @param newSourceId - Replacement source id.
+   * @param newSourceDescriptor - Source descriptor for the replacement.
+   */
+  public async remapSourceId(
+    oldSourceId: string,
+    newSourceId: string,
+    newSourceDescriptor: LockfileSourceEntry
+  ): Promise<void> {
+    for (const mode of ['commit', 'local-only'] as const) {
+      const lockfile = await this.readLockfileByMode(mode);
+      if (!lockfile) {
+        continue;
+      }
+
+      const hasAffectedBundles = Object.values(lockfile.bundles)
+        .some((b) => b.sourceId === oldSourceId);
+      if (!hasAffectedBundles) {
+        continue;
+      }
+
+      const updated = remapSourceId(lockfile, oldSourceId, newSourceId, newSourceDescriptor);
+      updated.generatedAt = new Date().toISOString();
+      await this.writeAtomicToPath(updated, this.getLockfilePathForMode(mode));
+      this._onLockfileUpdated.fire(updated);
+      this.logger.info(
+        `Remapped source ${oldSourceId} -> ${newSourceId} in ${mode} lockfile`
+      );
+    }
   }
 
   /**

--- a/apps/vscode-extension/src/services/registry-manager.ts
+++ b/apps/vscode-extension/src/services/registry-manager.ts
@@ -9,6 +9,7 @@ import {
 import * as path from 'node:path';
 import {
   activateRegistryProfile,
+  remapBundleSource as appRemapBundleSource,
   canonicalizeIndexHubId,
   createLocalProfile,
   deactivateRegistryProfile,
@@ -879,6 +880,44 @@ export class RegistryManager {
 
     this._onSourceRemoved.fire(sourceId);
     this.logger.info(`Source '${sourceId}' removed successfully`);
+  }
+
+  /**
+   * Remap installed bundles from an old source to a new one.
+   *
+   * Thin delegator to `@ai-primitives-hub/app`'s `remapBundleSource`, which
+   * owns the ordering that matters: it resolves the replacement source's
+   * descriptor and rejects before writing anything when that source is
+   * absent, so a failed remap never half-migrates and then lets the caller
+   * delete the orphan.
+   * @param oldSourceId - Source id being retired.
+   * @param newSourceId - Replacement source id.
+   */
+  public async remapBundleSource(oldSourceId: string, newSourceId: string): Promise<void> {
+    // No workspace means no repository in scope, hence no repository-scope
+    // bundles to migrate: the lockfile port is left unwired, which the use
+    // case treats as a valid skip rather than a failure.
+    const workspaceRoot = getWorkspaceRoot();
+
+    await appRemapBundleSource(
+      oldSourceId,
+      newSourceId,
+      {
+        listSources: () => this.storage.getSources(),
+        remapLockfileSourceId: workspaceRoot
+          ? (oldId, newId, descriptor) =>
+            LockfileManager.getInstance(workspaceRoot).remapSourceId(oldId, newId, descriptor)
+          : undefined,
+        getInstalledBundles: (scope) => this.storage.getInstalledBundles(scope),
+        // `core`'s `DeploymentManifest.mcpServers` is intentionally looser
+        // (`Record<string, unknown>`) than this extension's
+        // `McpServersManifest` (see `installBundle`'s identical, documented
+        // cast) — the data itself is always this extension's own shape here,
+        // since it only ever flows back out of `RegistryStorage` above.
+        recordInstallation: (bundle) => this.storage.recordInstallation(bundle as InstalledBundle)
+      },
+      (event) => this.forwardLogEvent(event)
+    );
   }
 
   /**

--- a/apps/vscode-extension/src/types/registry.ts
+++ b/apps/vscode-extension/src/types/registry.ts
@@ -39,6 +39,13 @@ export interface RegistrySource {
   private?: boolean;
   token?: string; // Environment variable or secure storage key
   hubId?: string; // Hub identifier if this source is from a curated hub
+  /**
+   * The hub config `sources[].id` this source was provisioned from — the
+   * stable, author-assigned identity that survives a `url` change. Used to
+   * match a pre-rename orphan to its replacement. Absent on manually-added
+   * sources and on hub sources persisted before this field existed.
+   */
+  hubSourceId?: string;
   metadata?: {
     description?: string;
     homepage?: string;

--- a/apps/vscode-extension/test/helpers/property-test-helpers.ts
+++ b/apps/vscode-extension/test/helpers/property-test-helpers.ts
@@ -231,7 +231,7 @@ export const PropertyTestConfig = {
   FAST_CHECK_OPTIONS: {
     verbose: false,
     endOnFailure: true, // Stop on first failure for faster feedback
-    interruptAfterTimeLimit: 1000 // Stop after 1 second per property
+    interruptAfterTimeLimit: 4000 // Stop after 4 seconds per property (Windows CI needs headroom for filesystem I/O)
   }
 };
 

--- a/apps/vscode-extension/test/services/hub-cleanup.test.ts
+++ b/apps/vscode-extension/test/services/hub-cleanup.test.ts
@@ -47,6 +47,10 @@ class MockRegistryManager {
     this.sources = this.sources.filter((s) => s.id !== sourceId);
   }
 
+  public listInstalledBundles() {
+    return Promise.resolve([]);
+  }
+
   public updateSource(sourceId: string, updates: any) {
     const source = this.sources.find((s) => s.id === sourceId);
     if (source) {
@@ -333,18 +337,22 @@ suite('Hub Cleanup', () => {
     });
 
     test('should cleanup when clearing active hub (setting to null)', async () => {
+      const fixturePath = path.join(__dirname, '..', 'fixtures', 'hubs', 'valid-hub-config.yml');
+      const ref: HubReference = { type: 'local', location: fixturePath };
+      await hubManager.importHub(ref, 'hub1');
+      await hubManager.setActiveHub('hub1');
+      await hubManager.toggleProfileFavorite('hub1', 'profile1');
+
+      // Seed a hub1 source/profile AFTER import so the clear-active-hub
+      // cleanup path (not import-time orphan pruning) is what removes them.
+      // These are not declared in the fixture, so seeding before import
+      // would let loadHubSources prune the source as an orphan first.
       mockRegistryManager.sources = [
         { id: 'hub-hub1-source1', name: 'Hub1 Source', hubId: 'hub1' }
       ];
       mockRegistryManager.profiles = [
         { id: 'hub1-profile', name: 'Hub1 Profile', active: true, hubId: 'hub1' }
       ];
-
-      const fixturePath = path.join(__dirname, '..', 'fixtures', 'hubs', 'valid-hub-config.yml');
-      const ref: HubReference = { type: 'local', location: fixturePath };
-      await hubManager.importHub(ref, 'hub1');
-      await hubManager.setActiveHub('hub1');
-      await hubManager.toggleProfileFavorite('hub1', 'profile1');
 
       // Clear active hub
       mockRegistryManager.removedSourceIds = [];

--- a/apps/vscode-extension/test/services/hub-manager.test.ts
+++ b/apps/vscode-extension/test/services/hub-manager.test.ts
@@ -762,6 +762,7 @@ suite('Hub Source Loading - SourceId Format', () => {
     public addSourceCalls: RegistrySource[] = [];
     public updateSourceCalls: { id: string; updates: Partial<RegistrySource> }[] = [];
     public syncSourceCalls: string[] = [];
+    public removeSourceCalls: string[] = [];
 
     public listSources(): Promise<RegistrySource[]> {
       return Promise.resolve([...this.sources]);
@@ -787,11 +788,25 @@ suite('Hub Source Loading - SourceId Format', () => {
       return Promise.resolve();
     }
 
+    public removeSource(id: string): Promise<void> {
+      const index = this.sources.findIndex((s) => s.id === id);
+      if (index !== -1) {
+        this.sources.splice(index, 1);
+        this.removeSourceCalls.push(id);
+      }
+      return Promise.resolve();
+    }
+
+    public listInstalledBundles(): Promise<RegistrySource[]> {
+      return Promise.resolve([]);
+    }
+
     public reset(): void {
       this.sources = [];
       this.addSourceCalls = [];
       this.updateSourceCalls = [];
       this.syncSourceCalls = [];
+      this.removeSourceCalls = [];
     }
 
     public getSourceCount(): number {
@@ -1055,6 +1070,52 @@ suite('Hub Source Loading - SourceId Format', () => {
       assert.strictEqual(sourcesAfterReload.length, 2, 'Should still have only 2 sources (no duplicates)');
       assert.strictEqual(mockRegistry.updateSourceCalls.length, 2, 'Should have 2 update calls');
       assert.strictEqual(mockRegistry.addSourceCalls.length, 0, 'Should have 0 add calls on reload');
+    });
+
+    test('should prune an orphaned hub source on collection URL rename, leaving manual sources untouched', async () => {
+      // Import the hub, loading its two declared sources under this hubId.
+      await hubManager.importHub(localRef, 'test-orphan-prune');
+      assert.strictEqual(mockRegistry.getSourceCount(), 2, 'Should have 2 sources after import');
+
+      // Stale source left behind by a collection URL rename: same hub,
+      // but a sourceId that is no longer present in the hub config.
+      const orphan: RegistrySource = {
+        id: 'awesome-copilot-oldhash',
+        name: 'Old Renamed Collection',
+        type: 'awesome-copilot',
+        url: 'https://github.com/github/old-name',
+        enabled: true,
+        priority: 1,
+        hubId: 'test-orphan-prune',
+        config: { branch: 'main', collectionsPath: 'collections' }
+      };
+      await mockRegistry.addSource(orphan);
+
+      // Manually-added source (no hubId) must never be touched.
+      const manual: RegistrySource = {
+        id: 'manual-source',
+        name: 'Manual',
+        type: 'awesome-copilot',
+        url: 'https://github.com/org/manual',
+        enabled: true,
+        priority: 1,
+        config: { branch: 'main', collectionsPath: 'collections' }
+      };
+      await mockRegistry.addSource(manual);
+
+      mockRegistry.removeSourceCalls = [];
+
+      // Reload the same hub: the orphan is pruned, the manual one kept.
+      await hubManager.loadHubSources('test-orphan-prune');
+
+      assert.ok(!mockRegistry.hasSource('awesome-copilot-oldhash'), 'Orphaned hub source should be removed');
+      assert.ok(mockRegistry.hasSource('manual-source'), 'Manually-added source should be preserved');
+      assert.deepStrictEqual(
+        mockRegistry.removeSourceCalls,
+        ['awesome-copilot-oldhash'],
+        'Only the orphaned hub source should be removed'
+      );
+      assert.strictEqual(mockRegistry.getSourceCount(), 3, 'Two hub sources + one manual source remain');
     });
   });
 });

--- a/apps/vscode-extension/test/services/hub-source-loading.test.ts
+++ b/apps/vscode-extension/test/services/hub-source-loading.test.ts
@@ -60,6 +60,14 @@ class MockRegistryManager {
     }
   }
 
+  public async removeSource(id: string): Promise<void> {
+    this.sources = this.sources.filter((s) => s.id !== id);
+  }
+
+  public async listInstalledBundles(): Promise<never[]> {
+    return [];
+  }
+
   public reset(): void {
     this.sources = [];
     this.addSourceCalls = [];

--- a/apps/vscode-extension/test/services/registry-manager.remapBundleSource.test.ts
+++ b/apps/vscode-extension/test/services/registry-manager.remapBundleSource.test.ts
@@ -1,0 +1,242 @@
+/**
+ * RegistryManager.remapBundleSource Delegation Tests
+ *
+ * Feature: hub-source-orphan-remap (Cycle F)
+ *
+ * `remapBundleSource` is a thin delegator over the shared
+ * `@ai-primitives-hub/app` use case: it wires the storage, lockfile, and
+ * logging boundaries and holds no orchestration of its own. These tests
+ * verify that contract through the delegator's observable behavior:
+ *
+ * - both source ids reach the remap, and the replacement's descriptor is
+ *   resolved from stored sources before any store is written
+ * - a start line and a completion line are recorded through
+ *   `Logger.getInstance()`, each naming both ids
+ * - a rejection raised by the use case reaches the caller, with nothing
+ *   written — an unresolvable replacement must not half-migrate and then let
+ *   the caller delete the orphan
+ *
+ * Only the storage and lockfile boundaries are mocked; the RegistryManager
+ * under test is a real instance.
+ *
+ * Validates: Requirements 6.4, 7.2
+ */
+
+import * as assert from 'node:assert';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import {
+  LockfileManager,
+} from '../../src/services/lockfile-manager';
+import {
+  RegistryManager,
+} from '../../src/services/registry-manager';
+import {
+  RegistryStorage,
+} from '../../src/storage/registry-storage';
+import {
+  InstalledBundle,
+  RegistrySource,
+} from '../../src/types/registry';
+import {
+  Logger,
+} from '../../src/utils/logger';
+
+suite('RegistryManager.remapBundleSource - delegates to the app use case', () => {
+  const OLD_SOURCE_ID = 'old-source-id';
+  const NEW_SOURCE_ID = 'new-source-id';
+  const WORKSPACE_ROOT = '/mock/workspace';
+
+  let sandbox: sinon.SinonSandbox;
+  let manager: RegistryManager;
+  let mockStorage: sinon.SinonStubbedInstance<RegistryStorage>;
+  let remapSourceIdStub: sinon.SinonStub;
+  let loggedMessages: string[];
+
+  const makeSource = (overrides: Partial<RegistrySource> = {}): RegistrySource => ({
+    id: NEW_SOURCE_ID,
+    name: 'Renamed Collection',
+    type: 'github',
+    url: 'https://github.com/org/renamed',
+    enabled: true,
+    priority: 1,
+    hubId: 'hub-a',
+    config: { branch: 'main', collectionsPath: 'collections' },
+    ...overrides
+  });
+
+  const makeInstalledBundle = (
+    bundleId: string,
+    sourceId: string,
+    scope: 'user' | 'workspace' = 'user'
+  ): InstalledBundle => ({
+    bundleId,
+    version: '1.0.0',
+    installedAt: '2024-01-01T00:00:00Z',
+    scope,
+    installPath: `/mock/${scope}/${bundleId}`,
+    sourceId,
+    sourceType: 'github',
+    manifest: { id: bundleId, name: bundleId, version: '1.0.0' } as any
+  });
+
+  const createMockContext = (mockSandbox: sinon.SinonSandbox): vscode.ExtensionContext => ({
+    globalState: {
+      get: mockSandbox.stub(),
+      update: mockSandbox.stub().resolves(),
+      keys: mockSandbox.stub().returns([]),
+      setKeysForSync: mockSandbox.stub()
+    } as any,
+    workspaceState: {
+      get: mockSandbox.stub(),
+      update: mockSandbox.stub().resolves(),
+      keys: mockSandbox.stub().returns([]),
+      setKeysForSync: mockSandbox.stub()
+    } as any,
+    subscriptions: [],
+    extensionPath: '/mock/path',
+    extensionUri: vscode.Uri.file('/mock/path'),
+    storageUri: vscode.Uri.file('/mock/storage'),
+    globalStorageUri: vscode.Uri.file('/mock/global'),
+    asAbsolutePath: (p: string) => `/mock/path/${p}`
+  } as any);
+
+  setup(() => {
+    sandbox = sinon.createSandbox();
+
+    // Record every line the delegator writes through the shared logger,
+    // whatever level it chooses.
+    loggedMessages = [];
+    const logger = Logger.getInstance();
+    const capture = (message: string): void => {
+      loggedMessages.push(message);
+    };
+    sandbox.stub(logger, 'info').callsFake(capture);
+    sandbox.stub(logger, 'debug').callsFake(capture);
+    sandbox.stub(logger, 'warn').callsFake(capture);
+
+    RegistryManager.resetInstance();
+    manager = RegistryManager.getInstance(createMockContext(sandbox));
+
+    mockStorage = sandbox.createStubInstance(RegistryStorage);
+    mockStorage.getSources.resolves([]);
+    mockStorage.getInstalledBundles.resolves([]);
+    mockStorage.recordInstallation.resolves();
+    (manager as any).storage = mockStorage;
+
+    // Lockfile boundary: a workspace is open, so the repository-scope port
+    // is wired.
+    const scopeSelectionUI = require('../../src/utils/scope-selection-ui');
+    sandbox.stub(scopeSelectionUI, 'getWorkspaceRoot').returns(WORKSPACE_ROOT);
+
+    remapSourceIdStub = sandbox.stub().resolves();
+    sandbox.stub(LockfileManager, 'getInstance').returns({
+      remapSourceId: remapSourceIdStub
+    } as any);
+  });
+
+  teardown(() => {
+    sandbox.restore();
+    RegistryManager.resetInstance();
+  });
+
+  test('forwards both source ids and the resolved replacement descriptor to every scope', async () => {
+    const replacement = makeSource();
+    mockStorage.getSources.resolves([
+      makeSource({ id: OLD_SOURCE_ID, name: 'Pre-rename Collection', url: 'https://github.com/org/old' }),
+      replacement
+    ]);
+    mockStorage.getInstalledBundles.withArgs('user').resolves([
+      makeInstalledBundle('bundle-a', OLD_SOURCE_ID),
+      makeInstalledBundle('bundle-untouched', 'unrelated-source')
+    ]);
+    mockStorage.getInstalledBundles.withArgs('workspace').resolves([
+      makeInstalledBundle('bundle-b', OLD_SOURCE_ID, 'workspace')
+    ]);
+
+    await manager.remapBundleSource(OLD_SOURCE_ID, NEW_SOURCE_ID);
+
+    assert.strictEqual(remapSourceIdStub.callCount, 1, 'repository scope should be remapped once');
+    const [oldId, newId, descriptor] = remapSourceIdStub.firstCall.args;
+    assert.strictEqual(oldId, OLD_SOURCE_ID, 'old source id should be forwarded');
+    assert.strictEqual(newId, NEW_SOURCE_ID, 'new source id should be forwarded');
+    assert.deepStrictEqual(
+      descriptor,
+      {
+        type: replacement.type,
+        url: replacement.url,
+        branch: 'main',
+        collectionsPath: 'collections'
+      },
+      'descriptor should be resolved from the replacement source'
+    );
+
+    const rewritten = mockStorage.recordInstallation.getCalls().map((call) => call.args[0]);
+    assert.deepStrictEqual(
+      rewritten.map((bundle) => bundle.bundleId).toSorted(),
+      ['bundle-a', 'bundle-b'],
+      'only records referencing the old source id should be rewritten'
+    );
+    assert.ok(
+      rewritten.every((bundle) => bundle.sourceId === NEW_SOURCE_ID),
+      'rewritten records should reference the new source id'
+    );
+  });
+
+  test('records a start line and a completion line through Logger.getInstance()', async () => {
+    mockStorage.getSources.resolves([
+      makeSource({ id: OLD_SOURCE_ID, url: 'https://github.com/org/old' }),
+      makeSource()
+    ]);
+    mockStorage.getInstalledBundles.withArgs('user').resolves([
+      makeInstalledBundle('bundle-a', OLD_SOURCE_ID)
+    ]);
+    mockStorage.getInstalledBundles.withArgs('workspace').resolves([]);
+
+    await manager.remapBundleSource(OLD_SOURCE_ID, NEW_SOURCE_ID);
+
+    const namingBothIds = loggedMessages.filter(
+      (message) => message.includes(OLD_SOURCE_ID) && message.includes(NEW_SOURCE_ID)
+    );
+    const completion = namingBothIds.filter((message) => /complete/i.test(message));
+    const start = namingBothIds.filter((message) => !/complete/i.test(message));
+
+    assert.strictEqual(
+      start.length,
+      1,
+      `expected one start line naming both ids, got: ${JSON.stringify(loggedMessages)}`
+    );
+    assert.strictEqual(
+      completion.length,
+      1,
+      `expected one completion line naming both ids, got: ${JSON.stringify(loggedMessages)}`
+    );
+  });
+
+  test('propagates the use case rejection and writes nothing when the replacement source is absent', async () => {
+    // The replacement id is not in storage: the shared use case rejects
+    // before touching any store, so the caller can keep the orphan alive.
+    mockStorage.getSources.resolves([
+      makeSource({ id: OLD_SOURCE_ID, url: 'https://github.com/org/old' })
+    ]);
+    mockStorage.getInstalledBundles.withArgs('user').resolves([
+      makeInstalledBundle('bundle-a', OLD_SOURCE_ID)
+    ]);
+    mockStorage.getInstalledBundles.withArgs('workspace').resolves([
+      makeInstalledBundle('bundle-b', OLD_SOURCE_ID, 'workspace')
+    ]);
+
+    await assert.rejects(
+      manager.remapBundleSource(OLD_SOURCE_ID, NEW_SOURCE_ID),
+      (error: Error) => error.message.includes(NEW_SOURCE_ID),
+      'an unresolvable replacement should reject, naming the missing source id'
+    );
+
+    assert.strictEqual(remapSourceIdStub.callCount, 0, 'the lockfile must not be rewritten');
+    assert.strictEqual(
+      mockStorage.recordInstallation.callCount,
+      0,
+      'no installation record must be rewritten'
+    );
+  });
+});

--- a/apps/vscode-extension/test/services/version-consolidator.property.test.ts
+++ b/apps/vscode-extension/test/services/version-consolidator.property.test.ts
@@ -249,8 +249,13 @@ suite('VersionConsolidator Property Tests', () => {
           // Consolidate
           const consolidated = consolidator.consolidateBundles(allBundles);
 
-          // Should have exactly one entry per unique repository
-          const expectedCount = repoConfigs.length;
+          // Should have exactly one entry per unique repository. The generator
+          // may emit the same owner/repo more than once; those collapse into a
+          // single consolidated entry, so count distinct repositories rather
+          // than raw config entries.
+          const expectedCount = new Set(
+            repoConfigs.map((config) => `${config.owner}/${config.repo}`)
+          ).size;
 
           // Verify count matches
           if (consolidated.length !== expectedCount) {

--- a/docs/author-guide/adding-profile-source-to-hub.md
+++ b/docs/author-guide/adding-profile-source-to-hub.md
@@ -20,7 +20,7 @@ Open the hub's YAML configuration file and add a new source to the `sources` arr
 sources:
   # Existing sources...
   
-  - id: "my-new-source"                    # Unique identifier
+  - id: "my-new-source"                    # Stable identity — keep unchanged once published
     type: "github"                         # Source type
     repository: "myorg/new-prompt-bundles" # Repository location
     name: "My New Source"                  # Display name
@@ -62,6 +62,30 @@ The Hub schema accepts priorities from `0` through `100`; higher values win
 when sources conflict. There are no canonical category ranges. Choose values
 relative to the other sources in the same Hub and document any team-specific
 convention in the Hub repository.
+
+## Renaming a Source URL
+
+A source's `id` is its stable identity. Keep the `id` value unchanged and change only the URL — `repository` for `github` and `awesome-copilot` sources, `url` for `apm` sources:
+
+```yaml
+sources:
+  - id: "ml-prompts"                              # Unchanged — this is the identity
+    type: "github"
+    repository: "myorg/ml-prompt-collection-v2"   # Changed — the new location
+    name: "ML Prompt Collection"
+    enabled: true
+    priority: 80
+```
+
+Because the `id` stayed the same, users who already installed bundles from this source keep them attached: on the next hub sync, their installed bundles migrate to the renamed repository and stay updatable.
+
+Changing an `id` means something different. It is read as removing one source and adding an unrelated one. The removed source is kept — not deleted — while installed bundles still reference it, so nothing is lost, but those bundles stay pointed at the old location and stop receiving updates from the new one.
+
+Changing an `id` also breaks profiles, with or without a URL change. A profile bundle's `source` field names a source `id`, so every profile entry referencing the old `id` no longer resolves. That constraint already exists today; keeping the `id` stable is how you avoid it.
+
+### Backfill Window
+
+The registry remembers which hub declaration each installed source came from. Sources that users stored before this tracking existed do not carry that link yet — it is written on the next successful sync of the hub that owns them. If a rename lands before that sync, the pre-rename source is kept alive instead of migrated, and users see a warning in the logs naming the reason. Publish the rename in a separate commit from any other source change so users get one sync to backfill first.
 
 ## Adding a Profile
 
@@ -257,6 +281,12 @@ profiles:
 - Confirm bundle IDs exist in specified sources
 - Check version availability
 - Verify source is enabled and synced
+
+### Installed Bundles Did Not Migrate After a Repository Rename
+- Confirm the source's `id` is byte-identical to what you published before the rename — a changed `id` is read as remove-plus-add, so the old source is kept and its bundles stay on the old location
+- Confirm exactly one source declaration carries that `id`; an ambiguous match is never guessed
+- If users synced the hub for the first time only after the rename, the pre-rename source has no recorded link yet (see [Backfill Window](#backfill-window)); reverting the URL, letting users sync once, then re-applying the rename restores the migration path
+- Ask users to check the extension logs: each kept-alive source is reported with the source id, how many installed bundles reference it, and the reason
 
 ### Permission Issues
 - Ensure you have write access to the hub repository

--- a/docs/contributor-guide/architecture/installation-flow.md
+++ b/docs/contributor-guide/architecture/installation-flow.md
@@ -281,6 +281,19 @@ This ensures:
 
 **Case normalization (v2)**: Source IDs generated after this version use fully case-insensitive URL normalization (host + path lowercased). Older source IDs preserved path case. The extension uses dual-read: when matching source IDs, it checks both current and legacy formats. Lockfile entries with old-format IDs continue to work and migrate organically when bundles are updated. Local data (config.json, cache) is migrated automatically on activation via `MigrationRegistry`. All migration-related code is tagged with `@migration-cleanup(sourceId-normalization-v2)` for future removal.
 
+### Orphaned Hub Source Pruning
+
+Because a hub source's sourceId is derived from its URL, renaming a collection's repository URL produces a *new* sourceId while the old source lingers—causing the same collection to appear twice in the registry.
+
+When syncing a hub, `loadHubSources` (in `@ai-primitives-hub/app`, `registry/load-hub-sources.ts`) tracks which existing sources are still represented in the current hub config (added, updated, or matched as a duplicate). Any source whose `hubId` matches the hub being loaded but is absent from that set is treated as orphaned. Manually-added sources (no `hubId`) and sources contributed by other hubs are never touched. The returned `LoadHubSourcesResult` includes a `removed` count alongside `added`/`updated`/`skipped`.
+
+Orphan handling depends on whether installed bundles reference the orphan:
+
+- **No consumers:** the orphan is removed via `HubSourceSync.removeSource`.
+- **Has consumers + `remapBundleSource` provided:** lockfile entries and installation records are remapped to the replacement source (the new sourceId from the renamed URL), then the orphan is removed. This ensures bundles continue receiving updates from the new source seamlessly.
+- **Has consumers + no `remapBundleSource`:** the orphan is kept alive with a warning, preventing bundles from becoming unmanaged.
+- **Any `addSource` failure this sync:** pruning is skipped entirely to avoid deleting an old source before its replacement lands.
+
 ### Hub Key Generation
 
 Hub entries in the lockfile use URL-based keys instead of user-defined hub IDs:

--- a/docs/contributor-guide/architecture/update-system.md
+++ b/docs/contributor-guide/architecture/update-system.md
@@ -79,6 +79,46 @@ Separate from bundle update checks, `HubSyncScheduler` keeps the active hub conf
 
 Source sync is event-driven: a single `onHubSynced` listener in `extension.ts` triggers `syncAllSources({ silent: true })` after any hub sync, ensuring sources stay in sync regardless of how the hub sync was initiated.
 
+### Source Registration and Pruning
+
+`loadHubSources` (in `packages/app`) reconciles a hub config's `sources[]` declarations with the registry on every sync. A stored source's id is derived from its location — `generateSourceId(type, url, { branch, collectionsPath })` — so the same URL declared by two hubs resolves to one stored source, and changing a declaration's `url` produces a *different* stored id.
+
+Each sync tracks two distinct sets:
+
+| Set | Contents | Purpose |
+|---|---|---|
+| Protected from pruning | Every declared source id, including disabled declarations and matched duplicates | Sources in this set are never removed |
+| Registered this cycle | Only ids a successful `addSource` or `updateSource` wrote during this sync | The only pool eligible as a remap target |
+
+A stored source belonging to the synced hub whose id is not protected is an **orphan** — typically the pre-rename record left behind by a `url` change.
+
+### Matching an Orphan to Its Replacement
+
+Each stored hub source carries `hubSourceId`, the author-assigned `sources[].id` from the hub config. That value is stable across a `url` change, so it is the matching key rather than the URL-derived id.
+
+An orphan's replacement candidates are the sources registered this cycle whose `(hubId, hubSourceId)` pair equals the orphan's. Since `hubSourceId` is unique within a hub by schema, the pair is unique across hubs.
+
+- **Exactly one candidate** — `remapBundleSource` moves installed-bundle references (repository-scope lockfile, plus user and workspace scope) from the orphan id to the candidate id, then the orphan is removed. The remap resolves the replacement descriptor *before* any write, so a missing replacement fails without mutating anything.
+- **Anything else** — keep-alive.
+
+Requiring exactly one candidate is what makes selection deterministic: a one-element result is independent of the order concurrent workers populated the map in, so `concurrency: 4` and `concurrency: 1` pick the same id.
+
+### Keep-Alive
+
+Keep-alive leaves the orphan in storage, leaves its installed-bundle records untouched, and emits one `warn` naming the orphan id and name, the number of referencing installed bundles, the reason, and the remediation. It applies when:
+
+- zero candidates match,
+- two or more candidates match,
+- the orphan carries no `hubSourceId`,
+- the remap failed,
+- or the `remapBundleSource` port is not wired.
+
+A guessed remap silently detaches bundles from their real origin and is unrecoverable; a kept orphan is inert and resolvable on the next sync. Two further guards: an orphan with zero referencing installed bundles is removed outright without a remap, and if any `addSource` failed during the sync, all orphan evaluation, removal, and remapping is skipped for that cycle.
+
+### Sticker Backfill
+
+`hubSourceId` is optional, so sources persisted before the field existed have none, and orphan handling for them falls back to keep-alive. Every successful sync writes `hubSourceId` on both added and updated sources, so the next successful sync of the owning hub backfills the field and restores deterministic matching.
+
 ## See Also
 
 - [Installation Flow](./installation-flow.md) — How updates are installed

--- a/docs/reference/hub-schema.md
+++ b/docs/reference/hub-schema.md
@@ -82,10 +82,22 @@ The `sources` array defines bundle sources available in the hub.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `id` | string | Unique identifier (alphanumeric, hyphens, underscores; 1-50 chars) |
+| `id` | string | Stable identity of the source, unique within the hub (alphanumeric, hyphens, underscores; 1-50 chars). Stays unchanged once the hub configuration is published — see [Source Identity](#source-identity) |
 | `type` | string | Source type (see below) |
 | `enabled` | boolean | Whether this source is currently active |
 | `priority` | number | Priority order for source resolution (0-100, higher = higher priority) |
+
+### Source Identity
+
+A source's `id` is its identity, not a label. Once a hub configuration is published, that value stays unchanged for the lifetime of the source.
+
+**Renaming a source URL.** Keep the `id` value unchanged and change only the location — `repository` for `github` and `awesome-copilot` sources, `url` for `apm` sources. Because the `id` stayed the same, users who already installed bundles from that source have those bundles migrated to the new location on the next hub sync, so they stay updatable.
+
+**Changing an `id` is a different edit.** It is read as removing one source and adding an unrelated one. The removed source is kept rather than deleted while installed bundles still reference it, so nothing is lost, but those bundles stay pointed at the old location and stop receiving updates from the new one.
+
+**Changing an `id` also breaks profiles**, with or without a URL change. A profile bundle's `source` field names a source `id` (see [Bundle Object](#bundle-object-within-profile)), so every profile entry referencing the old `id` no longer resolves. That consequence is independent of installed-bundle migration.
+
+See [Renaming a Source URL](../author-guide/adding-profile-source-to-hub.md#renaming-a-source-url) in the author guide for the full workflow and its troubleshooting entries.
 
 ### Source Types
 
@@ -187,7 +199,7 @@ The `profiles` array defines predefined bundle collections.
 |-------|------|----------|-------------|
 | `id` | string | Yes | Bundle identifier (1-50 chars) |
 | `version` | string | Yes | Bundle version (semver or `"latest"`) |
-| `source` | string | Yes | Source ID where this bundle is available |
+| `source` | string | Yes | The `id` of a source declared in this hub's `sources` array (see [Source Identity](#source-identity)) |
 | `required` | boolean | Yes | Whether this bundle is mandatory for the profile |
 
 ### Example
@@ -353,5 +365,6 @@ Validation errors are displayed in VS Code notifications and logged to the outpu
 
 - [Profiles and Hubs Guide](../user-guide/profiles-and-hubs.md) — User guide for working with hubs
 - [Creating a Hub](../author-guide/creating-a-hub.md) — End-to-end authoring and publishing
+- [Adding Profiles and Sources to Existing Hubs](../author-guide/adding-profile-source-to-hub.md) — Editing `sources[]`, including renaming a source URL
 - [Collection Schema](../author-guide/collection-schema.md) — Schema for collection YAML files
 - [Settings Reference](./settings.md) — Extension configuration options

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -55,6 +55,17 @@ If you selected a hub but it doesn't appear in the Registry Explorer:
 3. Run `AI Primitives Hub: Sync Hub` from the Command Palette
 4. If the hub still doesn't appear, run `AI Primitives Hub: Reset First Run`, then reload VS Code (`Ctrl+R`)
 
+### Bundles Stopped Updating After a Hub Renamed a Repository
+
+When a hub changes the URL of one of its sources, installed bundles normally follow the source to its new URL automatically. If they stopped receiving updates instead, the extension could not prove which new source replaced the old one.
+
+Nothing is lost: the pre-rename source is kept rather than deleted, so your installed bundles stay intact and keep working from where they were installed.
+
+1. Check the logs (`View → Output → AI Primitives Hub`) — a warning names the kept source and the reason its replacement could not be determined
+2. Run `AI Primitives Hub: Sync Hub` from the Command Palette to retry the migration
+3. If the bundles still don't update, reinstall them from the renamed source in the Registry Explorer — run `AI Primitives Hub: List Sources` to see both the kept source and its replacement
+4. Report the reason from the log to the hub author: keeping a source `id` stable while changing its `url` lets installed bundles migrate on their own
+
 ### Hub Selector Not Shown on First Launch
 
 If you installed the extension but were never prompted to select a hub:

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -42,6 +42,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.20.1",
     "@vitest/coverage-v8": "^4.1.10",
+    "fast-check": "3.23.2",
     "typescript": "^5.9.3",
     "vitest": "^4.1.10"
   },

--- a/packages/app/src/registry/index.ts
+++ b/packages/app/src/registry/index.ts
@@ -16,6 +16,7 @@ export * from './source-sync-queue';
 export * from './local-profile-crud';
 export * from './profile-lifecycle';
 export * from './registry-settings';
+export * from './remap-bundle-source';
 export * from './resolve-installation-bundle';
 export * from './search-registry-bundles';
 export * from './uninstall-installed-bundle';

--- a/packages/app/src/registry/load-hub-sources.ts
+++ b/packages/app/src/registry/load-hub-sources.ts
@@ -10,8 +10,11 @@
  * updates sources that already carry the same stable id (re-import/
  * sync of the same hub), skips true duplicates (same url/type/branch/
  * collectionsPath under a different id — e.g. added independently
- * before hub adoption, or shared across two hubs), and adds
- * everything else as new.
+ * before hub adoption, or shared across two hubs), adds everything
+ * else as new, and prunes orphaned sources — ones this hub previously
+ * contributed that are no longer in its config (e.g. a collection whose
+ * repository URL was renamed, producing a new sourceId while the old
+ * one lingers as a stale duplicate).
  *
  * SourceId format: `generateSourceId(type, url, config)` produces
  * `{type}-{12-char-hash}`, based on source properties rather than the
@@ -35,10 +38,30 @@ import {
   createSourceSyncQueue,
 } from './source-sync-queue';
 
+/**
+ * Why an orphaned source was kept rather than remapped and removed.
+ * Diagnostic only — never persisted; each value appears as the reason marker
+ * in the single keep-alive warning.
+ */
+export type KeepAliveReason =
+  | 'no-candidate'
+  | 'ambiguous-candidates'
+  | 'missing-sticker'
+  | 'remap-failed'
+  | 'port-absent';
+
+/**
+ * The actionable remediation every keep-alive warning ends with: the hub
+ * authoring convention that makes a URL rename provable in the first place.
+ */
+const KEEP_ALIVE_REMEDIATION
+  = 'keep a source\'s `id` stable when changing its `url`';
+
 export interface LoadHubSourcesResult {
   added: number;
   updated: number;
   skipped: number;
+  removed: number;
 }
 
 export interface LoadHubSourcesOptions {
@@ -86,17 +109,38 @@ export function findDuplicateSource(
 /**
  * Sync a hub's declared sources into the registry.
  *
- * Per-source `addSource` failures (e.g. a private repo returning 404)
- * are caught, logged, and skipped rather than failing the whole
- * operation — a hub with one bad source should still get its other
- * sources loaded. `listSources`/`updateSource` failures are not
+ * Per-source `addSource`/`removeSource` failures (e.g. a private repo
+ * returning 404) are caught, logged, and skipped rather than failing
+ * the whole operation — a hub with one bad source should still get its
+ * other sources loaded. `listSources`/`updateSource` failures are not
  * caught here; they propagate to the caller.
+ *
+ * After syncing, any source belonging to this hub (`hubId` match) that
+ * was not represented in the current config is pruned. Manually-added
+ * sources (no `hubId`) and sources contributed by other hubs are never
+ * touched. Disabled sources still count as "represented" — their id is
+ * protected from pruning so `enabled: false` suppresses fetching without
+ * destroying the registry entry.
+ *
+ * Pruning is deliberately conservative to avoid stranding installed
+ * bundles (`removeSource` detaches a source but does not uninstall bundles
+ * or clean lockfile entries, so a pruned source with live consumers can no
+ * longer be updated):
+ * - It is skipped entirely for the whole sync if any `addSource` failed,
+ *   so a transient error on a renamed source's new id cannot delete the
+ *   old id before its replacement lands.
+ * - An orphan with installed bundles still referencing it (via
+ *   `ports.listInstalledBundles`, when provided) is kept and logged as a
+ *   warning rather than removed; deletion only proceeds once those
+ *   consumers are migrated or uninstalled. When `listInstalledBundles` is
+ *   not provided this guard is skipped and a pruned source may leave its
+ *   installed bundles in an unmanaged state.
  * @param hubId Hub identifier the sources belong to.
  * @param hubSources Sources declared in the hub's config.
  * @param ports Registry read/write access.
  * @param onLog Optional sink for diagnostic log events.
  * @param options Optional orchestration settings.
- * @returns Counts of added/updated/skipped sources.
+ * @returns Counts of added/updated/skipped/removed sources.
  */
 export async function loadHubSources(
   hubId: string,
@@ -116,18 +160,53 @@ export async function loadHubSources(
   let added = 0;
   let updated = 0;
   let skipped = 0;
+  let removed = 0;
+
+  // Ids of existing sources still represented in the current hub config
+  // (added, updated, or matched as a duplicate). Any source belonging to
+  // this hub but absent from this set after processing is orphaned and
+  // must be pruned to avoid stale duplicates on URL rename.
+  const protectedSourceIds = new Set<string>();
+
+  // Stored source id -> its `hubSourceId` sticker, for sources storage actually
+  // received this cycle (successful `addSource`/`updateSource` only). Disabled
+  // declarations, failed adds, and matched duplicates stay out: remapping
+  // installed bundles onto an id storage never received would point them at a
+  // phantom source. This is the only pool replacement selection draws from.
+  const registeredThisCycle = new Map<string, string | undefined>();
+
+  // Set when any `addSource` fails this cycle. Orphan pruning is skipped
+  // entirely in that case: a transient failure on a renamed source's new
+  // id would otherwise let us delete the old id (now absent from config)
+  // while the replacement never landed, stranding installed bundles. Better
+  // to keep a stale duplicate than to lose the source outright.
+  let addFailed = false;
 
   const processSource = async (hubSource: HubSource): Promise<void> => {
+    // Generate the stable id up front and protect it from pruning
+    // regardless of the enabled flag. Disabling a source in hub config is a
+    // reversible action (e.g. a collection under maintenance); it must
+    // suppress fetching, not destroy the registry entry and strand any
+    // bundles installed from it.
+    const sourceId = generateSourceId(hubSource.type, hubSource.url, {
+      branch: hubSource.config?.branch,
+      collectionsPath: hubSource.config?.collectionsPath
+    });
+    protectedSourceIds.add(sourceId);
+
+    // The hub-author-assigned declaration id (the "sticker"): persisted as-is
+    // so a later sync can match a pre-rename orphan to its replacement even
+    // though the stored id is derived from the url. Declarations without an id
+    // persist no key at all, keeping pre-feature and manual records untouched.
+    const sticker: Pick<RegistrySource, 'hubSourceId'> = hubSource.id
+      ? { hubSourceId: hubSource.id }
+      : {};
+
     if (!hubSource.enabled) {
       log('debug', `Skipping disabled source: ${hubSource.id}`);
       skipped++;
       return;
     }
-
-    const sourceId = generateSourceId(hubSource.type, hubSource.url, {
-      branch: hubSource.config?.branch,
-      collectionsPath: hubSource.config?.collectionsPath
-    });
 
     const existingSourceById = existingSources.find((s) => s.id === sourceId);
 
@@ -143,8 +222,10 @@ export async function loadHubSources(
         token: hubSource.token,
         metadata: hubSource.metadata,
         config: hubSource.config,
-        hubId
+        hubId,
+        ...sticker
       });
+      registeredThisCycle.set(sourceId, hubSource.id);
       updated++;
       return;
     }
@@ -152,6 +233,7 @@ export async function loadHubSources(
     const duplicateSource = findDuplicateSource(hubSource, existingSources);
 
     if (duplicateSource) {
+      protectedSourceIds.add(duplicateSource.id);
       log(
         'info',
         `Skipping duplicate source: ${hubSource.name} `
@@ -180,11 +262,13 @@ export async function loadHubSources(
       token: hubSource.token,
       metadata: hubSource.metadata,
       config: hubSource.config,
-      hubId
+      hubId,
+      ...sticker
     };
 
     try {
       await ports.addSource(registrySource);
+      registeredThisCycle.set(sourceId, hubSource.id);
       added++;
       try {
         options?.onSourceAdded?.(registrySource);
@@ -195,6 +279,7 @@ export async function loadHubSources(
     } catch (sourceError) {
       const err = sourceError instanceof Error ? sourceError : new Error(String(sourceError));
       log('warn', `Failed to add hub source ${sourceId} (${hubSource.name}): ${err.message}`, err);
+      addFailed = true;
       skipped++;
     }
   };
@@ -212,9 +297,145 @@ export async function loadHubSources(
 
   await Promise.all(Array.from({ length: concurrency }, worker));
 
-  log('info', `Hub source loading complete for ${hubId}: ${added} added, ${updated} updated, ${skipped} skipped`);
+  // Skip pruning entirely if any add failed: the config sync is incomplete,
+  // and deleting an orphan (e.g. the pre-rename id) while its replacement
+  // never landed would strand installed bundles. A stale duplicate is
+  // recoverable on the next successful sync; lost sources are not.
+  if (addFailed) {
+    log(
+      'warn',
+      `Skipping orphaned source pruning for hub ${hubId}: one or more sources failed to add this sync`
+    );
+  } else {
+    // Prune orphaned sources: any source previously linked to this hub that
+    // is no longer represented in the current config (e.g. a renamed URL).
+    const orphanedSources = existingSources.filter(
+      (s) => s.hubId === hubId && !protectedSourceIds.has(s.id)
+    );
 
-  return { added, updated, skipped };
+    const installedBundles = orphanedSources.length > 0
+      ? await ports.listInstalledBundles()
+      : [];
+
+    for (const orphan of orphanedSources) {
+      const consumers = installedBundles.filter((b) => b.sourceId === orphan.id);
+
+      if (consumers.length > 0) {
+        // Find the replacement among the ids storage actually received this
+        // cycle, matching on the hub-author-assigned sticker: a renamed source
+        // keeps its declaration `id` while its url-derived stored id changes,
+        // so the sticker is what ties the pre-rename orphan to its successor.
+        // Ids that were only protected from pruning (disabled declarations,
+        // failed adds, matched duplicates) are not eligible: a remap onto one
+        // of them would strand installed bundles on a source id no store holds.
+        //
+        // An orphan with no sticker matches nothing — `undefined === undefined`
+        // is not evidence of a shared identity. Requiring exactly one candidate
+        // also makes selection independent of the order workers populated the
+        // map in, so `concurrency > 1` picks the same id as `concurrency: 1`.
+        const orphanSticker = orphan.hubSourceId;
+        const candidates = orphanSticker === undefined
+          ? []
+          : [...registeredThisCycle.entries()]
+            .filter(([id, sticker]) => id !== orphan.id && sticker === orphanSticker)
+            .map(([id]) => id);
+
+        // One warning per keep-alive, carrying the orphan id and name, the
+        // number of blocked consumers, the reason marker, and — last, so it is
+        // the line's takeaway — the convention that prevents a recurrence.
+        const keepAlive = (
+          reason: KeepAliveReason,
+          detail: string,
+          error?: Error
+        ): void => {
+          log(
+            'warn',
+            `Keeping orphaned hub source ${orphan.id} (${orphan.name}): `
+            + `${consumers.length} installed bundle(s) still reference it. `
+            + `Reason [${reason}]: ${detail} `
+            + `Remediation: ${KEEP_ALIVE_REMEDIATION}.`,
+            error
+          );
+        };
+
+        if (orphanSticker === undefined) {
+          keepAlive(
+            'missing-sticker',
+            'the stored source carries no hubSourceId, so no replacement can be proven; '
+            + 'it will be backfilled on the next successful sync of this hub.'
+          );
+          continue;
+        }
+
+        if (candidates.length === 0) {
+          keepAlive(
+            'no-candidate',
+            `no source registered this sync carries hubSourceId "${orphanSticker}".`
+          );
+          continue;
+        }
+
+        if (candidates.length > 1) {
+          keepAlive(
+            'ambiguous-candidates',
+            `${candidates.length} sources registered this sync carry hubSourceId `
+            + `"${orphanSticker}" (${candidates.join(', ')}), so the replacement is not unique.`
+          );
+          continue;
+        }
+
+        const replacementId = candidates[0];
+
+        if (!ports.remapBundleSource) {
+          keepAlive(
+            'port-absent',
+            `replacement source ${replacementId} is available but the remapBundleSource `
+            + 'port is not provided by this host.'
+          );
+          continue;
+        }
+
+        try {
+          await ports.remapBundleSource(orphan.id, replacementId);
+          await ports.removeSource(orphan.id);
+          // The single success report: it names the sticker that proved the
+          // match, so a reader can tell *why* these two ids were paired rather
+          // than having to reconstruct it from the hub config.
+          log(
+            'info',
+            `Remapped ${consumers.length} installed bundle record(s) from orphaned source `
+            + `${orphan.id} to ${replacementId} (matched on hubSourceId "${orphanSticker}") `
+            + 'and removed the orphan'
+          );
+          removed++;
+        } catch (remapError) {
+          const err = remapError instanceof Error ? remapError : new Error(String(remapError));
+          keepAlive(
+            'remap-failed',
+            `remapping onto replacement source ${replacementId} failed: ${err.message}.`,
+            err
+          );
+        }
+        continue;
+      }
+
+      try {
+        await ports.removeSource(orphan.id);
+        log('info', `Removed orphaned hub source: ${orphan.id} (${orphan.name}) - no longer present in hub ${hubId}`);
+        removed++;
+      } catch (removeError) {
+        const err = removeError instanceof Error ? removeError : new Error(String(removeError));
+        log('warn', `Failed to remove orphaned hub source ${orphan.id} (${orphan.name}): ${err.message}`, err);
+      }
+    }
+  }
+
+  log(
+    'info',
+    `Hub source loading complete for ${hubId}: ${added} added, ${updated} updated, ${skipped} skipped, ${removed} removed`
+  );
+
+  return { added, updated, skipped, removed };
 }
 
 export interface ProgressiveLoadResult {

--- a/packages/app/src/registry/remap-bundle-source.ts
+++ b/packages/app/src/registry/remap-bundle-source.ts
@@ -1,0 +1,110 @@
+/**
+ * Bundle-source remap — moves installed-bundle references from an old
+ * source id onto a new one after a hub renamed a source's `url` (which
+ * changes the `generateSourceId(type, url, config)`-derived stored id and
+ * leaves the pre-rename record orphaned).
+ *
+ * Extracted from the extension's
+ * `RegistryManager.remapBundleSource` (`apps/vscode-extension/src/services/
+ * registry-manager.ts`) so both delivery layers — and any other host
+ * consuming the `app` SDK surface — share one implementation. Takes ports,
+ * imports no `vscode`, touches no filesystem of its own.
+ *
+ * Resolution comes first, deliberately. The replacement source's descriptor
+ * is resolved before any store is written, and an unresolvable replacement
+ * throws while everything is still untouched. That ordering is what lets the
+ * caller (`loadHubSources`) keep an orphan alive on failure instead of
+ * deleting a source whose bundles were only half migrated.
+ * @module registry/remap-bundle-source
+ */
+import type {
+  BundleSourceRemap,
+  InstallationScope,
+  LockfileSourceDescriptor,
+  LogEvent,
+  OnLogEvent,
+  RegistrySource,
+} from '@ai-primitives-hub/core';
+
+/**
+ * Scopes whose installation records this use case rewrites itself.
+ *
+ * Repository scope is deliberately absent: its records live in the
+ * lockfile, which the `remapLockfileSourceId` port owns.
+ */
+const RECORD_SCOPES: InstallationScope[] = ['user', 'workspace'];
+
+/**
+ * Remap installed bundles from `oldSourceId` onto `newSourceId`.
+ *
+ * Rejects — before writing anything — when `newSourceId` is absent from
+ * stored sources, naming the missing id so the caller can report an
+ * actionable reason.
+ * @param oldSourceId Source id currently referenced by installed bundles.
+ * @param newSourceId Source id the bundles should reference instead.
+ * @param ports Registry read/write access needed for the remap.
+ * @param onLog Optional sink for diagnostic log events.
+ */
+export async function remapBundleSource(
+  oldSourceId: string,
+  newSourceId: string,
+  ports: BundleSourceRemap,
+  onLog?: OnLogEvent
+): Promise<void> {
+  const log = (level: LogEvent['level'], message: string, error?: Error): void => {
+    onLog?.({ level, message, error });
+  };
+
+  log('debug', `Remapping bundle source ${oldSourceId} -> ${newSourceId}`);
+
+  const sources = await ports.listSources();
+  const replacement: RegistrySource | undefined = sources.find((s) => s.id === newSourceId);
+
+  if (!replacement) {
+    throw new Error(
+      `Cannot remap bundle source '${oldSourceId}': `
+      + `replacement source '${newSourceId}' is not present in the registry`
+    );
+  }
+
+  const descriptor: LockfileSourceDescriptor = {
+    type: replacement.type,
+    url: replacement.url,
+    branch: replacement.config?.branch,
+    collectionsPath: replacement.config?.collectionsPath
+  };
+
+  // Repository scope, owned by the lockfile port: it consumes the
+  // descriptor to rewrite the lockfile's `sources` map alongside its bundle
+  // entries. An absent port is a valid skip, not a failure — repository-scope
+  // bundles only exist inside an open workspace, so with no repository in
+  // scope there is nothing to migrate, and refusing here would block an
+  // otherwise valid user-scope and workspace-scope remap.
+  if (ports.remapLockfileSourceId) {
+    await ports.remapLockfileSourceId(oldSourceId, newSourceId, descriptor);
+  }
+
+  // User then workspace scope. The `sourceId === oldSourceId` filter below is
+  // the single mechanism at work here: it selects what to rewrite, and it is
+  // also the whole of the idempotence guarantee — a record already carrying
+  // the new id no longer matches, so a retry after a partial run completes
+  // the remainder and leaves finished records byte-identical. No bookkeeping
+  // of what was already done, and no second pass, is needed on top of it.
+  let remapped = 0;
+  for (const scope of RECORD_SCOPES) {
+    const bundles = await ports.getInstalledBundles(scope);
+    const referencing = bundles.filter((bundle) => bundle.sourceId === oldSourceId);
+
+    for (const bundle of referencing) {
+      // Only `sourceId` changes; every other field is carried over as-is.
+      await ports.recordInstallation({ ...bundle, sourceId: newSourceId });
+    }
+
+    remapped += referencing.length;
+  }
+
+  log(
+    'debug',
+    `Bundle source remap complete: ${oldSourceId} -> ${newSourceId} (${remapped} record(s))`
+  );
+}

--- a/packages/app/src/stores/json-lockfile-store.ts
+++ b/packages/app/src/stores/json-lockfile-store.ts
@@ -289,6 +289,40 @@ export const upsertSource = (
 });
 
 /**
+ * Remap all bundle entries referencing `oldSourceId` to point at
+ * `newSourceId`, and move the source descriptor accordingly. Pure;
+ * doesn't touch disk.
+ * @param lock - Existing Lockfile.
+ * @param oldSourceId - Source id being retired.
+ * @param newSourceId - Replacement source id.
+ * @param newSourceDescriptor - Source descriptor for the replacement.
+ * @returns New Lockfile (input is not mutated).
+ */
+export const remapSourceId = (
+  lock: Lockfile,
+  oldSourceId: string,
+  newSourceId: string,
+  newSourceDescriptor: LockfileSourceEntry
+): Lockfile => {
+  const bundles: Record<string, LockfileBundleEntry> = {};
+  for (const [id, entry] of Object.entries(lock.bundles)) {
+    bundles[id] = entry.sourceId === oldSourceId
+      ? { ...entry, sourceId: newSourceId }
+      : entry;
+  }
+  const sources = { ...lock.sources };
+  delete sources[oldSourceId];
+  sources[newSourceId] = newSourceDescriptor;
+  return {
+    ...lock,
+    version: LOCKFILE_SCHEMA_VERSION,
+    generatedAt: new Date().toISOString(),
+    bundles,
+    sources
+  };
+};
+
+/**
  * Remove a source descriptor if no remaining bundle references it.
  * Pure; doesn't touch disk.
  * @param lock - Existing Lockfile.

--- a/packages/app/test/registry/generators.ts
+++ b/packages/app/test/registry/generators.ts
@@ -1,0 +1,394 @@
+/**
+ * Shared fast-check generators and in-memory port fakes for the
+ * `loadHubSources` property tests (design.md §Testing Strategy →
+ * Generators).
+ *
+ * `portSet` is the generalized form of the `makePorts` helper in
+ * `load-hub-sources.test.ts`: the same in-memory `HubSourceSync` over a
+ * mutable source array, extended with a call log, real installation records,
+ * an optional `remapBundleSource` port, and injectable rejection points so a
+ * property can drive the failure branches without mocking the unit under
+ * test.
+ *
+ * Everything here is in-memory: no filesystem, no network, no host.
+ * @module test/registry/generators
+ */
+import type {
+  HubSource,
+  HubSourceSync,
+  InstallationScope,
+  InstalledBundle,
+  RegistrySource,
+  SourceType,
+} from '@ai-primitives-hub/core';
+import {
+  generateSourceId,
+} from '@ai-primitives-hub/core';
+import * as fc from 'fast-check';
+
+/** Source types a generated declaration can carry, kept to a spread. */
+export const SOURCE_TYPES: SourceType[] = ['github', 'awesome-copilot', 'apm', 'skills'];
+
+/**
+ * A schema-valid hub declaration `id` (`^[a-zA-Z0-9-_]+$`) drawn from a
+ * small pool, so distinct declarations and stored stickers collide often
+ * enough for matching to be exercised rather than trivially unique.
+ */
+export const stickerArb: fc.Arbitrary<string> = fc
+  .tuple(fc.constantFrom('src', 'coll', 'pack'), fc.integer({ min: 0, max: 5 }))
+  .map(([prefix, index]) => `${prefix}_${index}`);
+
+/**
+ * One generated hub source declaration. The `url` is derived from the
+ * sticker so distinct declarations carry distinct urls — and therefore
+ * distinct generated stored ids — without a second uniqueness constraint.
+ */
+export interface HubSourceDeclarationSpec {
+  sticker: string;
+  type: SourceType;
+  enabled: boolean;
+  branch?: string;
+  collectionsPath?: string;
+}
+
+/**
+ * A declaration spec: a schema-valid sticker, a type, an `enabled` flag,
+ * and optional `branch`/`collectionsPath` so both the defaulted and the
+ * explicit descriptor shapes occur.
+ * @returns An arbitrary declaration spec.
+ */
+export function hubSourceDeclaration(): fc.Arbitrary<HubSourceDeclarationSpec> {
+  return fc.record<HubSourceDeclarationSpec>({
+    sticker: stickerArb,
+    type: fc.constantFrom(...SOURCE_TYPES),
+    enabled: fc.boolean(),
+    branch: fc.option(fc.constantFrom('main', 'release'), { nil: undefined }),
+    collectionsPath: fc.option(fc.constantFrom('collections', 'curated'), { nil: undefined })
+  });
+}
+
+/**
+ * The url a declaration spec resolves to, in either its pre-rename or its
+ * post-rename form. A rename changes only the url, never the sticker —
+ * which is exactly the situation orphan matching has to survive.
+ * @param spec The declaration spec.
+ * @param variant Which url generation to produce.
+ * @returns The url for that variant.
+ */
+export function urlFor(spec: HubSourceDeclarationSpec, variant: 'old' | 'new'): string {
+  return `https://github.com/org/${spec.sticker}${variant === 'old' ? '-old' : '-new'}`;
+}
+
+/**
+ * Turn a declaration spec into the `HubSource` a hub config would carry.
+ * @param spec The declaration spec.
+ * @param variant Which url generation the config declares.
+ * @returns The hub source declaration.
+ */
+export function toHubSource(
+  spec: HubSourceDeclarationSpec,
+  variant: 'old' | 'new'
+): HubSource {
+  return {
+    id: spec.sticker,
+    name: `Source ${spec.sticker}`,
+    type: spec.type,
+    url: urlFor(spec, variant),
+    enabled: spec.enabled,
+    priority: 1,
+    config: { branch: spec.branch, collectionsPath: spec.collectionsPath }
+  };
+}
+
+/**
+ * The stored id a declaration spec resolves to for one url generation — the
+ * same derivation `loadHubSources` performs, so a test can name the id a sync
+ * is about to produce without reaching into the implementation.
+ * @param spec The declaration spec.
+ * @param variant Which url generation to derive from.
+ * @returns The generated stored source id.
+ */
+export function storedIdFor(
+  spec: HubSourceDeclarationSpec,
+  variant: 'old' | 'new'
+): string {
+  return generateSourceId(spec.type, urlFor(spec, variant), {
+    branch: spec.branch,
+    collectionsPath: spec.collectionsPath
+  });
+}
+
+/**
+ * A declaration list where exactly one entry's `url` moved to its
+ * post-rename generation while its `id` stayed put — the situation orphan
+ * matching exists for. Every declaration is enabled, so each one is actually
+ * registered and the renamed entry has real siblings competing to be picked.
+ */
+export interface OneRenameSpec {
+  specs: HubSourceDeclarationSpec[];
+  /** Index into `specs` of the declaration whose url was renamed. */
+  renamedIndex: number;
+}
+
+/**
+ * A multi-source hub config with exactly one renamed declaration.
+ * @param options Bounds on how many declarations the hub carries.
+ * @param options.minLength
+ * @param options.maxLength
+ * @returns An arbitrary one-rename hub config.
+ */
+export function hubConfigWithOneRename(
+  options: { minLength?: number; maxLength?: number } = {}
+): fc.Arbitrary<OneRenameSpec> {
+  const minLength = options.minLength ?? 1;
+  const maxLength = options.maxLength ?? 5;
+
+  return fc
+    .uniqueArray(hubSourceDeclaration(), {
+      minLength,
+      maxLength,
+      selector: (spec) => spec.sticker
+    })
+    .chain((specs) => fc
+      .integer({ min: 0, max: specs.length - 1 })
+      .map((renamedIndex) => ({
+        // Disabled declarations are never registered, so they could not be
+        // replacement candidates and would make the property vacuous.
+        specs: specs.map((spec) => ({ ...spec, enabled: true })),
+        renamedIndex
+      })));
+}
+
+/**
+ * The url generation a declaration is *declared* at in a one-rename config:
+ * the renamed entry moved to its new url, every sibling stayed on its old one.
+ * @param scenario The one-rename config.
+ * @param index Index into `scenario.specs`.
+ * @returns Which url generation the config declares for that entry.
+ */
+export function declaredVariant(scenario: OneRenameSpec, index: number): 'old' | 'new' {
+  return index === scenario.renamedIndex ? 'new' : 'old';
+}
+
+/**
+ * Build a stored source, defaulting every field a test does not care about.
+ * @param overrides Fields to set on the stored source.
+ * @returns The stored source.
+ */
+export function makeRegistrySource(overrides: Partial<RegistrySource> = {}): RegistrySource {
+  return {
+    id: 'stored-source',
+    name: 'Stored Source',
+    type: 'awesome-copilot',
+    url: 'https://github.com/org/stored',
+    enabled: true,
+    priority: 1,
+    config: { branch: 'main', collectionsPath: 'collections' },
+    ...overrides
+  };
+}
+
+/**
+ * The stored source a declaration spec would have been persisted as, at one
+ * url generation. Carries the sticker, so a source stored at the pre-rename
+ * url is a matchable orphan rather than an unprovable one.
+ * @param spec The declaration spec.
+ * @param variant Which url generation the stored record holds.
+ * @param hubId The hub the source is attributed to.
+ * @param overrides Fields to override on the stored source.
+ * @returns The stored source.
+ */
+export function toStoredSource(
+  spec: HubSourceDeclarationSpec,
+  variant: 'old' | 'new',
+  hubId: string,
+  overrides: Partial<RegistrySource> = {}
+): RegistrySource {
+  return makeRegistrySource({
+    id: storedIdFor(spec, variant),
+    name: `Source ${spec.sticker}${variant === 'old' ? ' (pre-rename)' : ''}`,
+    type: spec.type,
+    url: urlFor(spec, variant),
+    config: { branch: spec.branch, collectionsPath: spec.collectionsPath },
+    hubId,
+    hubSourceId: spec.sticker,
+    ...overrides
+  });
+}
+
+/**
+ * Build one installation record pointing at a source id. Only `sourceId`
+ * matters to orphan handling; the rest exists so the record is a real
+ * `InstalledBundle` rather than a structural stand-in.
+ * @param bundleId Bundle identifier, unique per record.
+ * @param sourceId The source the record references.
+ * @param scope The installation scope.
+ * @returns The installation record.
+ */
+export function makeInstalledBundle(
+  bundleId: string,
+  sourceId: string,
+  scope: InstallationScope = 'user'
+): InstalledBundle {
+  return {
+    bundleId,
+    version: '1.0.0',
+    installedAt: '2024-01-01T00:00:00.000Z',
+    scope,
+    installPath: `/mock/${scope}/${bundleId}`,
+    sourceId,
+    manifest: {
+      common: { directories: [], files: [], include_patterns: [], exclude_patterns: [] },
+      bundle_settings: {
+        include_common_in_environment_bundles: false,
+        create_common_bundle: false,
+        compression: 'none',
+        naming: { environment_bundle: bundleId }
+      },
+      metadata: { manifest_version: '1.0.0', description: 'Generated' }
+    }
+  };
+}
+
+/**
+ * Installation records referencing the given source ids, one record per id
+ * with a unique bundle id so nothing collapses on upsert.
+ * @param sourceIds Source ids the records reference, in order.
+ * @returns The installation records.
+ */
+export function installedRecordSet(sourceIds: string[]): InstalledBundle[] {
+  return sourceIds.map((sourceId, index) => makeInstalledBundle(`bundle-${index}`, sourceId));
+}
+
+/** Every call a sync made through the ports, in invocation order. */
+export interface HubSourceSyncCalls {
+  /** Sources a successful `addSource` wrote. */
+  added: RegistrySource[];
+  /** Sources a successful `updateSource` wrote. */
+  updated: { sourceId: string; updates: Partial<RegistrySource> }[];
+  /** Source ids `removeSource` was called with. */
+  removed: string[];
+  /** Every remap invocation, whether it resolved or rejected. */
+  remapped: { oldSourceId: string; newSourceId: string }[];
+}
+
+/** In-memory `HubSourceSync` with its store and its call log exposed. */
+export interface RecordingHubSourcePorts extends HubSourceSync {
+  /** The live store, mutated by add/update/remove. */
+  sources: RegistrySource[];
+  /** The live installation records, repointed by a successful remap. */
+  installed: InstalledBundle[];
+  calls: HubSourceSyncCalls;
+}
+
+/** Injectable failure points and port wiring for `portSet`. */
+export interface PortSetOptions {
+  /** Stored source ids whose `addSource` must reject. */
+  failAddForIds?: readonly string[];
+  /** Wire the optional `remapBundleSource` port (default `true`). */
+  withRemap?: boolean;
+  /** Make every remap invocation reject. */
+  failRemap?: boolean;
+}
+
+/**
+ * In-memory `HubSourceSync` over a mutable source array, recording every
+ * write so a property can compare what a sync attempted against what
+ * storage actually received.
+ * @param initial Stored sources the sync starts from.
+ * @param installed Installation records `listInstalledBundles` returns.
+ * @param options Failure injection and port wiring.
+ * @returns The recording ports.
+ */
+export function portSet(
+  initial: RegistrySource[] = [],
+  installed: InstalledBundle[] = [],
+  options: PortSetOptions = {}
+): RecordingHubSourcePorts {
+  const sources = structuredClone(initial);
+  const records = structuredClone(installed);
+  const failAddForIds = new Set(options.failAddForIds);
+  const calls: HubSourceSyncCalls = { added: [], updated: [], removed: [], remapped: [] };
+
+  const ports: RecordingHubSourcePorts = {
+    sources,
+    installed: records,
+    calls,
+    listSources: () => Promise.resolve(structuredClone(sources)),
+    addSource: (source: RegistrySource) => {
+      if (failAddForIds.has(source.id)) {
+        return Promise.reject(new Error(`Source validation failed for ${source.id}`));
+      }
+      sources.push(structuredClone(source));
+      calls.added.push(structuredClone(source));
+
+      return Promise.resolve();
+    },
+    updateSource: (sourceId: string, updates: Partial<RegistrySource>) => {
+      const index = sources.findIndex((source) => source.id === sourceId);
+      if (index !== -1) {
+        sources[index] = { ...sources[index], ...updates };
+      }
+      calls.updated.push({ sourceId, updates: structuredClone(updates) });
+
+      return Promise.resolve();
+    },
+    removeSource: (sourceId: string) => {
+      const index = sources.findIndex((source) => source.id === sourceId);
+      if (index !== -1) {
+        sources.splice(index, 1);
+      }
+      calls.removed.push(sourceId);
+
+      return Promise.resolve();
+    },
+    listInstalledBundles: () => Promise.resolve(structuredClone(records))
+  };
+
+  if (options.withRemap ?? true) {
+    ports.remapBundleSource = (oldSourceId: string, newSourceId: string) => {
+      calls.remapped.push({ oldSourceId, newSourceId });
+
+      if (options.failRemap) {
+        // Reject before touching a record, mirroring the real use case's
+        // resolve-first-or-throw order: a keep-alive must be observable as
+        // records that never moved, not merely as a call that was logged.
+        return Promise.reject(new Error(`remap ${oldSourceId} -> ${newSourceId} failed`));
+      }
+
+      for (const record of records) {
+        if (record.sourceId === oldSourceId) {
+          record.sourceId = newSourceId;
+        }
+      }
+
+      return Promise.resolve();
+    };
+  }
+
+  return ports;
+}
+
+/**
+ * The installation records as they stand now, so a property can compare the
+ * store before and after a sync.
+ * @param ports The recording ports a sync ran against.
+ * @returns Bundle id to the source id it currently references.
+ */
+export function recordSourceIds(ports: RecordingHubSourcePorts): Map<string, string> {
+  return new Map(ports.installed.map((record) => [record.bundleId, record.sourceId]));
+}
+
+/**
+ * The ids storage actually received this cycle: every id a successful
+ * `addSource` or `updateSource` wrote. The only pool a remap target may
+ * legitimately come from.
+ * @param ports The recording ports a sync ran against.
+ * @returns The written source ids.
+ */
+export function writtenSourceIds(ports: RecordingHubSourcePorts): Set<string> {
+  return new Set([
+    ...ports.calls.added.map((source) => source.id),
+    ...ports.calls.updated.map((update) => update.sourceId)
+  ]);
+}

--- a/packages/app/test/registry/host-composition.test.ts
+++ b/packages/app/test/registry/host-composition.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Host-composition test (Cycle E) — proves the bundle-source remap is
+ * reachable and usable from a host that is not the VS Code extension.
+ *
+ * Two things are under test, and they are deliberately different in kind:
+ *
+ *  1. **Reachability.** `remapBundleSource` is imported from the package
+ *     entry point (`src/index.ts`, the barrel a `@ai-primitives-hub/app`
+ *     consumer resolves), never by deep path. A use case that only exists
+ *     at `src/registry/remap-bundle-source.ts` is invisible to the CLI and
+ *     to every other SDK consumer, so the import itself is the assertion
+ *     (Requirement 6.8).
+ *  2. **Constructibility.** Every port is composed from `packages/infra`
+ *     primitives — `NodeFileSystem` for disk I/O, `XdgAppStorage` for root
+ *     resolution — over a single temp directory. There is no `vscode`
+ *     value, no `ExtensionContext`, and no VS Code API call anywhere in
+ *     this file (Requirement 6.9), and every on-disk path the composition
+ *     touches comes out of the injected `AppStorage` port rather than
+ *     being resolved inline, per ADR-0005 (Requirement 6.10).
+ *
+ * This is the one test in the feature that touches the real filesystem,
+ * and it uses exactly one temp directory. No network, no GitHub, no VS
+ * Code host.
+ */
+import {
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+} from 'node:fs/promises';
+import {
+  tmpdir,
+} from 'node:os';
+import * as path from 'node:path';
+import type {
+  AppStorage,
+  AppStoragePaths,
+  BundleSourceRemap,
+  InstallationScope,
+  InstalledBundle,
+  RegistrySource,
+} from '@ai-primitives-hub/core';
+import {
+  NodeFileSystem,
+  XdgAppStorage,
+} from '@ai-primitives-hub/infra';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  emptyLockfile,
+  LOCKFILE_NAME,
+  readLockfile,
+  remapBundleSource,
+  remapSourceId,
+  writeLockfile,
+} from '../../src/index';
+
+const OLD_ID = 'source-old';
+const NEW_ID = 'source-new';
+
+/**
+ * Records file for one non-repository scope, rooted at the paths the
+ * injected `AppStorage` resolved — never at `os.homedir()` or an
+ * `ExtensionContext` URI (ADR-0005).
+ * @param paths Paths resolved by the injected `AppStorage` port.
+ * @param scope Installation scope whose records file is wanted.
+ */
+function recordsFile(paths: AppStoragePaths, scope: InstallationScope): string {
+  const dir = scope === 'user' ? paths.userInstalled : path.join(paths.installed, scope);
+  return path.join(dir, 'records.json');
+}
+
+/**
+ * Registry config file holding the stored sources, at the config path the
+ * injected `AppStorage` resolved.
+ * @param paths Paths resolved by the injected `AppStorage` port.
+ */
+function sourcesFile(paths: AppStoragePaths): string {
+  return paths.config;
+}
+
+/**
+ * Compose the four `BundleSourceRemap` ports the way a CLI-shaped host
+ * would: `NodeFileSystem` for every read and write, `AppStorage` for every
+ * root, and the app package's own pure lockfile transform for repository
+ * scope. Nothing here knows what VS Code is.
+ * @param storage Injected storage-root port.
+ * @param fs Injected filesystem adapter.
+ * @param repositoryRoot Repository root, when one is in scope. Omitting it leaves the lockfile port unwired.
+ */
+function composeHostPorts(
+  storage: AppStorage,
+  fs: NodeFileSystem,
+  repositoryRoot?: string
+): BundleSourceRemap {
+  const paths = storage.getPaths();
+
+  const readRecords = async (scope: InstallationScope): Promise<InstalledBundle[]> => {
+    const file = recordsFile(paths, scope);
+    return (await fs.exists(file)) ? fs.readJson<InstalledBundle[]>(file) : [];
+  };
+
+  const writeRecords = async (scope: InstallationScope, records: InstalledBundle[]): Promise<void> => {
+    const file = recordsFile(paths, scope);
+    await fs.mkdir(path.dirname(file), { recursive: true });
+    await fs.writeJson(file, records);
+  };
+
+  return {
+    listSources: async () => {
+      const file = sourcesFile(paths);
+      if (!(await fs.exists(file))) {
+        return [];
+      }
+      return (await fs.readJson<{ sources: RegistrySource[] }>(file)).sources;
+    },
+    remapLockfileSourceId: repositoryRoot === undefined
+      ? undefined
+      : async (oldSourceId, newSourceId, descriptor) => {
+        const file = path.join(repositoryRoot, LOCKFILE_NAME);
+        const lock = await readLockfile(file, fs);
+        if (!lock) {
+          return;
+        }
+        await writeLockfile(file, remapSourceId(lock, oldSourceId, newSourceId, descriptor), fs);
+      },
+    getInstalledBundles: async (scope) => readRecords(scope),
+    recordInstallation: async (bundle) => {
+      const records = await readRecords(bundle.scope);
+      const index = records.findIndex((r) => r.bundleId === bundle.bundleId);
+      if (index === -1) {
+        records.push(bundle);
+      } else {
+        records[index] = bundle;
+      }
+      await writeRecords(bundle.scope, records);
+    }
+  };
+}
+
+/**
+ * A stored source with a distinct descriptor, so the descriptor written to
+ * the lockfile cannot accidentally match by reusing the orphan's fields.
+ * @param overrides Fields to override on the base source.
+ */
+function makeSource(overrides: Partial<RegistrySource> = {}): RegistrySource {
+  return {
+    id: OLD_ID,
+    name: 'Old Source',
+    type: 'awesome-copilot',
+    url: 'https://github.com/github/awesome-copilot',
+    enabled: true,
+    priority: 1,
+    config: { branch: 'main', collectionsPath: 'collections' },
+    ...overrides
+  };
+}
+
+/**
+ * One installation record.
+ * @param overrides Fields to override on the base record.
+ */
+function makeInstalled(overrides: Partial<InstalledBundle> = {}): InstalledBundle {
+  return {
+    bundleId: 'bundle-1',
+    version: '1.0.0',
+    installedAt: '2024-01-01T00:00:00.000Z',
+    scope: 'user',
+    installPath: '/mock/path',
+    sourceId: OLD_ID,
+    manifest: {
+      common: { directories: [], files: [], include_patterns: [], exclude_patterns: [] },
+      bundle_settings: {
+        include_common_in_environment_bundles: false,
+        create_common_bundle: false,
+        compression: 'none',
+        naming: { environment_bundle: 'bundle-1' }
+      },
+      metadata: { manifest_version: '1.0.0', description: 'Test' }
+    },
+    ...overrides
+  };
+}
+
+/**
+ * Every file under one directory tree, mapped path to contents, so a
+ * "nothing was written" claim can be checked against real bytes rather
+ * than against a spy.
+ * @param root Directory to walk.
+ */
+async function snapshotTree(root: string): Promise<Map<string, string>> {
+  const snapshot = new Map<string, string>();
+  const walk = async (dir: string): Promise<void> => {
+    for (const entry of await readdir(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(full);
+      } else {
+        snapshot.set(path.relative(root, full), await readFile(full, 'utf8'));
+      }
+    }
+  };
+  await walk(root);
+  return snapshot;
+}
+
+describe('remapBundleSource composed from packages/infra primitives (non-VS-Code host)', () => {
+  let tempDir: string;
+  let storage: AppStorage;
+  let fs: NodeFileSystem;
+  let repositoryRoot: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), 'aph-host-composition-'));
+    fs = new NodeFileSystem();
+
+    storage = new XdgAppStorage({
+      XDG_DATA_HOME: path.join(tempDir, 'data'),
+      XDG_CONFIG_HOME: path.join(tempDir, 'config'),
+      XDG_CACHE_HOME: path.join(tempDir, 'cache')
+    });
+
+    repositoryRoot = path.join(tempDir, 'repo');
+
+    const paths = storage.getPaths();
+    const sources = [makeSource(), makeSource({
+      id: NEW_ID,
+      name: 'Renamed Source',
+      type: 'github',
+      url: 'https://github.com/org/renamed',
+      config: { branch: 'release', collectionsPath: 'curated' }
+    })];
+
+    await fs.mkdir(path.dirname(sourcesFile(paths)), { recursive: true });
+    await fs.writeJson(sourcesFile(paths), { sources });
+
+    await fs.mkdir(path.dirname(recordsFile(paths, 'user')), { recursive: true });
+    await fs.writeJson(recordsFile(paths, 'user'), [
+      makeInstalled({ bundleId: 'user-migrating', scope: 'user', sourceId: OLD_ID }),
+      makeInstalled({ bundleId: 'user-unrelated', scope: 'user', sourceId: 'source-other' })
+    ]);
+
+    await fs.mkdir(path.dirname(recordsFile(paths, 'workspace')), { recursive: true });
+    await fs.writeJson(recordsFile(paths, 'workspace'), [
+      makeInstalled({ bundleId: 'workspace-migrating', scope: 'workspace', sourceId: OLD_ID })
+    ]);
+
+    const lock = emptyLockfile('ai-primitives-hub-test');
+    lock.bundles['repo-migrating'] = {
+      version: '1.0.0',
+      sourceId: OLD_ID,
+      sourceType: 'awesome-copilot',
+      installedAt: '2024-01-01T00:00:00.000Z',
+      files: []
+    };
+    lock.sources[OLD_ID] = {
+      type: 'awesome-copilot',
+      url: 'https://github.com/github/awesome-copilot',
+      branch: 'main',
+      collectionsPath: 'collections'
+    };
+    await writeLockfile(path.join(repositoryRoot, LOCKFILE_NAME), lock, fs);
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('is reachable from the package entry point', () => {
+    expect(typeof remapBundleSource).toBe('function');
+  });
+
+  it('resolves every on-disk root through the injected AppStorage port', () => {
+    const paths = storage.getPaths();
+
+    expect(paths.root.startsWith(tempDir)).toBe(true);
+    expect(sourcesFile(paths).startsWith(tempDir)).toBe(true);
+    expect(recordsFile(paths, 'user').startsWith(paths.root)).toBe(true);
+    expect(recordsFile(paths, 'workspace').startsWith(paths.root)).toBe(true);
+  });
+
+  it('remaps user-scope records on disk', async () => {
+    const ports = composeHostPorts(storage, fs, repositoryRoot);
+
+    await remapBundleSource(OLD_ID, NEW_ID, ports);
+
+    const records = await fs.readJson<InstalledBundle[]>(recordsFile(storage.getPaths(), 'user'));
+
+    expect(records.find((r) => r.bundleId === 'user-migrating')?.sourceId).toBe(NEW_ID);
+  });
+
+  it('remaps workspace-scope records on disk', async () => {
+    const ports = composeHostPorts(storage, fs, repositoryRoot);
+
+    await remapBundleSource(OLD_ID, NEW_ID, ports);
+
+    const records = await fs.readJson<InstalledBundle[]>(recordsFile(storage.getPaths(), 'workspace'));
+
+    expect(records.find((r) => r.bundleId === 'workspace-migrating')?.sourceId).toBe(NEW_ID);
+  });
+
+  it('leaves records referencing another source untouched', async () => {
+    const ports = composeHostPorts(storage, fs, repositoryRoot);
+
+    await remapBundleSource(OLD_ID, NEW_ID, ports);
+
+    const records = await fs.readJson<InstalledBundle[]>(recordsFile(storage.getPaths(), 'user'));
+
+    expect(records.find((r) => r.bundleId === 'user-unrelated')?.sourceId).toBe('source-other');
+  });
+
+  it('remaps the repository-scope lockfile through the composed lockfile port', async () => {
+    const ports = composeHostPorts(storage, fs, repositoryRoot);
+
+    await remapBundleSource(OLD_ID, NEW_ID, ports);
+
+    const lock = await readLockfile(path.join(repositoryRoot, LOCKFILE_NAME), fs);
+
+    expect(lock?.bundles['repo-migrating']?.sourceId).toBe(NEW_ID);
+    expect(lock?.sources[NEW_ID]).toEqual({
+      type: 'github',
+      url: 'https://github.com/org/renamed',
+      branch: 'release',
+      collectionsPath: 'curated'
+    });
+    expect(lock?.sources[OLD_ID]).toBeUndefined();
+  });
+
+  it('completes without a repository in scope, leaving the lockfile port unwired', async () => {
+    const ports = composeHostPorts(storage, fs);
+
+    await expect(remapBundleSource(OLD_ID, NEW_ID, ports)).resolves.toBeUndefined();
+
+    const lock = await readLockfile(path.join(repositoryRoot, LOCKFILE_NAME), fs);
+
+    expect(lock?.bundles['repo-migrating']?.sourceId).toBe(OLD_ID);
+  });
+
+  it('rejects and writes nothing when the replacement source is absent from stored sources', async () => {
+    const ports = composeHostPorts(storage, fs, repositoryRoot);
+    const before = await snapshotTree(tempDir);
+
+    await expect(remapBundleSource(OLD_ID, 'source-never-stored', ports)).rejects.toThrow(/source-never-stored/);
+
+    expect(await snapshotTree(tempDir)).toEqual(before);
+  });
+});

--- a/packages/app/test/registry/host-parity.property.test.ts
+++ b/packages/app/test/registry/host-parity.property.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Property-based test for registry/load-hub-sources.ts — behavior is
+ * invariant across hosts.
+ *
+ * Generalizes the host-composition example (Cycle E, `host-composition.test.ts`)
+ * from "the remap is reachable and usable from a non-VS-Code host" to "driving
+ * a full hub sync through ports composed from `packages/infra` primitives
+ * produces the same observable result as driving it through in-memory ports".
+ *
+ * For each generated one-rename hub config plus stored-source set, the same
+ * sync is run twice over identical inputs:
+ *
+ *  1. Through the in-memory `portSet` fake (`generators.ts`).
+ *  2. Through a `HubSourceSync` composed the way a CLI-shaped host composes it:
+ *     `NodeFileSystem` for every read and write, `XdgAppStorage` for every
+ *     on-disk root, over a single temp directory, with the `remapBundleSource`
+ *     port delegating to the app's own `remapBundleSource` use case wired from
+ *     the same infra primitives — and with no `vscode` value and no
+ *     `ExtensionContext` anywhere in the composition.
+ *
+ * The two runs must agree on the added, updated, skipped, and removed counts
+ * and on the exact remap argument pairs. The final installed-record state is
+ * compared too, so parity is demonstrated at the level of what the sync
+ * actually did to storage, not merely at the level of its return value.
+ *
+ * A fresh temp directory is created and removed per iteration. No network, no
+ * GitHub, no VS Code host.
+ */
+import {
+  mkdtemp,
+  rm,
+} from 'node:fs/promises';
+import {
+  tmpdir,
+} from 'node:os';
+import * as path from 'node:path';
+import type {
+  AppStorage,
+  AppStoragePaths,
+  BundleSourceRemap,
+  HubSourceSync,
+  InstallationScope,
+  InstalledBundle,
+  RegistrySource,
+} from '@ai-primitives-hub/core';
+import {
+  NodeFileSystem,
+  XdgAppStorage,
+} from '@ai-primitives-hub/infra';
+import * as fc from 'fast-check';
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  remapBundleSource as appRemapBundleSource,
+  LOCKFILE_NAME,
+  readLockfile,
+  remapSourceId,
+  writeLockfile,
+} from '../../src/index';
+import {
+  loadHubSources,
+} from '../../src/registry/load-hub-sources';
+import type {
+  OneRenameSpec,
+} from './generators';
+import {
+  declaredVariant,
+  hubConfigWithOneRename,
+  installedRecordSet,
+  portSet,
+  recordSourceIds,
+  storedIdFor,
+  toHubSource,
+  toStoredSource,
+} from './generators';
+
+/** The hub under sync. */
+const HUB_ID = 'hub-a';
+
+/** The two non-repository scopes a sync's installed records live under. */
+const SCOPES: InstallationScope[] = ['user', 'workspace'];
+
+/** A one-rename hub config plus how many installed bundles pin the orphan. */
+interface Scenario {
+  config: OneRenameSpec;
+  consumerCount: number;
+}
+
+const scenarioArb = fc.record({
+  config: hubConfigWithOneRename({ minLength: 1, maxLength: 4 }),
+  // Zero exercises consumer-free pruning (remove without remap); one or more
+  // exercises the remap-then-remove path. Both must agree across hosts.
+  consumerCount: fc.integer({ min: 0, max: 3 })
+});
+
+/**
+ * Records file for one non-repository scope, rooted at the paths the injected
+ * `AppStorage` resolved — never at `os.homedir()` or an `ExtensionContext` URI.
+ * @param paths Paths resolved by the injected `AppStorage` port.
+ * @param scope Installation scope whose records file is wanted.
+ */
+function recordsFile(paths: AppStoragePaths, scope: InstallationScope): string {
+  const dir = scope === 'user' ? paths.userInstalled : path.join(paths.installed, scope);
+  return path.join(dir, 'records.json');
+}
+
+/**
+ * Registry config file holding the stored sources, at the config path the
+ * injected `AppStorage` resolved.
+ * @param paths Paths resolved by the injected `AppStorage` port.
+ */
+function sourcesFile(paths: AppStoragePaths): string {
+  return paths.config;
+}
+
+/**
+ * The `BundleSourceRemap` ports a CLI-shaped host composes for the app's
+ * `remapBundleSource` use case: `NodeFileSystem` for every read and write,
+ * `AppStorage` for every root, and the app package's own pure lockfile
+ * transform for repository scope. Nothing here knows what VS Code is.
+ * @param storage Injected storage-root port.
+ * @param fs Injected filesystem adapter.
+ * @param repositoryRoot Repository root, when one is in scope.
+ */
+function composeRemapPorts(
+  storage: AppStorage,
+  fs: NodeFileSystem,
+  repositoryRoot: string
+): BundleSourceRemap {
+  const paths = storage.getPaths();
+
+  const readRecords = async (scope: InstallationScope): Promise<InstalledBundle[]> => {
+    const file = recordsFile(paths, scope);
+    return (await fs.exists(file)) ? fs.readJson<InstalledBundle[]>(file) : [];
+  };
+
+  const writeRecords = async (scope: InstallationScope, records: InstalledBundle[]): Promise<void> => {
+    const file = recordsFile(paths, scope);
+    await fs.mkdir(path.dirname(file), { recursive: true });
+    await fs.writeJson(file, records);
+  };
+
+  return {
+    listSources: async () => {
+      const file = sourcesFile(paths);
+      if (!(await fs.exists(file))) {
+        return [];
+      }
+      return (await fs.readJson<{ sources: RegistrySource[] }>(file)).sources;
+    },
+    remapLockfileSourceId: async (oldSourceId, newSourceId, descriptor) => {
+      const file = path.join(repositoryRoot, LOCKFILE_NAME);
+      const lock = await readLockfile(file, fs);
+      if (!lock) {
+        return;
+      }
+      await writeLockfile(file, remapSourceId(lock, oldSourceId, newSourceId, descriptor), fs);
+    },
+    getInstalledBundles: async (scope) => readRecords(scope),
+    recordInstallation: async (bundle) => {
+      const records = await readRecords(bundle.scope);
+      const index = records.findIndex((r) => r.bundleId === bundle.bundleId);
+      if (index === -1) {
+        records.push(bundle);
+      } else {
+        records[index] = bundle;
+      }
+      await writeRecords(bundle.scope, records);
+    }
+  };
+}
+
+/** A `HubSourceSync` composed from infra primitives, with its remap log. */
+interface InfraHost {
+  ports: HubSourceSync;
+  /** Every remap invocation the sync made, in order. */
+  remapCalls: { oldSourceId: string; newSourceId: string }[];
+}
+
+/**
+ * Compose the full `HubSourceSync` a non-VS-Code host wires: source CRUD and
+ * installed-bundle reads backed by `NodeFileSystem` over the `AppStorage`
+ * roots, and a `remapBundleSource` port delegating to the app's own
+ * `remapBundleSource` use case (itself composed from infra primitives). The
+ * remap arguments are recorded so a parity check can compare them against the
+ * in-memory run without reaching into the use case.
+ * @param storage Injected storage-root port.
+ * @param fs Injected filesystem adapter.
+ * @param repositoryRoot Repository root, when one is in scope.
+ */
+function composeInfraHost(
+  storage: AppStorage,
+  fs: NodeFileSystem,
+  repositoryRoot: string
+): InfraHost {
+  const paths = storage.getPaths();
+  const file = sourcesFile(paths);
+  const remapCalls: { oldSourceId: string; newSourceId: string }[] = [];
+  const remapPorts = composeRemapPorts(storage, fs, repositoryRoot);
+
+  const readSources = async (): Promise<RegistrySource[]> => {
+    if (!(await fs.exists(file))) {
+      return [];
+    }
+    return (await fs.readJson<{ sources: RegistrySource[] }>(file)).sources;
+  };
+
+  const writeSources = async (sources: RegistrySource[]): Promise<void> => {
+    await fs.mkdir(path.dirname(file), { recursive: true });
+    await fs.writeJson(file, { sources });
+  };
+
+  const ports: HubSourceSync = {
+    listSources: readSources,
+    addSource: async (source) => {
+      const sources = await readSources();
+      sources.push(source);
+      await writeSources(sources);
+    },
+    updateSource: async (sourceId, updates) => {
+      const sources = await readSources();
+      const index = sources.findIndex((s) => s.id === sourceId);
+      if (index !== -1) {
+        sources[index] = { ...sources[index], ...updates };
+        await writeSources(sources);
+      }
+    },
+    removeSource: async (sourceId) => {
+      const sources = await readSources();
+      await writeSources(sources.filter((s) => s.id !== sourceId));
+    },
+    listInstalledBundles: async () => {
+      const all: InstalledBundle[] = [];
+      for (const scope of SCOPES) {
+        all.push(...(await remapPorts.getInstalledBundles(scope)));
+      }
+      return all;
+    },
+    remapBundleSource: async (oldSourceId, newSourceId) => {
+      remapCalls.push({ oldSourceId, newSourceId });
+      await appRemapBundleSource(oldSourceId, newSourceId, remapPorts);
+    }
+  };
+
+  return { ports, remapCalls };
+}
+
+/**
+ * The final source id each installed record references, read back from disk
+ * across both scopes, so host parity can be checked at the level of what the
+ * sync did to storage.
+ * @param storage Injected storage-root port.
+ * @param fs Injected filesystem adapter.
+ * @returns Bundle id to the source id it currently references.
+ */
+async function diskRecordSourceIds(
+  storage: AppStorage,
+  fs: NodeFileSystem
+): Promise<Map<string, string>> {
+  const paths = storage.getPaths();
+  const map = new Map<string, string>();
+  for (const scope of SCOPES) {
+    const recordsPath = recordsFile(paths, scope);
+    if (await fs.exists(recordsPath)) {
+      for (const record of await fs.readJson<InstalledBundle[]>(recordsPath)) {
+        map.set(record.bundleId, record.sourceId);
+      }
+    }
+  }
+  return map;
+}
+
+// Feature: hub-source-orphan-remap, Property 9: Behavior is invariant across hosts
+describe('loadHubSources — Property 9', () => {
+  /**
+   * **Validates: Requirements 6.11, 6.12**
+   */
+  it(
+    'yields the same counts and remap arguments through infra-composed ports as through in-memory ports',
+    async () => {
+      let runsWithRemap = 0;
+
+      await fc.assert(
+        fc.asyncProperty(scenarioArb, async ({ config, consumerCount }: Scenario) => {
+          const renamedSpec = config.specs[config.renamedIndex];
+
+          // The config declares the renamed entry at its new url and every
+          // sibling at its unchanged old url.
+          const declarations = config.specs.map((spec, index) =>
+            toHubSource(spec, declaredVariant(config, index)));
+
+          // Storage holds every declaration at its pre-rename url, so siblings
+          // update in place and the renamed entry orphans.
+          const stored = config.specs.map((spec) => toStoredSource(spec, 'old', HUB_ID));
+
+          const orphanOldId = storedIdFor(renamedSpec, 'old');
+
+          // Installed bundles pin the pre-rename stored id. Zero consumers
+          // means the orphan is pruned directly; one or more triggers the
+          // remap-then-remove path.
+          const consumers = installedRecordSet(
+            Array.from({ length: consumerCount }, () => orphanOldId)
+          );
+
+          // --- Run 1: in-memory ports -------------------------------------
+          const memoryPorts = portSet(stored, consumers, { withRemap: true });
+          const memoryResult = await loadHubSources(HUB_ID, declarations, memoryPorts);
+          const memoryRecords = recordSourceIds(memoryPorts);
+
+          // --- Run 2: infra-composed ports over one temp directory --------
+          const tempDir = await mkdtemp(path.join(tmpdir(), 'aph-host-parity-'));
+          try {
+            const fs = new NodeFileSystem();
+            const storage = new XdgAppStorage({
+              XDG_DATA_HOME: path.join(tempDir, 'data'),
+              XDG_CONFIG_HOME: path.join(tempDir, 'config'),
+              XDG_CACHE_HOME: path.join(tempDir, 'cache')
+            });
+            const paths = storage.getPaths();
+
+            // Seed the same starting state onto disk: stored sources, and the
+            // installed records under user scope (the scope installedRecordSet
+            // produces).
+            await fs.mkdir(path.dirname(sourcesFile(paths)), { recursive: true });
+            await fs.writeJson(sourcesFile(paths), { sources: stored });
+
+            await fs.mkdir(path.dirname(recordsFile(paths, 'user')), { recursive: true });
+            await fs.writeJson(recordsFile(paths, 'user'), consumers);
+
+            const host = composeInfraHost(storage, fs, path.join(tempDir, 'repo'));
+            const infraResult = await loadHubSources(HUB_ID, declarations, host.ports);
+            const infraRecords = await diskRecordSourceIds(storage, fs);
+
+            // Counts agree (Requirement 6.12).
+            expect(infraResult).toEqual(memoryResult);
+
+            // The exact remap argument pairs agree (Requirement 6.11).
+            expect(host.remapCalls).toEqual(memoryPorts.calls.remapped);
+
+            // And the observable effect on installed records agrees, so parity
+            // holds at the level of what the sync did, not just what it returned.
+            expect(infraRecords).toEqual(memoryRecords);
+
+            if (host.remapCalls.length > 0) {
+              runsWithRemap++;
+            }
+          } finally {
+            await rm(tempDir, { recursive: true, force: true });
+          }
+        })
+      );
+
+      // Premise guard: the remap-argument parity clause is only meaningful when
+      // the generator actually produced runs that remapped.
+      expect(runsWithRemap).toBeGreaterThan(0);
+    },
+    60_000
+  );
+});

--- a/packages/app/test/registry/load-hub-sources.concurrency.property.test.ts
+++ b/packages/app/test/registry/load-hub-sources.concurrency.property.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Property-based test for registry/load-hub-sources.ts — replacement selection
+ * is invariant under concurrency.
+ *
+ * Generalizes the determinism guard in `load-hub-sources.test.ts`
+ * (`replacementIdAtConcurrency`, which pins the renamed three-source hub at
+ * `concurrency: 1` versus `concurrency: 4`) across any one-rename hub config
+ * the generator can produce. The exactly-one-candidate rule in `loadHubSources`
+ * makes selection independent of the order workers populated the
+ * `registeredThisCycle` map in, so a sync at `concurrency > 1` must hand the
+ * remap the same argument pair as a sync at `concurrency: 1`.
+ *
+ * Runs against in-memory ports only — no filesystem, no network, no host.
+ */
+import * as fc from 'fast-check';
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  loadHubSources,
+} from '../../src/registry/load-hub-sources';
+import type {
+  OneRenameSpec,
+} from './generators';
+import {
+  declaredVariant,
+  hubConfigWithOneRename,
+  installedRecordSet,
+  portSet,
+  storedIdFor,
+  toHubSource,
+  toStoredSource,
+} from './generators';
+
+/** The hub under sync. */
+const HUB_ID = 'hub-a';
+
+/** A one-rename hub config, its consumer count, and a concurrency above one. */
+interface Scenario {
+  config: OneRenameSpec;
+  consumerCount: number;
+  concurrency: number;
+}
+
+const scenarioArb = fc.record({
+  // Two or more declarations, so the renamed entry always has siblings whose
+  // registration order across workers could otherwise shift the selection.
+  config: hubConfigWithOneRename({ minLength: 2, maxLength: 5 }),
+  consumerCount: fc.integer({ min: 1, max: 3 }),
+  concurrency: fc.integer({ min: 2, max: 6 })
+});
+
+/**
+ * Run one sync of a one-rename hub config at the given concurrency and return
+ * the single remap invocation's argument pair.
+ * @param config The one-rename hub config.
+ * @param consumerCount How many installed bundles pin the orphan.
+ * @param concurrency The `concurrency` option to pass to the sync.
+ * @returns The `{ oldSourceId, newSourceId }` the remap was invoked with.
+ */
+async function remapArgsAtConcurrency(
+  config: OneRenameSpec,
+  consumerCount: number,
+  concurrency: number
+): Promise<{ oldSourceId: string; newSourceId: string }> {
+  const renamedSpec = config.specs[config.renamedIndex];
+  const declarations = config.specs.map((spec, index) =>
+    toHubSource(spec, declaredVariant(config, index)));
+  const stored = config.specs.map((spec) => toStoredSource(spec, 'old', HUB_ID));
+  const orphanOldId = storedIdFor(renamedSpec, 'old');
+  const consumers = installedRecordSet(
+    Array.from({ length: consumerCount }, () => orphanOldId)
+  );
+
+  const ports = portSet(stored, consumers, { withRemap: true });
+
+  await loadHubSources(HUB_ID, declarations, ports, undefined, { concurrency });
+
+  expect(ports.calls.remapped).toHaveLength(1);
+
+  return ports.calls.remapped[0];
+}
+
+// Feature: hub-source-orphan-remap, Property 2: Replacement selection is invariant under concurrency
+describe('loadHubSources — Property 2', () => {
+  /**
+   * **Validates: Requirements 2.5, 9.15**
+   */
+  it('selects the same replacement id at concurrency greater than 1 as at concurrency 1', async () => {
+    await fc.assert(
+      fc.asyncProperty(scenarioArb, async ({ config, consumerCount, concurrency }: Scenario) => {
+        const sequential = await remapArgsAtConcurrency(config, consumerCount, 1);
+        const parallel = await remapArgsAtConcurrency(config, consumerCount, concurrency);
+
+        // Selection is invariant: the same orphan id maps onto the same
+        // replacement id regardless of how many workers ran the registration.
+        expect(parallel).toEqual(sequential);
+      })
+    );
+  });
+});

--- a/packages/app/test/registry/load-hub-sources.eligibility.property.test.ts
+++ b/packages/app/test/registry/load-hub-sources.eligibility.property.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Property-based test for registry/load-hub-sources.ts — replacement
+ * eligibility.
+ *
+ * Generalizes Cycle H (the phantom-target hazard) across generated hub
+ * configs: declarations that are disabled, declarations whose `addSource`
+ * rejects, declarations already stored under their declared url, and
+ * declarations whose url was renamed while their `id` stayed put — with
+ * installed bundles pinned to the pre-rename stored ids. It does not replace
+ * that cycle's own tests: they pin the exact call counts and the suspension
+ * of orphan evaluation that this property only constrains structurally.
+ *
+ * Runs against in-memory ports only — no filesystem, no network, no host.
+ */
+import * as fc from 'fast-check';
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  loadHubSources,
+} from '../../src/registry/load-hub-sources';
+import type {
+  HubSourceDeclarationSpec,
+} from './generators';
+import {
+  hubSourceDeclaration,
+  installedRecordSet,
+  makeRegistrySource,
+  portSet,
+  storedIdFor,
+  toHubSource,
+  urlFor,
+  writtenSourceIds,
+} from './generators';
+
+/** The hub under sync. */
+const HUB_ID = 'hub-a';
+
+/** One declaration and the storage situation it is synced against. */
+interface DeclarationScenario {
+  spec: HubSourceDeclarationSpec;
+  /** A stored source holds the pre-rename url, so it orphans on this sync. */
+  renamed: boolean;
+  /** A stored source already holds the declared url, so the sync updates it. */
+  storedCurrent: boolean;
+  /** Installed records reference the pre-rename stored id. */
+  hasConsumers: boolean;
+  /** `addSource` rejects for this declaration's generated id. */
+  addFails: boolean;
+}
+
+/** One generated sync scenario. */
+interface Scenario {
+  declarations: DeclarationScenario[];
+  withRemap: boolean;
+  failRemap: boolean;
+}
+
+const declarationScenarioArb = fc.record<DeclarationScenario>({
+  spec: hubSourceDeclaration(),
+  renamed: fc.boolean(),
+  storedCurrent: fc.boolean(),
+  hasConsumers: fc.boolean(),
+  addFails: fc.boolean()
+});
+
+const scenarioArb = fc.record<Scenario>({
+  declarations: fc.uniqueArray(declarationScenarioArb, {
+    minLength: 1,
+    maxLength: 5,
+    selector: (declaration) => declaration.spec.sticker
+  }),
+  withRemap: fc.boolean(),
+  failRemap: fc.boolean()
+});
+
+// Feature: hub-source-orphan-remap, Property 3: Every remap target was registered this cycle
+describe('loadHubSources — Property 3', () => {
+  /**
+   * **Validates: Requirements 4.1, 4.3**
+   */
+  it('only ever remaps onto a source id a successful add or update wrote this cycle', async () => {
+    let runsThatRemapped = 0;
+
+    await fc.assert(
+      fc.asyncProperty(scenarioArb, async (scenario) => {
+        // The config always declares the post-rename url. A `renamed`
+        // declaration additionally has a stored source at its pre-rename url,
+        // which is what turns into an orphan on this sync.
+        const declarations = scenario.declarations.map((declaration) =>
+          toHubSource(declaration.spec, 'new'));
+
+        const stored = scenario.declarations.flatMap((declaration) => [
+          ...declaration.renamed
+            ? [makeRegistrySource({
+              id: storedIdFor(declaration.spec, 'old'),
+              name: `Source ${declaration.spec.sticker} (pre-rename)`,
+              type: declaration.spec.type,
+              url: urlFor(declaration.spec, 'old'),
+              config: {
+                branch: declaration.spec.branch,
+                collectionsPath: declaration.spec.collectionsPath
+              },
+              hubId: HUB_ID,
+              hubSourceId: declaration.spec.sticker
+            })]
+            : [],
+          ...declaration.storedCurrent
+            ? [makeRegistrySource({
+              id: storedIdFor(declaration.spec, 'new'),
+              name: `Source ${declaration.spec.sticker}`,
+              type: declaration.spec.type,
+              url: urlFor(declaration.spec, 'new'),
+              config: {
+                branch: declaration.spec.branch,
+                collectionsPath: declaration.spec.collectionsPath
+              },
+              hubId: HUB_ID,
+              hubSourceId: declaration.spec.sticker
+            })]
+            : []
+        ]);
+
+        const consumerIds = scenario.declarations
+          .filter((declaration) => declaration.renamed && declaration.hasConsumers)
+          .map((declaration) => storedIdFor(declaration.spec, 'old'));
+
+        const ports = portSet(stored, installedRecordSet(consumerIds), {
+          failAddForIds: scenario.declarations
+            .filter((declaration) => declaration.addFails)
+            .map((declaration) => storedIdFor(declaration.spec, 'new')),
+          withRemap: scenario.withRemap,
+          failRemap: scenario.failRemap
+        });
+
+        await loadHubSources(HUB_ID, declarations, ports);
+
+        // The pool a remap target may legitimately be drawn from: ids storage
+        // actually received. Disabled declarations, rejected adds and matched
+        // duplicates are protected from pruning but never written, so a remap
+        // onto one of them would point installed bundles at a phantom source.
+        const registered = writtenSourceIds(ports);
+
+        for (const { newSourceId } of ports.calls.remapped) {
+          expect(registered).toContain(newSourceId);
+        }
+
+        if (ports.calls.remapped.length > 0) {
+          runsThatRemapped++;
+        }
+      }),
+      { numRuns: 200 }
+    );
+
+    // Premise guard: a property about remap targets is vacuous if the
+    // generator never produced a remap.
+    expect(runsThatRemapped).toBeGreaterThan(0);
+  });
+});

--- a/packages/app/test/registry/load-hub-sources.isolation.property.test.ts
+++ b/packages/app/test/registry/load-hub-sources.isolation.property.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Property-based test for registry/load-hub-sources.ts — only the synced
+ * hub's sources are affected.
+ *
+ * Generalizes Cycle L's isolation guard across generated stored-source sets:
+ * alongside the target hub's own sources — some renamed, some with installed
+ * consumers, so the sync genuinely adds, updates, remaps, and prunes — the
+ * store also holds manually-added sources (no `hubId`) and sources owned by a
+ * different hub. Pruning is filtered by `s.hubId === hubId` and no write path
+ * touches a foreign id, so every non-target source must survive the sync
+ * byte-identical.
+ *
+ * Runs against in-memory ports only — no filesystem, no network, no host.
+ */
+import type {
+  RegistrySource,
+  SourceType,
+} from '@ai-primitives-hub/core';
+import * as fc from 'fast-check';
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  loadHubSources,
+} from '../../src/registry/load-hub-sources';
+import type {
+  OneRenameSpec,
+} from './generators';
+import {
+  declaredVariant,
+  hubConfigWithOneRename,
+  installedRecordSet,
+  makeRegistrySource,
+  portSet,
+  SOURCE_TYPES,
+  storedIdFor,
+  toHubSource,
+  toStoredSource,
+} from './generators';
+
+/** The hub under sync. */
+const HUB_ID = 'hub-a';
+
+/** The hub that owns the foreign, must-not-touch sources. */
+const OTHER_HUB_ID = 'hub-b';
+
+/** A stored source that does not belong to the hub being synced. */
+interface NonTargetSpec {
+  /** Unique index, so the literal id never collides across the set. */
+  index: number;
+  type: SourceType;
+  /** `manual` leaves `hubId` absent; `other` attributes it to another hub. */
+  owner: 'manual' | 'other';
+  branch?: string;
+  collectionsPath?: string;
+}
+
+const nonTargetSpecArb = fc.record<NonTargetSpec>({
+  index: fc.integer({ min: 0, max: 999 }),
+  type: fc.constantFrom(...SOURCE_TYPES),
+  owner: fc.constantFrom('manual', 'other'),
+  branch: fc.option(fc.constantFrom('main', 'release'), { nil: undefined }),
+  collectionsPath: fc.option(fc.constantFrom('collections', 'curated'), { nil: undefined })
+});
+
+/**
+ * Build the stored source a non-target spec describes. Its id is a literal
+ * unique to the set — never a `generateSourceId` hash — so it cannot collide
+ * with any id the sync derives from the target hub's declarations.
+ * @param spec The non-target spec.
+ * @returns The stored source, with `hubId` absent for a manual source.
+ */
+function toNonTargetSource(spec: NonTargetSpec): RegistrySource {
+  return makeRegistrySource({
+    id: `${spec.owner}-${spec.index}`,
+    name: `Foreign ${spec.owner} source ${spec.index}`,
+    type: spec.type,
+    url: `https://github.com/foreign/${spec.owner}-${spec.index}`,
+    config: { branch: spec.branch, collectionsPath: spec.collectionsPath },
+    ...spec.owner === 'other' ? { hubId: OTHER_HUB_ID } : {}
+  });
+}
+
+/** A target-hub sync scenario plus the foreign sources sharing its store. */
+interface Scenario {
+  config: OneRenameSpec;
+  consumerCount: number;
+  nonTarget: NonTargetSpec[];
+}
+
+const scenarioArb = fc.record<Scenario>({
+  config: hubConfigWithOneRename({ minLength: 1, maxLength: 4 }),
+  consumerCount: fc.integer({ min: 0, max: 3 }),
+  nonTarget: fc.uniqueArray(nonTargetSpecArb, {
+    minLength: 0,
+    maxLength: 4,
+    selector: (spec) => `${spec.owner}-${spec.index}`
+  })
+});
+
+// Feature: hub-source-orphan-remap, Property 7: Only the synced hub's sources are affected
+describe('loadHubSources — Property 7', () => {
+  let runsWithManual = 0;
+  let runsWithOtherHub = 0;
+
+  /**
+   * **Validates: Requirements 9.5, 9.6**
+   */
+  it('leaves every manual and other-hub source byte-identical across a sync', async () => {
+    await fc.assert(
+      fc.asyncProperty(scenarioArb, async ({ config, consumerCount, nonTarget }: Scenario) => {
+        const renamedSpec = config.specs[config.renamedIndex];
+
+        // The target hub declares its renamed entry at the new url and every
+        // sibling at its unchanged old url — a real sync with updates, an
+        // orphan, and (given consumers) a remap.
+        const declarations = config.specs.map((spec, index) =>
+          toHubSource(spec, declaredVariant(config, index)));
+
+        // Storage holds the target hub's sources at their pre-rename urls plus
+        // the foreign sources that must never be touched.
+        const targetStored = config.specs.map((spec) => toStoredSource(spec, 'old', HUB_ID));
+        const nonTargetStored = nonTarget.map((spec) => toNonTargetSource(spec));
+        const stored = [...targetStored, ...nonTargetStored];
+
+        const consumers = installedRecordSet(
+          Array.from({ length: consumerCount }, () => storedIdFor(renamedSpec, 'old'))
+        );
+
+        const ports = portSet(stored, consumers, { withRemap: true });
+
+        // Snapshot the foreign sources before the sync, keyed by id.
+        const before = new Map(
+          nonTargetStored.map((source) => [source.id, structuredClone(source)])
+        );
+
+        await loadHubSources(HUB_ID, declarations, ports);
+
+        // Every foreign source is still present and byte-identical afterwards.
+        for (const [id, snapshot] of before) {
+          const after = ports.sources.find((source) => source.id === id);
+          expect(after).toEqual(snapshot);
+        }
+
+        if (nonTarget.some((spec) => spec.owner === 'manual')) {
+          runsWithManual++;
+        }
+        if (nonTarget.some((spec) => spec.owner === 'other')) {
+          runsWithOtherHub++;
+        }
+      })
+    );
+
+    // Premise guard: the isolation claim is vacuous unless the generator
+    // actually produced both a manual source and an other-hub source.
+    expect(runsWithManual).toBeGreaterThan(0);
+    expect(runsWithOtherHub).toBeGreaterThan(0);
+  });
+});

--- a/packages/app/test/registry/load-hub-sources.keep-alive.property.test.ts
+++ b/packages/app/test/registry/load-hub-sources.keep-alive.property.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Property-based tests for registry/load-hub-sources.ts — the keep-alive
+ * safety net.
+ *
+ * Generalizes Cycle J across generated hub configs. Every keep-alive reason
+ * the use case distinguishes — no candidate, ambiguous candidates, a missing
+ * sticker, a rejecting remap port, and an absent remap port — is produced by
+ * the generator, and each one must leave the orphan and its installed bundles
+ * exactly where they were. It does not replace that cycle's own unit test:
+ * the example pins the specific warning text and the per-reason branch; these
+ * properties widen the *outcome* guarantee to any shape the generator emits.
+ *
+ * This file also holds Property 5 (task 3.14, the warning-content property),
+ * one property per test.
+ *
+ * Runs against in-memory ports only — no filesystem, no network, no host.
+ */
+import type {
+  HubSource,
+  InstalledBundle,
+  RegistrySource,
+} from '@ai-primitives-hub/core';
+import * as fc from 'fast-check';
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  loadHubSources,
+} from '../../src/registry/load-hub-sources';
+import type {
+  HubSourceDeclarationSpec,
+  PortSetOptions,
+} from './generators';
+import {
+  hubSourceDeclaration,
+  installedRecordSet,
+  portSet,
+  recordSourceIds,
+  storedIdFor,
+  toHubSource,
+  toStoredSource,
+} from './generators';
+
+/** The hub under sync. */
+const HUB_ID = 'hub-a';
+
+/** The five reasons an orphan with consumers is kept rather than remapped. */
+type KeepAliveReason =
+  | 'no-candidate'
+  | 'ambiguous-candidates'
+  | 'missing-sticker'
+  | 'remap-failed'
+  | 'port-absent';
+
+const KEEP_ALIVE_REASONS: KeepAliveReason[] = [
+  'no-candidate',
+  'ambiguous-candidates',
+  'missing-sticker',
+  'remap-failed',
+  'port-absent'
+];
+
+/** One generated keep-alive scenario before it is compiled into ports. */
+interface KeepAliveSpec {
+  reason: KeepAliveReason;
+  /** The declaration whose pre-rename stored source becomes the orphan. */
+  orphanSpec: HubSourceDeclarationSpec;
+  /** Unrelated sibling declarations, distinct stickers, always registered. */
+  siblingSpecs: HubSourceDeclarationSpec[];
+  /** How many installed bundles pin the orphan's pre-rename id. */
+  consumerCount: number;
+}
+
+const keepAliveSpecArb: fc.Arbitrary<KeepAliveSpec> = fc
+  .uniqueArray(hubSourceDeclaration(), {
+    minLength: 1,
+    maxLength: 4,
+    selector: (spec) => spec.sticker
+  })
+  // Every declaration is enabled: a disabled one would never register, which
+  // is a different (eligibility) concern than the keep-alive outcome here.
+  .map((specs) => specs.map((spec) => ({ ...spec, enabled: true })))
+  .chain((specs) => fc.record<KeepAliveSpec>({
+    reason: fc.constantFrom(...KEEP_ALIVE_REASONS),
+    orphanSpec: fc.constant(specs[0]),
+    siblingSpecs: fc.constant(specs.slice(1)),
+    consumerCount: fc.integer({ min: 1, max: 3 })
+  }));
+
+/** What a compiled scenario feeds to a sync, plus the orphan to inspect. */
+interface CompiledScenario {
+  declarations: HubSource[];
+  stored: RegistrySource[];
+  consumers: InstalledBundle[];
+  orphanId: string;
+  portOptions: PortSetOptions;
+}
+
+/**
+ * Compile a generated spec into the config, storage, records, and port wiring
+ * that provoke its keep-alive reason. The orphan is always a pre-rename stored
+ * source of `orphanSpec` with live consumers; only the config shape and the
+ * port options differ per reason.
+ * @param spec The generated keep-alive spec.
+ * @returns The compiled scenario.
+ */
+function compile(spec: KeepAliveSpec): CompiledScenario {
+  const { reason, orphanSpec, siblingSpecs, consumerCount } = spec;
+
+  // Siblings are declared new every time, so the sync always registers real
+  // sources whose stickers differ from the orphan's — they must never become
+  // the orphan's replacement candidate.
+  const siblingDeclarations = siblingSpecs.map((sibling) => toHubSource(sibling, 'new'));
+
+  const orphanId = storedIdFor(orphanSpec, 'old');
+  const consumers = installedRecordSet(
+    Array.from({ length: consumerCount }, () => orphanId)
+  );
+
+  // The orphan carries its sticker unless the reason under test is a missing
+  // one, in which case the stored record predates the feature.
+  const orphanStored = toStoredSource(
+    orphanSpec,
+    'old',
+    HUB_ID,
+    reason === 'missing-sticker' ? { hubSourceId: undefined } : {}
+  );
+
+  const base = {
+    stored: [orphanStored],
+    consumers,
+    orphanId
+  };
+
+  switch (reason) {
+    case 'no-candidate': {
+      // The orphan's declaration is dropped from the config, so no source
+      // registered this cycle carries its sticker.
+      return { ...base, declarations: siblingDeclarations, portOptions: { withRemap: true } };
+    }
+
+    case 'missing-sticker': {
+      // The renamed declaration is present and registers a sticker, but the
+      // orphan has none, so `undefined === undefined` proves nothing.
+      return {
+        ...base,
+        declarations: [toHubSource(orphanSpec, 'new'), ...siblingDeclarations],
+        portOptions: { withRemap: true }
+      };
+    }
+
+    case 'ambiguous-candidates': {
+      // Two enabled declarations share the orphan's sticker under distinct
+      // urls, so both register and the match is not unique.
+      const candidateA = toHubSource(orphanSpec, 'new');
+      const candidateB: HubSource = {
+        ...candidateA,
+        url: `${candidateA.url}-alt`,
+        name: `${candidateA.name} (alt)`
+      };
+
+      return {
+        ...base,
+        declarations: [candidateA, candidateB, ...siblingDeclarations],
+        portOptions: { withRemap: true }
+      };
+    }
+
+    case 'remap-failed': {
+      // Exactly one candidate, but the remap port rejects before any write.
+      return {
+        ...base,
+        declarations: [toHubSource(orphanSpec, 'new'), ...siblingDeclarations],
+        portOptions: { withRemap: true, failRemap: true }
+      };
+    }
+
+    default: {
+      // 'port-absent': exactly one candidate, but the host wired no remap port.
+      return {
+        ...base,
+        declarations: [toHubSource(orphanSpec, 'new'), ...siblingDeclarations],
+        portOptions: { withRemap: false }
+      };
+    }
+  }
+}
+
+// Feature: hub-source-orphan-remap, Property 4: An unprovable match keeps the orphan alive
+describe('loadHubSources — Property 4', () => {
+  /**
+   * **Validates: Requirements 3.1, 3.3, 3.4, 3.5, 9.8, 9.11, 9.13**
+   */
+  it('keeps the orphan in storage and leaves every installed record untouched', async () => {
+    // Guard that the generator actually exercised every keep-alive reason,
+    // so a passing run is not one where whole branches were never produced.
+    const reasonsSeen = new Set<KeepAliveReason>();
+
+    await fc.assert(
+      fc.asyncProperty(keepAliveSpecArb, async (spec: KeepAliveSpec) => {
+        const scenario = compile(spec);
+        const ports = portSet(scenario.stored, scenario.consumers, scenario.portOptions);
+
+        // The records as they stand before the sync: nothing may move them.
+        const before = recordSourceIds(ports);
+
+        const result = await loadHubSources(HUB_ID, scenario.declarations, ports);
+
+        // The orphan is still stored, was never removed, and is not counted.
+        expect(ports.sources.map((source) => source.id)).toContain(scenario.orphanId);
+        expect(ports.calls.removed).not.toContain(scenario.orphanId);
+        expect(result.removed).toBe(0);
+
+        // No installed-bundle record's sourceId changed.
+        expect(recordSourceIds(ports)).toEqual(before);
+
+        reasonsSeen.add(spec.reason);
+      }),
+      { numRuns: 300 }
+    );
+
+    expect([...reasonsSeen].toSorted()).toEqual([...KEEP_ALIVE_REASONS].toSorted());
+  });
+});
+
+/** The exact remediation clause every keep-alive warning must end with. */
+const REMEDIATION_FRAGMENT = 'keep a source\'s `id` stable when changing its `url`';
+
+// Feature: hub-source-orphan-remap, Property 5: Keep-alive warnings carry every diagnostic fragment
+describe('loadHubSources — Property 5', () => {
+  /**
+   * **Validates: Requirements 3.6**
+   */
+  it('emits exactly one warn per orphan carrying every diagnostic fragment', async () => {
+    const reasonsSeen = new Set<KeepAliveReason>();
+
+    await fc.assert(
+      fc.asyncProperty(keepAliveSpecArb, async (spec: KeepAliveSpec) => {
+        const scenario = compile(spec);
+        const ports = portSet(scenario.stored, scenario.consumers, scenario.portOptions);
+
+        // The orphan is the single pre-rename stored source the scenario built.
+        const [orphan] = scenario.stored;
+        const consumerCount = scenario.consumers.length;
+
+        // Capture every log event so the warning content can be inspected.
+        const events: { level: string; message: string }[] = [];
+
+        await loadHubSources(HUB_ID, scenario.declarations, ports, (event) => {
+          events.push({ level: event.level, message: event.message });
+        });
+
+        // Exactly one warn event references this orphan by id.
+        const orphanWarnings = events.filter(
+          (event) => event.level === 'warn' && event.message.includes(orphan.id)
+        );
+        expect(orphanWarnings).toHaveLength(1);
+
+        const [{ message }] = orphanWarnings;
+
+        // Every diagnostic fragment the requirement enumerates is present.
+        expect(message).toContain(orphan.id);
+        expect(message).toContain(orphan.name);
+        expect(message).toContain(`${consumerCount} installed bundle(s)`);
+        expect(message).toContain(`[${spec.reason}]`);
+        expect(message).toContain(REMEDIATION_FRAGMENT);
+
+        reasonsSeen.add(spec.reason);
+      }),
+      { numRuns: 300 }
+    );
+
+    expect([...reasonsSeen].toSorted()).toEqual([...KEEP_ALIVE_REASONS].toSorted());
+  });
+});

--- a/packages/app/test/registry/load-hub-sources.matching.property.test.ts
+++ b/packages/app/test/registry/load-hub-sources.matching.property.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Property-based test for registry/load-hub-sources.ts — the renamed source is
+ * the exact replacement.
+ *
+ * Generalizes Cycle I (the FN-1 defect) across generated multi-source hub
+ * configs: several declarations carrying distinct stickers, exactly one of
+ * them renamed by `url` only, with installed bundles pinned to the pre-rename
+ * stored id. It does not replace that cycle's own test: the example pins the
+ * exact `remapBundleSource` argument pair and the sibling ids that must never
+ * appear; this property widens that guarantee to any shape the generator can
+ * produce.
+ *
+ * Runs against in-memory ports only — no filesystem, no network, no host.
+ */
+import * as fc from 'fast-check';
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  loadHubSources,
+} from '../../src/registry/load-hub-sources';
+import type {
+  OneRenameSpec,
+} from './generators';
+import {
+  declaredVariant,
+  hubConfigWithOneRename,
+  installedRecordSet,
+  portSet,
+  storedIdFor,
+  toHubSource,
+  toStoredSource,
+} from './generators';
+
+/** The hub under sync. */
+const HUB_ID = 'hub-a';
+
+/** A one-rename hub config plus how many installed bundles pin the orphan. */
+interface Scenario {
+  config: OneRenameSpec;
+  consumerCount: number;
+}
+
+const scenarioArb = fc.record({
+  // At least one declaration; up to five, so the renamed entry is frequently
+  // surrounded by siblings competing to be picked as the replacement.
+  config: hubConfigWithOneRename({ minLength: 1, maxLength: 5 }),
+  consumerCount: fc.integer({ min: 1, max: 3 })
+});
+
+// Feature: hub-source-orphan-remap, Property 1: The renamed source is the exact replacement
+describe('loadHubSources — Property 1', () => {
+  /**
+   * **Validates: Requirements 2.1, 2.2, 2.3, 2.4, 2.6, 9.10**
+   */
+  it('remaps the pre-rename id onto the renamed declaration id, never onto a sibling', async () => {
+    let runsWithSiblings = 0;
+
+    await fc.assert(
+      fc.asyncProperty(scenarioArb, async ({ config, consumerCount }: Scenario) => {
+        const renamedSpec = config.specs[config.renamedIndex];
+
+        // The config declares the renamed entry at its new url and every
+        // sibling at its unchanged old url.
+        const declarations = config.specs.map((spec, index) =>
+          toHubSource(spec, declaredVariant(config, index)));
+
+        // Storage holds every declaration at its pre-rename url. Siblings
+        // therefore match their declared id and update in place; the renamed
+        // entry's stored id no longer matches any declaration, so it orphans.
+        const stored = config.specs.map((spec) => toStoredSource(spec, 'old', HUB_ID));
+
+        const orphanOldId = storedIdFor(renamedSpec, 'old');
+        const orphanNewId = storedIdFor(renamedSpec, 'new');
+
+        // Installed bundles pin the pre-rename stored id, so the orphan cannot
+        // simply be pruned — it must be remapped onto its successor.
+        const consumers = installedRecordSet(
+          Array.from({ length: consumerCount }, () => orphanOldId)
+        );
+
+        const ports = portSet(stored, consumers, { withRemap: true });
+
+        const result = await loadHubSources(HUB_ID, declarations, ports);
+
+        // Exactly one remap, and its argument pair is the renamed source's own
+        // pre-rename id mapped onto its own post-rename id.
+        expect(ports.calls.remapped).toHaveLength(1);
+        expect(ports.calls.remapped[0]).toEqual({
+          oldSourceId: orphanOldId,
+          newSourceId: orphanNewId
+        });
+
+        // No sibling id — in either url generation — may ever be handed to the
+        // remap as the replacement. This is the FN-1 defect the property closes.
+        const siblingIds = config.specs
+          .filter((_, index) => index !== config.renamedIndex)
+          .flatMap((spec) => [storedIdFor(spec, 'old'), storedIdFor(spec, 'new')]);
+
+        for (const { newSourceId } of ports.calls.remapped) {
+          expect(siblingIds).not.toContain(newSourceId);
+        }
+
+        // The orphan is gone from storage and counted as removed, exactly once.
+        expect(ports.sources.map((source) => source.id)).not.toContain(orphanOldId);
+        expect(ports.calls.removed).toContain(orphanOldId);
+        expect(result.removed).toBe(1);
+
+        if (config.specs.length > 1) {
+          runsWithSiblings++;
+        }
+      })
+    );
+
+    // Premise guard: the "never a sibling" clause is only meaningful when the
+    // generator actually produced siblings to reject.
+    expect(runsWithSiblings).toBeGreaterThan(0);
+  });
+});

--- a/packages/app/test/registry/load-hub-sources.pruning.property.test.ts
+++ b/packages/app/test/registry/load-hub-sources.pruning.property.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Property-based tests for registry/load-hub-sources.ts — orphan pruning and
+ * the add-failure suspension.
+ *
+ * Generalizes the two halves of Property 6 across generated orphan sets:
+ *
+ * - **Pruning.** With every declared source registering cleanly, an orphan
+ *   that no installed bundle references is removed outright, and the remap is
+ *   never invoked for it — the zero-consumer branch does not need a
+ *   replacement.
+ * - **Suspension.** When any `addSource` rejects during the sync, orphan
+ *   evaluation is skipped for the whole cycle: no orphan is removed, whether
+ *   or not it has consumers, and the remap is never invoked at all.
+ *
+ * It does not replace the existing example coverage of these branches; it
+ * widens the outcome guarantee to any orphan set the generator emits, and its
+ * premise guards prove both branches were actually exercised.
+ *
+ * Runs against in-memory ports only — no filesystem, no network, no host.
+ */
+import * as fc from 'fast-check';
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  loadHubSources,
+} from '../../src/registry/load-hub-sources';
+import type {
+  HubSourceDeclarationSpec,
+} from './generators';
+import {
+  hubSourceDeclaration,
+  installedRecordSet,
+  portSet,
+  storedIdFor,
+  toHubSource,
+  toStoredSource,
+} from './generators';
+
+/** The hub under sync. */
+const HUB_ID = 'hub-a';
+
+/** One pre-rename stored source that becomes an orphan on this sync. */
+interface OrphanEntry {
+  spec: HubSourceDeclarationSpec;
+  /** Whether installed bundles pin the orphan's stored id. */
+  hasConsumers: boolean;
+}
+
+/** A generated pruning or suspension scenario. */
+interface Scenario {
+  mode: 'prune' | 'suspend';
+  /** Sources stored at their pre-rename url and absent from the config. */
+  orphans: OrphanEntry[];
+  /** Enabled declarations the sync registers fresh this cycle. */
+  freshSpecs: HubSourceDeclarationSpec[];
+  /** In suspend mode, the first fresh declaration's `addSource` rejects. */
+  failFirstAdd: boolean;
+}
+
+/**
+ * Consumer-free orphans plus cleanly-registering declarations. Every orphan is
+ * removable, so the pruning half of the property is never vacuous.
+ */
+const pruneScenarioArb: fc.Arbitrary<Scenario> = fc
+  .uniqueArray(hubSourceDeclaration(), {
+    minLength: 1,
+    maxLength: 5,
+    selector: (spec) => spec.sticker
+  })
+  .chain((specs) => fc
+    .integer({ min: 1, max: specs.length })
+    .map((orphanCount) => ({
+      mode: 'prune' as const,
+      orphans: specs
+        .slice(0, orphanCount)
+        .map((spec) => ({ spec, hasConsumers: false })),
+      // Enabled so the sync actually adds them; distinct stickers from the
+      // orphans, so no fresh source is ever a replacement candidate.
+      freshSpecs: specs.slice(orphanCount).map((spec) => ({ ...spec, enabled: true })),
+      failFirstAdd: false
+    })));
+
+/**
+ * At least one orphan and at least one fresh declaration whose `addSource`
+ * rejects, so a real add failure suspends pruning while genuine orphans exist.
+ */
+const suspendScenarioArb: fc.Arbitrary<Scenario> = fc
+  .uniqueArray(hubSourceDeclaration(), {
+    minLength: 2,
+    maxLength: 6,
+    selector: (spec) => spec.sticker
+  })
+  .chain((specs) => fc
+    .record({
+      orphanCount: fc.integer({ min: 1, max: specs.length - 1 }),
+      consumerFlags: fc.array(fc.boolean(), {
+        minLength: specs.length,
+        maxLength: specs.length
+      })
+    })
+    .map(({ orphanCount, consumerFlags }) => ({
+      mode: 'suspend' as const,
+      orphans: specs
+        .slice(0, orphanCount)
+        .map((spec, index) => ({ spec, hasConsumers: consumerFlags[index] })),
+      freshSpecs: specs.slice(orphanCount).map((spec) => ({ ...spec, enabled: true })),
+      failFirstAdd: true
+    })));
+
+const scenarioArb: fc.Arbitrary<Scenario> = fc.oneof(pruneScenarioArb, suspendScenarioArb);
+
+// Feature: hub-source-orphan-remap, Property 6: Consumer-free orphans are pruned, and a failed add suspends all pruning
+describe('loadHubSources — Property 6', () => {
+  /**
+   * **Validates: Requirements 3.7, 3.8, 9.7**
+   */
+  it('prunes consumer-free orphans without remapping, and a failed add suspends all pruning', async () => {
+    let pruneRuns = 0;
+    let suspendRuns = 0;
+
+    await fc.assert(
+      fc.asyncProperty(scenarioArb, async (scenario) => {
+        // The config declares only the fresh sources; each orphan is a stored
+        // source at its pre-rename url that no declaration re-declares.
+        const declarations = scenario.freshSpecs.map((spec) => toHubSource(spec, 'new'));
+        const stored = scenario.orphans.map((orphan) =>
+          toStoredSource(orphan.spec, 'old', HUB_ID));
+        const orphanIds = scenario.orphans.map((orphan) => storedIdFor(orphan.spec, 'old'));
+
+        // Consumer records pin only the orphans flagged as having consumers.
+        const consumerIds = scenario.orphans
+          .filter((orphan) => orphan.hasConsumers)
+          .map((orphan) => storedIdFor(orphan.spec, 'old'));
+
+        const failAddForIds = scenario.failFirstAdd && scenario.freshSpecs.length > 0
+          ? [storedIdFor(scenario.freshSpecs[0], 'new')]
+          : [];
+
+        const ports = portSet(stored, installedRecordSet(consumerIds), {
+          failAddForIds,
+          withRemap: true
+        });
+
+        const result = await loadHubSources(HUB_ID, declarations, ports);
+
+        const storedIdsAfter = ports.sources.map((source) => source.id);
+
+        if (scenario.mode === 'prune') {
+          // Every consumer-free orphan is removed, counted, and gone from the
+          // store, and the remap was never needed for the zero-consumer path.
+          for (const orphanId of orphanIds) {
+            expect(ports.calls.removed).toContain(orphanId);
+            expect(storedIdsAfter).not.toContain(orphanId);
+          }
+          expect(result.removed).toBe(orphanIds.length);
+          expect(ports.calls.remapped).toHaveLength(0);
+          pruneRuns++;
+        } else {
+          // A failed add suspends pruning: no orphan is removed, every orphan
+          // survives in the store, and the remap is never invoked at all.
+          for (const orphanId of orphanIds) {
+            expect(ports.calls.removed).not.toContain(orphanId);
+            expect(storedIdsAfter).toContain(orphanId);
+          }
+          expect(result.removed).toBe(0);
+          expect(ports.calls.remapped).toHaveLength(0);
+          suspendRuns++;
+        }
+      }),
+      { numRuns: 200 }
+    );
+
+    // Premise guards: both halves of the property must have actually run,
+    // otherwise a passing suite could be hiding an unexercised branch.
+    expect(pruneRuns).toBeGreaterThan(0);
+    expect(suspendRuns).toBeGreaterThan(0);
+  });
+});

--- a/packages/app/test/registry/load-hub-sources.reporting.property.test.ts
+++ b/packages/app/test/registry/load-hub-sources.reporting.property.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Property-based test for registry/load-hub-sources.ts — a successful remap is
+ * fully reported.
+ *
+ * Generalizes Cycle K across generated multi-source hub configs: several
+ * declarations carrying distinct stickers, exactly one of them renamed by
+ * `url` only, with installed bundles pinned to the pre-rename stored id, so
+ * the sync performs a real remap-and-remove. It does not replace that cycle's
+ * own unit test: the example pins the specific `info` message for one config;
+ * this property widens the reporting guarantee to any shape the generator can
+ * produce — exactly one `info` event referencing the orphan, carrying the
+ * remapped record count, the old id, the new id, and the matched sticker.
+ *
+ * Runs against in-memory ports only — no filesystem, no network, no host.
+ */
+import * as fc from 'fast-check';
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  loadHubSources,
+} from '../../src/registry/load-hub-sources';
+import type {
+  OneRenameSpec,
+} from './generators';
+import {
+  declaredVariant,
+  hubConfigWithOneRename,
+  installedRecordSet,
+  portSet,
+  storedIdFor,
+  toHubSource,
+  toStoredSource,
+} from './generators';
+
+/** The hub under sync. */
+const HUB_ID = 'hub-a';
+
+/** A one-rename hub config plus how many installed bundles pin the orphan. */
+interface Scenario {
+  config: OneRenameSpec;
+  consumerCount: number;
+}
+
+const scenarioArb = fc.record({
+  // At least one declaration; up to five, so the renamed entry is frequently
+  // surrounded by siblings whose own writes also emit info events — the
+  // "exactly one" clause has to hold amid that noise.
+  config: hubConfigWithOneRename({ minLength: 1, maxLength: 5 }),
+  consumerCount: fc.integer({ min: 1, max: 3 })
+});
+
+// Feature: hub-source-orphan-remap, Property 11: A successful remap is fully reported
+describe('loadHubSources — Property 11', () => {
+  /**
+   * **Validates: Requirements 7.1**
+   */
+  it('emits exactly one info event naming the record count, old id, new id, and sticker', async () => {
+    await fc.assert(
+      fc.asyncProperty(scenarioArb, async ({ config, consumerCount }: Scenario) => {
+        const renamedSpec = config.specs[config.renamedIndex];
+
+        // The config declares the renamed entry at its new url and every
+        // sibling at its unchanged old url.
+        const declarations = config.specs.map((spec, index) =>
+          toHubSource(spec, declaredVariant(config, index)));
+
+        // Storage holds every declaration at its pre-rename url, so the renamed
+        // entry's stored id orphans while its successor registers this cycle.
+        const stored = config.specs.map((spec) => toStoredSource(spec, 'old', HUB_ID));
+
+        const orphanOldId = storedIdFor(renamedSpec, 'old');
+        const orphanNewId = storedIdFor(renamedSpec, 'new');
+
+        // Installed bundles pin the pre-rename stored id, so the orphan is
+        // remapped onto its successor rather than simply pruned.
+        const consumers = installedRecordSet(
+          Array.from({ length: consumerCount }, () => orphanOldId)
+        );
+
+        const ports = portSet(stored, consumers, { withRemap: true });
+
+        // Capture every log event so the success report can be inspected.
+        const events: { level: string; message: string }[] = [];
+
+        const result = await loadHubSources(HUB_ID, declarations, ports, (event) => {
+          events.push({ level: event.level, message: event.message });
+        });
+
+        // Premise guard: the scenario really did perform the remap-and-remove
+        // whose reporting this property is about.
+        expect(result.removed).toBe(1);
+        expect(ports.calls.remapped).toEqual([
+          { oldSourceId: orphanOldId, newSourceId: orphanNewId }
+        ]);
+
+        // Exactly one info event references the orphan by its pre-rename id.
+        const successReports = events.filter(
+          (event) => event.level === 'info' && event.message.includes(orphanOldId)
+        );
+        expect(successReports).toHaveLength(1);
+
+        const [{ message }] = successReports;
+
+        // That single event names every fragment Requirement 7.1 enumerates:
+        // the number of remapped records, the old id, the new id, and the
+        // hubSourceId that proved the match.
+        expect(message).toContain(`${consumerCount} installed bundle record(s)`);
+        expect(message).toContain(orphanOldId);
+        expect(message).toContain(orphanNewId);
+        expect(message).toContain(`"${renamedSpec.sticker}"`);
+      })
+    );
+  });
+});

--- a/packages/app/test/registry/load-hub-sources.sticker.property.test.ts
+++ b/packages/app/test/registry/load-hub-sources.sticker.property.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Property-based test for registry/load-hub-sources.ts — sticker persistence.
+ *
+ * Generalizes Cycle G across generated hub configs: declarations that are new
+ * to storage, declarations already stored under the declared url *with* a
+ * sticker, declarations already stored *without* one (the pre-feature record
+ * whose sticker has to be backfilled), and declarations whose url was renamed
+ * while their `id` stayed put. It does not replace that cycle's own tests:
+ * they pin the exact payload shape and the no-`id` edge case that this
+ * property leaves out by construction.
+ *
+ * Runs against in-memory ports only — no filesystem, no network, no host.
+ */
+import {
+  generateSourceId,
+} from '@ai-primitives-hub/core';
+import * as fc from 'fast-check';
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  loadHubSources,
+} from '../../src/registry/load-hub-sources';
+import type {
+  HubSourceDeclarationSpec,
+} from './generators';
+import {
+  hubSourceDeclaration,
+  makeRegistrySource,
+  portSet,
+  toHubSource,
+  urlFor,
+} from './generators';
+
+/** The hub under sync. */
+const HUB_ID = 'hub-a';
+
+/** How a declaration is already represented in storage, if at all. */
+type StoredShape =
+  /** Nothing stored: the sync adds a new record. */
+  | 'absent'
+  /** Stored at the declared url with its sticker: the sync updates it. */
+  | 'current-with-sticker'
+  /** Stored at the declared url without a sticker: the sync backfills it. */
+  | 'current-without-sticker'
+  /** Stored at the pre-rename url: it orphans, and the sync adds the new id. */
+  | 'renamed';
+
+/** One declaration and the storage situation it is synced against. */
+interface DeclarationScenario {
+  spec: HubSourceDeclarationSpec;
+  stored: StoredShape;
+}
+
+const declarationScenarioArb = fc.record<DeclarationScenario>({
+  spec: hubSourceDeclaration(),
+  stored: fc.constantFrom<StoredShape>(
+    'absent',
+    'current-with-sticker',
+    'current-without-sticker',
+    'renamed'
+  )
+});
+
+const scenarioArb = fc.uniqueArray(declarationScenarioArb, {
+  minLength: 1,
+  maxLength: 5,
+  selector: (declaration) => declaration.spec.sticker
+});
+
+/**
+ * The stored id a declaration resolves to for one url generation — the same
+ * derivation `loadHubSources` performs.
+ * @param spec The declaration spec.
+ * @param variant Which url generation to derive from.
+ * @returns The generated stored source id.
+ */
+function storedIdFor(spec: HubSourceDeclarationSpec, variant: 'old' | 'new'): string {
+  return generateSourceId(spec.type, urlFor(spec, variant), {
+    branch: spec.branch,
+    collectionsPath: spec.collectionsPath
+  });
+}
+
+// Feature: hub-source-orphan-remap, Property 10: The sticker is persisted on every write
+describe('loadHubSources — Property 10', () => {
+  /**
+   * **Validates: Requirements 1.1, 1.2, 1.3**
+   */
+  it('writes hubSourceId equal to the declaration id on every added and updated source', async () => {
+    let runsThatAdded = 0;
+    let runsThatUpdated = 0;
+    let runsThatBackfilled = 0;
+
+    await fc.assert(
+      fc.asyncProperty(scenarioArb, async (declarations) => {
+        // The config always declares the post-rename url; storage holds the
+        // pre-rename record only for the `renamed` shape.
+        const hubSources = declarations.map((declaration) =>
+          toHubSource(declaration.spec, 'new'));
+
+        // Stored id -> the sticker its declaration carries. Every write the
+        // sync performs must land the sticker this map names.
+        const expectedSticker = new Map(declarations.map((declaration) => [
+          storedIdFor(declaration.spec, 'new'),
+          declaration.spec.sticker
+        ]));
+
+        const stored = declarations.flatMap((declaration) => {
+          const { spec, stored: shape } = declaration;
+          const base = {
+            name: `Source ${spec.sticker}`,
+            type: spec.type,
+            config: { branch: spec.branch, collectionsPath: spec.collectionsPath },
+            hubId: HUB_ID
+          };
+
+          if (shape === 'renamed') {
+            return [makeRegistrySource({
+              ...base,
+              id: storedIdFor(spec, 'old'),
+              url: urlFor(spec, 'old'),
+              hubSourceId: spec.sticker
+            })];
+          }
+
+          if (shape === 'current-with-sticker') {
+            return [makeRegistrySource({
+              ...base,
+              id: storedIdFor(spec, 'new'),
+              url: urlFor(spec, 'new'),
+              hubSourceId: spec.sticker
+            })];
+          }
+
+          if (shape === 'current-without-sticker') {
+            // The pre-feature record: same stored id, no sticker key at all.
+            return [makeRegistrySource({
+              ...base,
+              id: storedIdFor(spec, 'new'),
+              url: urlFor(spec, 'new')
+            })];
+          }
+
+          return [];
+        });
+
+        const backfillIds = declarations
+          .filter((declaration) => declaration.stored === 'current-without-sticker'
+            && declaration.spec.enabled)
+          .map((declaration) => storedIdFor(declaration.spec, 'new'));
+
+        const ports = portSet(stored);
+
+        await loadHubSources(HUB_ID, hubSources, ports);
+
+        for (const source of ports.calls.added) {
+          expect(source.hubSourceId).toBe(expectedSticker.get(source.id));
+        }
+
+        for (const update of ports.calls.updated) {
+          expect(update.updates.hubSourceId).toBe(expectedSticker.get(update.sourceId));
+        }
+
+        // The observable end state, not just the call payloads: every id
+        // storage received this cycle holds its declaration's sticker,
+        // including the records that were persisted without the field.
+        const writtenIds = [
+          ...ports.calls.added.map((source) => source.id),
+          ...ports.calls.updated.map((update) => update.sourceId)
+        ];
+
+        for (const id of writtenIds) {
+          const persisted = ports.sources.find((source) => source.id === id);
+          expect(persisted?.hubSourceId).toBe(expectedSticker.get(id));
+        }
+
+        for (const id of backfillIds) {
+          expect(writtenIds).toContain(id);
+        }
+
+        if (ports.calls.added.length > 0) {
+          runsThatAdded++;
+        }
+        if (ports.calls.updated.length > 0) {
+          runsThatUpdated++;
+        }
+        if (backfillIds.length > 0) {
+          runsThatBackfilled++;
+        }
+      }),
+      { numRuns: 200 }
+    );
+
+    // Premise guards: a property about writes is vacuous unless the generator
+    // produced adds, updates, and at least one sticker-less record to backfill.
+    expect(runsThatAdded).toBeGreaterThan(0);
+    expect(runsThatUpdated).toBeGreaterThan(0);
+    expect(runsThatBackfilled).toBeGreaterThan(0);
+  });
+});

--- a/packages/app/test/registry/load-hub-sources.test.ts
+++ b/packages/app/test/registry/load-hub-sources.test.ts
@@ -3,6 +3,7 @@
  */
 import type {
   HubSource,
+  LogEvent,
   RegistrySource,
 } from '@ai-primitives-hub/core';
 import {
@@ -47,13 +48,22 @@ function makeRegistrySource(overrides: Partial<RegistrySource> = {}): RegistrySo
   };
 }
 
-function makePorts(initial: RegistrySource[] = []): {
+function makePorts(
+  initial: RegistrySource[] = [],
+  installedBundleSourceIds: string[] = []
+): {
   listSources: ReturnType<typeof vi.fn>;
   addSource: ReturnType<typeof vi.fn>;
   updateSource: ReturnType<typeof vi.fn>;
+  removeSource: ReturnType<typeof vi.fn>;
+  listInstalledBundles: ReturnType<typeof vi.fn>;
   sources: RegistrySource[];
 } {
   const sources = [...initial];
+  const installed = installedBundleSourceIds.map((sourceId, index) => ({
+    bundleId: `bundle-${index}`,
+    sourceId
+  }));
   return {
     sources,
     listSources: vi.fn(async () => [...sources]),
@@ -65,8 +75,25 @@ function makePorts(initial: RegistrySource[] = []): {
       if (index !== -1) {
         sources[index] = { ...sources[index], ...updates };
       }
-    })
+    }),
+    removeSource: vi.fn(async (id: string) => {
+      const index = sources.findIndex((s) => s.id === id);
+      if (index !== -1) {
+        sources.splice(index, 1);
+      }
+    }),
+    listInstalledBundles: vi.fn(async () => [...installed])
   };
+}
+
+/**
+ * Capture every log event a sync emits, so assertions can count events by
+ * level and inspect their content.
+ * @returns The captured events array and the `onLog` sink to pass to the sync.
+ */
+function collectEvents(): { events: LogEvent[]; onLog: (event: LogEvent) => void } {
+  const events: LogEvent[] = [];
+  return { events, onLog: (event) => events.push(event) };
 }
 
 describe('findDuplicateSource', () => {
@@ -118,7 +145,7 @@ describe('loadHubSources', () => {
     const source = makeHubSource();
     const result = await loadHubSources('hub-a', [source], ports);
 
-    expect(result).toEqual({ added: 1, updated: 0, skipped: 0 });
+    expect(result).toEqual({ added: 1, updated: 0, skipped: 0, removed: 0 });
     expect(ports.addSource).toHaveBeenCalledWith(expect.objectContaining({
       id: generateSourceId('awesome-copilot', source.url, { branch: 'main', collectionsPath: 'collections' }),
       name: 'Source 1',
@@ -129,7 +156,7 @@ describe('loadHubSources', () => {
   it('skips disabled sources', async () => {
     const result = await loadHubSources('hub-a', [makeHubSource({ enabled: false })], ports);
 
-    expect(result).toEqual({ added: 0, updated: 0, skipped: 1 });
+    expect(result).toEqual({ added: 0, updated: 0, skipped: 1, removed: 0 });
     expect(ports.addSource).not.toHaveBeenCalled();
   });
 
@@ -139,7 +166,7 @@ describe('loadHubSources', () => {
 
     const result = await loadHubSources('hub-a', [{ ...source, name: 'Renamed' }], ports);
 
-    expect(result).toEqual({ added: 0, updated: 1, skipped: 0 });
+    expect(result).toEqual({ added: 0, updated: 1, skipped: 0, removed: 0 });
     expect(ports.sources).toHaveLength(1);
     expect(ports.sources[0].name).toBe('Renamed');
   });
@@ -150,7 +177,7 @@ describe('loadHubSources', () => {
 
     const result = await loadHubSources('hub-a', [makeHubSource()], ports);
 
-    expect(result).toEqual({ added: 0, updated: 0, skipped: 1 });
+    expect(result).toEqual({ added: 0, updated: 0, skipped: 1, removed: 0 });
     expect(ports.sources).toHaveLength(1);
   });
 
@@ -163,7 +190,7 @@ describe('loadHubSources', () => {
       ports
     );
 
-    expect(result).toEqual({ added: 1, updated: 0, skipped: 0 });
+    expect(result).toEqual({ added: 1, updated: 0, skipped: 0, removed: 0 });
     expect(ports.sources).toHaveLength(2);
   });
 
@@ -181,7 +208,7 @@ describe('loadHubSources', () => {
 
     const result = await loadHubSources('hub-a', sources, ports);
 
-    expect(result).toEqual({ added: 2, updated: 0, skipped: 1 });
+    expect(result).toEqual({ added: 2, updated: 0, skipped: 1, removed: 0 });
   });
 
   it('adds sources concurrently without exceeding the configured limit', async () => {
@@ -247,7 +274,7 @@ describe('loadHubSources', () => {
       }
     );
 
-    expect(result).toEqual({ added: 1, updated: 0, skipped: 1 });
+    expect(result).toEqual({ added: 1, updated: 0, skipped: 1, removed: 0 });
     expect(addedSources).toEqual([
       generateSourceId('awesome-copilot', 'https://github.com/org/one', {
         branch: 'main',
@@ -268,7 +295,709 @@ describe('loadHubSources', () => {
 
     expect(events.some((m) => m.includes('Found 1 sources in hub hub-a'))).toBe(true);
     expect(events.some((m) => m.includes('Adding new hub source'))).toBe(true);
-    expect(events.some((m) => m.includes('Hub source loading complete for hub-a: 1 added, 0 updated, 0 skipped'))).toBe(true);
+    expect(events.some((m) => m.includes('Hub source loading complete for hub-a: 1 added, 0 updated, 0 skipped, 0 removed'))).toBe(true);
+  });
+
+  it('prunes an orphaned source when a hub collection URL is renamed', async () => {
+    const source = makeHubSource();
+    await loadHubSources('hub-a', [source], ports);
+    expect(ports.sources).toHaveLength(1);
+
+    // Simulate a repository rename: same logical source, new URL -> new sourceId.
+    const renamed = makeHubSource({ url: 'https://github.com/github/awesome-copilot-renamed' });
+    const result = await loadHubSources('hub-a', [renamed], ports);
+
+    expect(result).toEqual({ added: 1, updated: 0, skipped: 0, removed: 1 });
+    expect(ports.sources).toHaveLength(1);
+    expect(ports.sources[0].url).toBe('https://github.com/github/awesome-copilot-renamed');
+    expect(ports.removeSource).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not touch manually-added sources (no hubId) or sources from other hubs', async () => {
+    const manual = makeRegistrySource({ id: 'manual', url: 'https://github.com/org/manual', hubId: undefined });
+    const otherHub = makeRegistrySource({ id: 'other', url: 'https://github.com/org/other', hubId: 'hub-b' });
+    ports = makePorts([manual, otherHub]);
+
+    const result = await loadHubSources('hub-a', [makeHubSource()], ports);
+
+    expect(result).toEqual({ added: 1, updated: 0, skipped: 0, removed: 0 });
+    expect(ports.removeSource).not.toHaveBeenCalled();
+    expect(ports.sources.map((s) => s.id)).toEqual(expect.arrayContaining(['manual', 'other']));
+  });
+
+  it('prunes an orphan whose collection was removed from the hub config entirely', async () => {
+    const stale = makeRegistrySource({ id: 'stale', url: 'https://github.com/org/stale', hubId: 'hub-a' });
+    ports = makePorts([stale]);
+
+    const result = await loadHubSources('hub-a', [], ports);
+
+    expect(result).toEqual({ added: 0, updated: 0, skipped: 0, removed: 1 });
+    expect(ports.sources).toHaveLength(0);
+  });
+
+  it('does not prune a previously-synced source that is later disabled in the hub config', async () => {
+    const source = makeHubSource();
+    await loadHubSources('hub-a', [source], ports);
+    expect(ports.sources).toHaveLength(1);
+
+    const result = await loadHubSources('hub-a', [{ ...source, enabled: false }], ports);
+
+    expect(result).toEqual({ added: 0, updated: 0, skipped: 1, removed: 0 });
+    expect(ports.removeSource).not.toHaveBeenCalled();
+    expect(ports.sources).toHaveLength(1);
+  });
+
+  it('skips orphan pruning entirely when any addSource fails this sync', async () => {
+    const stale = makeRegistrySource({ id: 'stale', url: 'https://github.com/org/stale', hubId: 'hub-a' });
+    ports = makePorts([stale]);
+    ports.addSource = vi.fn().mockRejectedValue(new Error('Source validation failed: HTTP 503'));
+
+    const result = await loadHubSources('hub-a', [makeHubSource()], ports);
+
+    expect(result).toEqual({ added: 0, updated: 0, skipped: 1, removed: 0 });
+    expect(ports.removeSource).not.toHaveBeenCalled();
+    expect(ports.sources.map((s) => s.id)).toContain('stale');
+  });
+
+  it('keeps an orphaned source that still has installed bundles referencing it when remapBundleSource is not provided', async () => {
+    const stale = makeRegistrySource({ id: 'stale', url: 'https://github.com/org/stale', hubId: 'hub-a' });
+    ports = makePorts([stale], ['stale']);
+
+    const result = await loadHubSources('hub-a', [], ports);
+
+    expect(result).toEqual({ added: 0, updated: 0, skipped: 0, removed: 0 });
+    expect(ports.removeSource).not.toHaveBeenCalled();
+    expect(ports.sources.map((s) => s.id)).toContain('stale');
+  });
+
+  it('remaps and removes an orphan with installed consumers when remapBundleSource is provided and a replacement exists', async () => {
+    const source = makeHubSource();
+    await loadHubSources('hub-a', [source], ports);
+    expect(ports.sources).toHaveLength(1);
+
+    const oldSourceId = ports.sources[0].id;
+
+    // Seed installed bundles referencing the old source
+    ports.listInstalledBundles = vi.fn(async () => [{ bundleId: 'bundle-0', sourceId: oldSourceId }]);
+    const remapFn = vi.fn(async () => {});
+    (ports as Record<string, unknown>).remapBundleSource = remapFn;
+
+    // Rename URL -> new sourceId, old one becomes orphan with consumers
+    const renamed = makeHubSource({ url: 'https://github.com/github/awesome-copilot-renamed' });
+    const result = await loadHubSources('hub-a', [renamed], ports);
+
+    const renamedId = generateSourceId('awesome-copilot', renamed.url, {
+      branch: 'main',
+      collectionsPath: 'collections'
+    });
+    expect(remapFn).toHaveBeenCalledWith(oldSourceId, renamedId);
+    expect(result.removed).toBe(1);
+    expect(ports.sources.every((s) => s.url === 'https://github.com/github/awesome-copilot-renamed')).toBe(true);
+  });
+
+  it('keeps an orphan when remapBundleSource fails (does not strand bundles)', async () => {
+    const source = makeHubSource();
+    await loadHubSources('hub-a', [source], ports);
+    const oldSourceId = ports.sources[0].id;
+
+    ports.listInstalledBundles = vi.fn(async () => [{ bundleId: 'bundle-0', sourceId: oldSourceId }]);
+    const remapFn = vi.fn(async () => {
+      throw new Error('lockfile write failed');
+    });
+    (ports as Record<string, unknown>).remapBundleSource = remapFn;
+
+    const renamed = makeHubSource({ url: 'https://github.com/github/awesome-copilot-renamed' });
+    const result = await loadHubSources('hub-a', [renamed], ports);
+
+    expect(result.removed).toBe(0);
+    expect(ports.sources.map((s) => s.id)).toContain(oldSourceId);
+  });
+
+  it('prunes an orphan with no installed consumers even when listInstalledBundles is provided', async () => {
+    const stale = makeRegistrySource({ id: 'stale', url: 'https://github.com/org/stale', hubId: 'hub-a' });
+    ports = makePorts([stale], ['some-other-source']);
+
+    const result = await loadHubSources('hub-a', [], ports);
+
+    expect(result).toEqual({ added: 0, updated: 0, skipped: 0, removed: 1 });
+    expect(ports.removeSource).toHaveBeenCalledWith('stale');
+    expect(ports.sources).toHaveLength(0);
+  });
+
+  describe('hubSourceId sticker persistence', () => {
+    it('stores the declaration id as hubSourceId on a newly added source', async () => {
+      const declaration = makeHubSource({ id: 'stable-sticker' });
+
+      const result = await loadHubSources('hub-a', [declaration], ports);
+
+      expect(result).toEqual({ added: 1, updated: 0, skipped: 0, removed: 0 });
+      expect(ports.addSource).toHaveBeenCalledWith(expect.objectContaining({
+        hubId: 'hub-a',
+        hubSourceId: 'stable-sticker'
+      }));
+      expect(ports.sources[0].hubSourceId).toBe('stable-sticker');
+    });
+
+    it('backfills hubSourceId on a source that was persisted without it', async () => {
+      const declaration = makeHubSource({ id: 'stable-sticker' });
+      const storedId = generateSourceId(declaration.type, declaration.url, {
+        branch: 'main',
+        collectionsPath: 'collections'
+      });
+      const stored = makeRegistrySource({ id: storedId, hubId: 'hub-a' });
+      expect(stored.hubSourceId).toBeUndefined();
+      ports = makePorts([stored]);
+
+      const result = await loadHubSources('hub-a', [declaration], ports);
+
+      expect(result).toEqual({ added: 0, updated: 1, skipped: 0, removed: 0 });
+      expect(ports.updateSource).toHaveBeenCalledWith(
+        storedId,
+        expect.objectContaining({ hubSourceId: 'stable-sticker' })
+      );
+      expect(ports.sources[0].hubSourceId).toBe('stable-sticker');
+    });
+
+    it('stores no hubSourceId key when the declaration carries no id', async () => {
+      const declaration = makeHubSource({ id: undefined as unknown as string });
+
+      await loadHubSources('hub-a', [declaration], ports);
+
+      const addedSource = ports.addSource.mock.calls[0][0] as RegistrySource;
+      expect(Object.hasOwn(addedSource, 'hubSourceId')).toBe(false);
+      expect(Object.hasOwn(ports.sources[0], 'hubSourceId')).toBe(false);
+    });
+
+    it('writes no hubSourceId key on update when the declaration carries no id', async () => {
+      const declaration = makeHubSource({ id: undefined as unknown as string });
+      const storedId = generateSourceId(declaration.type, declaration.url, {
+        branch: 'main',
+        collectionsPath: 'collections'
+      });
+      ports = makePorts([makeRegistrySource({ id: storedId, hubId: 'hub-a' })]);
+
+      await loadHubSources('hub-a', [declaration], ports);
+
+      const updates = ports.updateSource.mock.calls[0][1] as Partial<RegistrySource>;
+      expect(Object.hasOwn(updates, 'hubSourceId')).toBe(false);
+      expect(Object.hasOwn(ports.sources[0], 'hubSourceId')).toBe(false);
+    });
+  });
+
+  describe('replacement eligibility (only sources registered this cycle)', () => {
+    it('never selects a disabled sibling declaration as the replacement', async () => {
+      const orphan = makeRegistrySource({
+        id: 'orphan-old',
+        name: 'Alpha (pre-rename)',
+        url: 'https://github.com/org/alpha-old',
+        hubId: 'hub-a',
+        hubSourceId: 'src-alpha'
+      });
+      ports = makePorts([orphan], ['orphan-old']);
+      const remapFn = vi.fn(async () => {});
+      (ports as Record<string, unknown>).remapBundleSource = remapFn;
+
+      const disabledSibling = makeHubSource({
+        id: 'src-beta',
+        name: 'Beta',
+        url: 'https://github.com/org/beta',
+        enabled: false
+      });
+
+      const result = await loadHubSources('hub-a', [disabledSibling], ports);
+
+      // A disabled declaration is never written to storage, so its generated id
+      // must not be a remap target: remapping onto it would point installed
+      // bundles at a source id storage never received.
+      expect(remapFn).not.toHaveBeenCalled();
+      expect(ports.removeSource).not.toHaveBeenCalled();
+      expect(result.removed).toBe(0);
+      expect(ports.sources.map((s) => s.id)).toContain('orphan-old');
+    });
+
+    it('never selects a declaration whose addSource rejected, and suspends all orphan handling for that sync', async () => {
+      const orphan = makeRegistrySource({
+        id: 'orphan-old',
+        name: 'Alpha (pre-rename)',
+        url: 'https://github.com/org/alpha-old',
+        hubId: 'hub-a',
+        hubSourceId: 'src-alpha'
+      });
+      const consumerFreeOrphan = makeRegistrySource({
+        id: 'orphan-free',
+        name: 'Gamma (pre-rename)',
+        url: 'https://github.com/org/gamma-old',
+        hubId: 'hub-a',
+        hubSourceId: 'src-gamma'
+      });
+      ports = makePorts([orphan, consumerFreeOrphan], ['orphan-old']);
+      ports.addSource = vi.fn().mockRejectedValue(new Error('Source validation failed: HTTP 503'));
+      const remapFn = vi.fn(async () => {});
+      (ports as Record<string, unknown>).remapBundleSource = remapFn;
+
+      const renamedAlpha = makeHubSource({
+        id: 'src-alpha',
+        name: 'Alpha',
+        url: 'https://github.com/org/alpha-new'
+      });
+
+      const result = await loadHubSources('hub-a', [renamedAlpha], ports);
+
+      expect(remapFn).not.toHaveBeenCalled();
+      expect(ports.removeSource).not.toHaveBeenCalled();
+      // Orphan evaluation itself is suspended, not just the removal.
+      expect(ports.listInstalledBundles).not.toHaveBeenCalled();
+      expect(result).toEqual({ added: 0, updated: 0, skipped: 1, removed: 0 });
+      expect(ports.sources.map((s) => s.id)).toEqual(
+        expect.arrayContaining(['orphan-old', 'orphan-free'])
+      );
+    });
+
+    it('keeps a matched duplicate protected from pruning', async () => {
+      const duplicate = makeRegistrySource({
+        id: 'manually-added',
+        name: 'Alpha (manual)',
+        url: 'https://github.com/org/alpha',
+        hubId: 'hub-a',
+        config: { branch: 'main', collectionsPath: 'collections' }
+      });
+      ports = makePorts([duplicate]);
+      const remapFn = vi.fn(async () => {});
+      (ports as Record<string, unknown>).remapBundleSource = remapFn;
+
+      const declaration = makeHubSource({
+        id: 'src-alpha',
+        name: 'Alpha',
+        url: 'https://github.com/org/alpha'
+      });
+
+      const result = await loadHubSources('hub-a', [declaration], ports);
+
+      expect(result).toEqual({ added: 0, updated: 0, skipped: 1, removed: 0 });
+      expect(ports.removeSource).not.toHaveBeenCalled();
+      expect(remapFn).not.toHaveBeenCalled();
+      expect(ports.sources.map((s) => s.id)).toEqual(['manually-added']);
+    });
+  });
+
+  describe('replacement selection on a multi-source hub', () => {
+    const storedIdFor = (url: string): string => generateSourceId('awesome-copilot', url, {
+      branch: 'main',
+      collectionsPath: 'collections'
+    });
+
+    const ALPHA_URL = 'https://github.com/org/alpha';
+    const BETA_URL = 'https://github.com/org/beta';
+    const GAMMA_OLD_URL = 'https://github.com/org/gamma-old';
+    const GAMMA_NEW_URL = 'https://github.com/org/gamma-new';
+
+    it('remaps the renamed source onto its own new id, never onto a sibling', async () => {
+      const alphaId = storedIdFor(ALPHA_URL);
+      const betaId = storedIdFor(BETA_URL);
+      const gammaOldId = storedIdFor(GAMMA_OLD_URL);
+      const gammaNewId = storedIdFor(GAMMA_NEW_URL);
+
+      ports = makePorts(
+        [
+          makeRegistrySource({
+            id: alphaId,
+            name: 'Alpha',
+            url: ALPHA_URL,
+            hubId: 'hub-a',
+            hubSourceId: 'src-alpha'
+          }),
+          makeRegistrySource({
+            id: betaId,
+            name: 'Beta',
+            url: BETA_URL,
+            hubId: 'hub-a',
+            hubSourceId: 'src-beta'
+          }),
+          makeRegistrySource({
+            id: gammaOldId,
+            name: 'Gamma (pre-rename)',
+            url: GAMMA_OLD_URL,
+            hubId: 'hub-a',
+            hubSourceId: 'src-gamma'
+          })
+        ],
+        [gammaOldId]
+      );
+      const remapFn = vi.fn(async () => {});
+      (ports as Record<string, unknown>).remapBundleSource = remapFn;
+
+      // Only gamma is renamed: its `id` stays `src-gamma`, its `url` changes.
+      const result = await loadHubSources(
+        'hub-a',
+        [
+          makeHubSource({ id: 'src-alpha', name: 'Alpha', url: ALPHA_URL }),
+          makeHubSource({ id: 'src-beta', name: 'Beta', url: BETA_URL }),
+          makeHubSource({ id: 'src-gamma', name: 'Gamma', url: GAMMA_NEW_URL })
+        ],
+        ports
+      );
+
+      expect(remapFn).toHaveBeenCalledTimes(1);
+      expect(remapFn).toHaveBeenCalledWith(gammaOldId, gammaNewId);
+
+      // No sibling id may ever be handed to the remap as the replacement.
+      const replacementIds = remapFn.mock.calls.map((call) => (call as unknown as string[])[1]);
+      expect(replacementIds).not.toContain(alphaId);
+      expect(replacementIds).not.toContain(betaId);
+
+      expect(result).toEqual({ added: 1, updated: 2, skipped: 0, removed: 1 });
+      expect(ports.removeSource).toHaveBeenCalledWith(gammaOldId);
+      expect(ports.sources.map((s) => s.id).toSorted()).toEqual([alphaId, betaId, gammaNewId].toSorted());
+    });
+  });
+
+  describe('keep-alive when the match is not provable', () => {
+    /**
+     * The remediation every keep-alive warning must end with, so the reader
+     * learns the convention that prevents the situation from recurring.
+     */
+    const REMEDIATION = 'keep a source\'s `id` stable when changing its `url`';
+
+    const storedIdFor = (url: string): string => generateSourceId('awesome-copilot', url, {
+      branch: 'main',
+      collectionsPath: 'collections'
+    });
+
+    const ORPHAN_ID = 'orphan-old';
+    const ORPHAN_NAME = 'Alpha (pre-rename)';
+
+    /** The two installed records that make the orphan un-deletable. */
+    const CONSUMER_COUNT = 2;
+
+    const makeOrphan = (overrides: Partial<RegistrySource> = {}): RegistrySource => makeRegistrySource({
+      id: ORPHAN_ID,
+      name: ORPHAN_NAME,
+      url: 'https://github.com/org/alpha-old',
+      hubId: 'hub-a',
+      hubSourceId: 'src-alpha',
+      ...overrides
+    });
+
+    /**
+     * Assert the single keep-alive warning for `orphanId` carries every
+     * diagnostic fragment Requirement 3.6 demands.
+     * @param events Log events captured from the sync.
+     * @param reasonMarker The keep-alive reason marker expected in the message.
+     */
+    const expectSingleKeepAliveWarning = (events: LogEvent[], reasonMarker: string): void => {
+      const warnings = events.filter(
+        (event) => event.level === 'warn' && event.message.includes(ORPHAN_ID)
+      );
+
+      expect(warnings).toHaveLength(1);
+      const { message } = warnings[0];
+      expect(message).toContain(ORPHAN_ID);
+      expect(message).toContain(ORPHAN_NAME);
+      expect(message).toContain(String(CONSUMER_COUNT));
+      expect(message).toContain(reasonMarker);
+      expect(message).toContain(REMEDIATION);
+    };
+
+    /**
+     * Assert the orphan survived the sync untouched: still stored, excluded
+     * from `removed`, and with no installed record repointed.
+     * @param result The sync result counts.
+     * @param activePorts The ports used for the sync.
+     */
+    const expectOrphanKeptAlive = async (
+      result: Awaited<ReturnType<typeof loadHubSources>>,
+      activePorts: ReturnType<typeof makePorts>
+    ): Promise<void> => {
+      expect(activePorts.sources.map((s) => s.id)).toContain(ORPHAN_ID);
+      expect(activePorts.removeSource).not.toHaveBeenCalledWith(ORPHAN_ID);
+      expect(result.removed).toBe(0);
+
+      const installed = await activePorts.listInstalledBundles();
+      expect(installed.filter((b: { sourceId: string }) => b.sourceId === ORPHAN_ID))
+        .toHaveLength(CONSUMER_COUNT);
+    };
+
+    it('keeps the orphan alive and warns with a no-candidate reason when nothing matches its sticker', async () => {
+      ports = makePorts([makeOrphan()], [ORPHAN_ID, ORPHAN_ID]);
+      const remapFn = vi.fn(async () => {});
+      (ports as Record<string, unknown>).remapBundleSource = remapFn;
+      const { events, onLog } = collectEvents();
+
+      // A sibling declaration carrying a different sticker: registered this
+      // cycle, but no evidence that it replaces the orphan.
+      const result = await loadHubSources(
+        'hub-a',
+        [makeHubSource({ id: 'src-beta', name: 'Beta', url: 'https://github.com/org/beta' })],
+        ports,
+        onLog
+      );
+
+      expect(remapFn).not.toHaveBeenCalled();
+      await expectOrphanKeptAlive(result, ports);
+      expectSingleKeepAliveWarning(events, 'no-candidate');
+    });
+
+    it('keeps the orphan alive and warns with an ambiguous-candidates reason when two declarations share its sticker', async () => {
+      ports = makePorts([makeOrphan()], [ORPHAN_ID, ORPHAN_ID]);
+      const remapFn = vi.fn(async () => {});
+      (ports as Record<string, unknown>).remapBundleSource = remapFn;
+      const { events, onLog } = collectEvents();
+
+      const result = await loadHubSources(
+        'hub-a',
+        [
+          makeHubSource({ id: 'src-alpha', name: 'Alpha one', url: 'https://github.com/org/alpha-one' }),
+          makeHubSource({ id: 'src-alpha', name: 'Alpha two', url: 'https://github.com/org/alpha-two' })
+        ],
+        ports,
+        onLog
+      );
+
+      expect(remapFn).not.toHaveBeenCalled();
+      await expectOrphanKeptAlive(result, ports);
+      expectSingleKeepAliveWarning(events, 'ambiguous-candidates');
+    });
+
+    it('keeps the orphan alive and warns with a missing-sticker reason when the orphan carries no hubSourceId', async () => {
+      ports = makePorts([makeOrphan({ hubSourceId: undefined })], [ORPHAN_ID, ORPHAN_ID]);
+      const remapFn = vi.fn(async () => {});
+      (ports as Record<string, unknown>).remapBundleSource = remapFn;
+      const { events, onLog } = collectEvents();
+
+      const result = await loadHubSources(
+        'hub-a',
+        [makeHubSource({ id: 'src-alpha', name: 'Alpha', url: 'https://github.com/org/alpha-new' })],
+        ports,
+        onLog
+      );
+
+      expect(remapFn).not.toHaveBeenCalled();
+      await expectOrphanKeptAlive(result, ports);
+      expectSingleKeepAliveWarning(events, 'missing-sticker');
+    });
+
+    it('keeps the orphan alive and warns with a remap-failed reason when the remap port rejects', async () => {
+      ports = makePorts([makeOrphan()], [ORPHAN_ID, ORPHAN_ID]);
+      const remapFn = vi.fn(async () => {
+        throw new Error('lockfile write failed');
+      });
+      (ports as Record<string, unknown>).remapBundleSource = remapFn;
+      const { events, onLog } = collectEvents();
+
+      const renamed = makeHubSource({
+        id: 'src-alpha',
+        name: 'Alpha',
+        url: 'https://github.com/org/alpha-new'
+      });
+      const result = await loadHubSources('hub-a', [renamed], ports, onLog);
+
+      expect(remapFn).toHaveBeenCalledWith(ORPHAN_ID, storedIdFor(renamed.url));
+      await expectOrphanKeptAlive(result, ports);
+      expectSingleKeepAliveWarning(events, 'remap-failed');
+    });
+
+    it('keeps the orphan alive and warns with a port-absent reason when remapBundleSource is not wired', async () => {
+      ports = makePorts([makeOrphan()], [ORPHAN_ID, ORPHAN_ID]);
+      const { events, onLog } = collectEvents();
+
+      const result = await loadHubSources(
+        'hub-a',
+        [makeHubSource({ id: 'src-alpha', name: 'Alpha', url: 'https://github.com/org/alpha-new' })],
+        ports,
+        onLog
+      );
+
+      await expectOrphanKeptAlive(result, ports);
+      expectSingleKeepAliveWarning(events, 'port-absent');
+    });
+  });
+
+  describe('reporting a successful remap', () => {
+    const ORPHAN_ID = 'orphan-old';
+    const ORPHAN_STICKER = 'src-alpha';
+    const RENAMED_URL = 'https://github.com/org/alpha-new';
+
+    /** The installed records the remap moves onto the replacement. */
+    const CONSUMER_COUNT = 2;
+
+    it('emits exactly one info event naming the record count, both source ids, and the matched sticker', async () => {
+      const orphan = makeRegistrySource({
+        id: ORPHAN_ID,
+        name: 'Alpha (pre-rename)',
+        url: 'https://github.com/org/alpha-old',
+        hubId: 'hub-a',
+        hubSourceId: ORPHAN_STICKER
+      });
+      ports = makePorts([orphan], [ORPHAN_ID, ORPHAN_ID]);
+      const remapFn = vi.fn(async () => {});
+      (ports as Record<string, unknown>).remapBundleSource = remapFn;
+      const { events, onLog } = collectEvents();
+
+      const renamed = makeHubSource({
+        id: ORPHAN_STICKER,
+        name: 'Alpha',
+        url: RENAMED_URL
+      });
+      const replacementId = generateSourceId(renamed.type, RENAMED_URL, {
+        branch: 'main',
+        collectionsPath: 'collections'
+      });
+
+      const result = await loadHubSources('hub-a', [renamed], ports, onLog);
+
+      // Guard the premise: this only reports on the success path.
+      expect(remapFn).toHaveBeenCalledWith(ORPHAN_ID, replacementId);
+      expect(result.removed).toBe(1);
+
+      // The report is the only info line that names the retired source id.
+      const reports = events.filter(
+        (event) => event.level === 'info' && event.message.includes(ORPHAN_ID)
+      );
+      expect(reports).toHaveLength(1);
+
+      const { message } = reports[0];
+      expect(message).toContain(String(CONSUMER_COUNT));
+      expect(message).toContain(ORPHAN_ID);
+      expect(message).toContain(replacementId);
+      expect(message).toContain(ORPHAN_STICKER);
+    });
+  });
+
+  describe('determinism and isolation guards', () => {
+    const storedIdFor = (url: string): string => generateSourceId('awesome-copilot', url, {
+      branch: 'main',
+      collectionsPath: 'collections'
+    });
+
+    const ALPHA_URL = 'https://github.com/org/alpha';
+    const BETA_URL = 'https://github.com/org/beta';
+    const GAMMA_OLD_URL = 'https://github.com/org/gamma-old';
+    const GAMMA_NEW_URL = 'https://github.com/org/gamma-new';
+
+    /**
+     * The stored-source set for a three-source hub whose gamma entry was
+     * renamed, with installed bundles pinned to the pre-rename gamma id.
+     * @returns A fresh set of stored sources (the sync mutates them).
+     */
+    const makeRenamedHubStore = (): RegistrySource[] => [
+      makeRegistrySource({
+        id: storedIdFor(ALPHA_URL),
+        name: 'Alpha',
+        url: ALPHA_URL,
+        hubId: 'hub-a',
+        hubSourceId: 'src-alpha'
+      }),
+      makeRegistrySource({
+        id: storedIdFor(BETA_URL),
+        name: 'Beta',
+        url: BETA_URL,
+        hubId: 'hub-a',
+        hubSourceId: 'src-beta'
+      }),
+      makeRegistrySource({
+        id: storedIdFor(GAMMA_OLD_URL),
+        name: 'Gamma (pre-rename)',
+        url: GAMMA_OLD_URL,
+        hubId: 'hub-a',
+        hubSourceId: 'src-gamma'
+      })
+    ];
+
+    const renamedHubDeclarations = (): HubSource[] => [
+      makeHubSource({ id: 'src-alpha', name: 'Alpha', url: ALPHA_URL }),
+      makeHubSource({ id: 'src-beta', name: 'Beta', url: BETA_URL }),
+      makeHubSource({ id: 'src-gamma', name: 'Gamma', url: GAMMA_NEW_URL })
+    ];
+
+    /**
+     * Run one sync of the renamed three-source hub at a given concurrency.
+     * @param concurrency The `concurrency` option to pass to the sync.
+     * @returns The replacement id handed to `remapBundleSource`.
+     */
+    const replacementIdAtConcurrency = async (concurrency: number): Promise<string> => {
+      const gammaOldId = storedIdFor(GAMMA_OLD_URL);
+      const runPorts = makePorts(makeRenamedHubStore(), [gammaOldId]);
+      const remapFn = vi.fn(async () => {});
+      (runPorts as Record<string, unknown>).remapBundleSource = remapFn;
+
+      await loadHubSources('hub-a', renamedHubDeclarations(), runPorts, undefined, { concurrency });
+
+      expect(remapFn).toHaveBeenCalledTimes(1);
+      const [oldId, newId] = remapFn.mock.calls[0] as unknown as [string, string];
+      expect(oldId).toBe(gammaOldId);
+      return newId;
+    };
+
+    it('selects the same replacement id at concurrency greater than 1 as at concurrency 1', async () => {
+      const sequential = await replacementIdAtConcurrency(1);
+      const parallel = await replacementIdAtConcurrency(4);
+
+      expect(parallel).toBe(sequential);
+      expect(sequential).toBe(storedIdFor(GAMMA_NEW_URL));
+    });
+
+    it('removes a consumer-free orphan without invoking the remap port', async () => {
+      const stale = makeRegistrySource({
+        id: 'stale',
+        name: 'Stale',
+        url: 'https://github.com/org/stale',
+        hubId: 'hub-a',
+        hubSourceId: 'src-stale'
+      });
+      ports = makePorts([stale], []);
+      const remapFn = vi.fn(async () => {});
+      (ports as Record<string, unknown>).remapBundleSource = remapFn;
+
+      const result = await loadHubSources('hub-a', [], ports);
+
+      expect(remapFn).not.toHaveBeenCalled();
+      expect(ports.removeSource).toHaveBeenCalledWith('stale');
+      expect(result.removed).toBe(1);
+      expect(ports.sources).toHaveLength(0);
+    });
+
+    it('leaves a source with no hubId and a source owned by another hub byte-identical across a sync', async () => {
+      const manual = makeRegistrySource({
+        id: 'manual',
+        name: 'Manual',
+        url: 'https://github.com/org/manual',
+        hubId: undefined,
+        hubSourceId: 'src-gamma'
+      });
+      const otherHub = makeRegistrySource({
+        id: 'other-hub-source',
+        name: 'Other hub',
+        url: 'https://github.com/org/other',
+        hubId: 'hub-b',
+        hubSourceId: 'src-gamma'
+      });
+      // Installed bundles reference both, and both carry the sticker of the
+      // renamed declaration: neither may be treated as this hub's orphan.
+      ports = makePorts([...makeRenamedHubStore(), manual, otherHub], [
+        storedIdFor(GAMMA_OLD_URL),
+        'manual',
+        'other-hub-source'
+      ]);
+      const remapFn = vi.fn(async () => {});
+      (ports as Record<string, unknown>).remapBundleSource = remapFn;
+
+      const before = structuredClone(
+        ports.sources.filter((s) => s.id === 'manual' || s.id === 'other-hub-source')
+      );
+
+      await loadHubSources('hub-a', renamedHubDeclarations(), ports);
+
+      const after = ports.sources.filter((s) => s.id === 'manual' || s.id === 'other-hub-source');
+      expect(after).toEqual(before);
+      expect(ports.removeSource).not.toHaveBeenCalledWith('manual');
+      expect(ports.removeSource).not.toHaveBeenCalledWith('other-hub-source');
+      expect(ports.updateSource).not.toHaveBeenCalledWith('manual', expect.anything());
+      expect(ports.updateSource).not.toHaveBeenCalledWith('other-hub-source', expect.anything());
+
+      const remappedOldIds = remapFn.mock.calls.map((call) => (call as unknown as string[])[0]);
+      expect(remappedOldIds).not.toContain('manual');
+      expect(remappedOldIds).not.toContain('other-hub-source');
+    });
   });
 });
 

--- a/packages/app/test/registry/remap-bundle-source.property.test.ts
+++ b/packages/app/test/registry/remap-bundle-source.property.test.ts
@@ -1,0 +1,395 @@
+/**
+ * Property-based test for registry/remap-bundle-source.ts — the shared
+ * bundle-source remap use case.
+ *
+ * Generalizes the four example-driven cycles in
+ * `remap-bundle-source.test.ts` (resolve-first-or-throw, the three-store
+ * happy path, the absent lockfile port, and retry idempotence) across
+ * generated record sets spanning user, workspace and repository scope,
+ * every mix of referencing and non-referencing `sourceId` values, a present
+ * or absent replacement source, a wired or unwired lockfile port, and an
+ * arbitrary subset of records already carrying the new id. It does not
+ * replace those cycles' own tests: they pin the exact messages, call counts
+ * and descriptor shape that this property only constrains structurally.
+ *
+ * Runs against in-memory ports only — no filesystem, no network, no host.
+ */
+import type {
+  BundleSourceRemap,
+  InstallationScope,
+  InstalledBundle,
+  LockfileSourceDescriptor,
+  RegistrySource,
+  SourceType,
+} from '@ai-primitives-hub/core';
+import * as fc from 'fast-check';
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  remapBundleSource,
+} from '../../src/registry/remap-bundle-source';
+
+/** The orphaned source id installed bundles reference before the remap. */
+const OLD_ID = 'source-old';
+/** The replacement source id installed bundles must reference afterwards. */
+const NEW_ID = 'source-new';
+
+/**
+ * Scopes the use case rewrites itself. Repository scope is deliberately
+ * absent: those records live in the lockfile, which the
+ * `remapLockfileSourceId` port owns, so a repository-scope record carrying
+ * the old id must come out of a remap untouched.
+ */
+const REWRITTEN_SCOPES: InstallationScope[] = ['user', 'workspace'];
+
+/** Every scope a generated record can land in, including repository. */
+const ALL_SCOPES: InstallationScope[] = ['user', 'workspace', 'repository'];
+
+/** Replacement source types, kept to a representative spread. */
+const SOURCE_TYPES: SourceType[] = ['github', 'local', 'awesome-copilot', 'apm', 'skills'];
+
+/**
+ * Upper bound on a generated record set, and the fixed length of the
+ * already-remapped flag array so a flag exists for every possible index.
+ */
+const MAX_RECORDS = 12;
+
+/** One generated installation record, before a bundle id is assigned. */
+interface RecordSpec {
+  scope: InstallationScope;
+  sourceId: string | undefined;
+  version: string;
+}
+
+/** The generated replacement source, minus its fixed id. */
+interface ReplacementSpec {
+  name: string;
+  type: SourceType;
+  url: string;
+  config: RegistrySource['config'];
+}
+
+/** One generated remap scenario. */
+interface Scenario {
+  specs: RecordSpec[];
+  preRemapped: boolean[];
+  replacement: ReplacementSpec;
+  newSourcePresent: boolean;
+  withLockfile: boolean;
+  extraSourceCount: number;
+}
+
+/**
+ * A `sourceId` value worth generating: the old id (the records that must
+ * migrate), the new id (records a previous run already finished), no value
+ * at all, and unrelated ids that must never be touched.
+ */
+const sourceIdArb = fc.oneof(
+  fc.constant(OLD_ID),
+  fc.constant(NEW_ID),
+  fc.constant(undefined),
+  fc.integer({ min: 0, max: 4 }).map((n) => `source-unrelated-${n}`)
+);
+
+const recordSpecArb = fc.record<RecordSpec>({
+  scope: fc.constantFrom(...ALL_SCOPES),
+  sourceId: sourceIdArb,
+  version: fc.constantFrom('1.0.0', '2.1.3', '0.0.1-alpha.1')
+});
+
+/**
+ * The replacement's `config`, covering all four descriptor shapes: absent
+ * entirely, and present with either `branch` or `collectionsPath` missing.
+ */
+const configArb = fc.option(
+  fc.record({
+    branch: fc.option(fc.constantFrom('main', 'release', 'next'), { nil: undefined }),
+    collectionsPath: fc.option(fc.constantFrom('collections', 'curated'), { nil: undefined })
+  }),
+  { nil: undefined }
+);
+
+const scenarioArb = fc.record<Scenario>({
+  specs: fc.array(recordSpecArb, { maxLength: MAX_RECORDS }),
+  preRemapped: fc.array(fc.boolean(), { minLength: MAX_RECORDS, maxLength: MAX_RECORDS }),
+  replacement: fc.record<ReplacementSpec>({
+    name: fc.constantFrom('Renamed Source', 'Moved Collection'),
+    type: fc.constantFrom(...SOURCE_TYPES),
+    url: fc.constantFrom('https://github.com/org/renamed', 'https://github.com/org/moved'),
+    config: configArb
+  }),
+  newSourcePresent: fc.boolean(),
+  withLockfile: fc.boolean(),
+  extraSourceCount: fc.integer({ min: 0, max: 3 })
+});
+
+/**
+ * Build one installation record from its generated spec, with a manifest
+ * and install path that must survive the remap byte-identically.
+ * @param bundleId Bundle id, unique per record so scope + id upserts cleanly.
+ * @param spec The generated scope, source id and version.
+ */
+function makeInstalled(bundleId: string, spec: RecordSpec): InstalledBundle {
+  return {
+    bundleId,
+    version: spec.version,
+    installedAt: '2024-01-01T00:00:00.000Z',
+    scope: spec.scope,
+    installPath: `/mock/${spec.scope}/${bundleId}`,
+    sourceId: spec.sourceId,
+    manifest: {
+      common: { directories: [], files: [], include_patterns: [], exclude_patterns: [] },
+      bundle_settings: {
+        include_common_in_environment_bundles: false,
+        create_common_bundle: false,
+        compression: 'none',
+        naming: { environment_bundle: bundleId }
+      },
+      metadata: { manifest_version: '1.0.0', description: 'Generated' }
+    }
+  };
+}
+
+/**
+ * Assign bundle ids by index, which keeps every (bundleId, scope) pair
+ * unique so the upsert in `recordInstallation` cannot collide.
+ * @param specs Generated record specs.
+ */
+function buildRecords(specs: RecordSpec[]): InstalledBundle[] {
+  return specs.map((spec, index) => makeInstalled(`bundle-${index}`, spec));
+}
+
+/**
+ * The stored-source set. The replacement is appended last, behind the
+ * orphan and any unrelated sources, so resolution has to match on the id
+ * rather than land on it by position.
+ * @param scenario The generated scenario.
+ */
+function buildSources(scenario: Scenario): RegistrySource[] {
+  const sources: RegistrySource[] = [
+    {
+      id: OLD_ID,
+      name: 'Old Source',
+      type: 'awesome-copilot',
+      url: 'https://github.com/org/old',
+      enabled: true,
+      priority: 1,
+      config: { branch: 'main', collectionsPath: 'collections' }
+    }
+  ];
+
+  for (let index = 0; index < scenario.extraSourceCount; index++) {
+    sources.push({
+      id: `source-unrelated-${index}`,
+      name: `Unrelated ${index}`,
+      type: 'github',
+      url: `https://github.com/org/unrelated-${index}`,
+      enabled: true,
+      priority: 2
+    });
+  }
+
+  if (scenario.newSourcePresent) {
+    sources.push({ id: NEW_ID, enabled: true, priority: 3, ...scenario.replacement });
+  }
+
+  return sources;
+}
+
+/** In-memory ports recording every write and every lockfile invocation. */
+interface RecordingPorts extends BundleSourceRemap {
+  records: InstalledBundle[];
+  installCalls: InstalledBundle[];
+  lockfileCalls: { oldSourceId: string; newSourceId: string; descriptor: LockfileSourceDescriptor }[];
+}
+
+/**
+ * In-memory `BundleSourceRemap` over a mutable record set. Reads and writes
+ * are cloned so a caller holding a returned record cannot mutate the store
+ * by accident, which keeps the before/after comparisons honest.
+ * @param sources Stored sources the remap resolves its replacement from.
+ * @param installed Initial installation records.
+ * @param withLockfile Whether to wire the optional repository-scope port.
+ */
+function makePorts(
+  sources: RegistrySource[],
+  installed: InstalledBundle[],
+  withLockfile: boolean
+): RecordingPorts {
+  const records = structuredClone(installed);
+  const installCalls: InstalledBundle[] = [];
+  const lockfileCalls: RecordingPorts['lockfileCalls'] = [];
+
+  const ports: RecordingPorts = {
+    records,
+    installCalls,
+    lockfileCalls,
+    listSources: () => Promise.resolve(structuredClone(sources)),
+    getInstalledBundles: (scope: InstallationScope) =>
+      Promise.resolve(structuredClone(records.filter((record) => record.scope === scope))),
+    recordInstallation: (bundle: InstalledBundle) => {
+      installCalls.push(structuredClone(bundle));
+      const index = records.findIndex(
+        (record) => record.bundleId === bundle.bundleId && record.scope === bundle.scope
+      );
+      if (index === -1) {
+        records.push(structuredClone(bundle));
+      } else {
+        records[index] = structuredClone(bundle);
+      }
+
+      return Promise.resolve();
+    }
+  };
+
+  if (withLockfile) {
+    ports.remapLockfileSourceId = (
+      oldSourceId: string,
+      newSourceId: string,
+      descriptor: LockfileSourceDescriptor
+    ) => {
+      lockfileCalls.push({ oldSourceId, newSourceId, descriptor });
+
+      return Promise.resolve();
+    };
+  }
+
+  return ports;
+}
+
+/**
+ * Whether a record is one the use case is expected to rewrite: it carries
+ * the old source id and lives in a scope the use case owns.
+ * @param record The record to classify.
+ */
+function isMigrating(record: InstalledBundle): boolean {
+  return REWRITTEN_SCOPES.includes(record.scope) && record.sourceId === OLD_ID;
+}
+
+/**
+ * The final record set a correct remap must produce: only migrating
+ * records change, and only their `sourceId`.
+ * @param original The record set before the remap.
+ */
+function expectedFinalRecords(original: InstalledBundle[]): InstalledBundle[] {
+  return original.map((record) => (isMigrating(record) ? { ...record, sourceId: NEW_ID } : record));
+}
+
+/**
+ * The record set a crashed first run leaves behind: the flagged migrating
+ * records already carry the new id, the rest still carry the old one.
+ * @param original The record set before the remap.
+ * @param flags Per-index "already remapped" flags.
+ */
+function partiallyRemapped(original: InstalledBundle[], flags: boolean[]): InstalledBundle[] {
+  return original.map((record, index) =>
+    isMigrating(record) && flags[index] ? { ...record, sourceId: NEW_ID } : record);
+}
+
+/**
+ * Stable ordering for whole-record-set comparison, since the use case may
+ * reorder nothing but the store's upsert is positional.
+ * @param records The records to order.
+ */
+function byKey(records: InstalledBundle[]): InstalledBundle[] {
+  return records.toSorted((a, b) => `${a.bundleId}|${a.scope}`.localeCompare(`${b.bundleId}|${b.scope}`));
+}
+
+/**
+ * The identity of every record a correct run writes, as sorted keys.
+ * @param records The records to key.
+ */
+function migratingKeys(records: InstalledBundle[]): string[] {
+  return records.filter((record) => isMigrating(record)).map((record) => `${record.bundleId}|${record.scope}`)
+    .toSorted();
+}
+
+/**
+ * The Replacement_Descriptor the lockfile port must receive, derived from
+ * the replacement source exactly as the use case derives it.
+ * @param replacement The generated replacement source.
+ */
+function expectedDescriptor(replacement: ReplacementSpec): LockfileSourceDescriptor {
+  return {
+    type: replacement.type,
+    url: replacement.url,
+    branch: replacement.config?.branch,
+    collectionsPath: replacement.config?.collectionsPath
+  };
+}
+
+// Feature: hub-source-orphan-remap, Property 8: A remap either fully applies or changes nothing, and repeats change nothing further
+describe('remapBundleSource — Property 8', () => {
+  /**
+   * **Validates: Requirements 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 9.16, 9.17**
+   */
+  it('either fully applies or changes nothing, and repeats change nothing further', async () => {
+    await fc.assert(
+      fc.asyncProperty(scenarioArb, async (scenario) => {
+        const original = buildRecords(scenario.specs);
+        const sources = buildSources(scenario);
+
+        // Replacement absent: reject naming the missing id, having written
+        // neither an installation record nor the lockfile (5.1, 5.2).
+        if (!scenario.newSourcePresent) {
+          const ports = makePorts(sources, original, scenario.withLockfile);
+
+          await expect(remapBundleSource(OLD_ID, NEW_ID, ports)).rejects.toThrow(NEW_ID);
+
+          expect(ports.installCalls).toEqual([]);
+          expect(ports.lockfileCalls).toEqual([]);
+          expect(byKey(ports.records)).toEqual(byKey(original));
+
+          return;
+        }
+
+        const expected = byKey(expectedFinalRecords(original));
+
+        // A single clean run: exactly the migrating records are written,
+        // every other record and every other field is untouched (5.5), and
+        // the repository-scope step runs once with the descriptor derived
+        // from the replacement, or is skipped without error when its port
+        // is absent while the rest still completes (5.3, 5.4).
+        const clean = makePorts(sources, original, scenario.withLockfile);
+
+        await remapBundleSource(OLD_ID, NEW_ID, clean);
+
+        expect(clean.installCalls.map((b) => `${b.bundleId}|${b.scope}`).toSorted())
+          .toEqual(migratingKeys(original));
+        expect(clean.installCalls.every((b) => b.sourceId === NEW_ID)).toBe(true);
+        expect(byKey(clean.records)).toEqual(expected);
+        expect(clean.lockfileCalls).toEqual(scenario.withLockfile
+          ? [{
+            oldSourceId: OLD_ID,
+            newSourceId: NEW_ID,
+            descriptor: expectedDescriptor(scenario.replacement)
+          }]
+          : []);
+
+        // A second invocation over a partially completed run reaches the
+        // same final state as that single clean run (5.6).
+        const retry = makePorts(
+          sources,
+          partiallyRemapped(original, scenario.preRemapped),
+          scenario.withLockfile
+        );
+
+        await remapBundleSource(OLD_ID, NEW_ID, retry);
+
+        expect(byKey(retry.records)).toEqual(expected);
+
+        // And a third invocation changes nothing further: no write at all.
+        const writesBeforeThird = retry.installCalls.length;
+
+        await remapBundleSource(OLD_ID, NEW_ID, retry);
+
+        expect(retry.installCalls).toHaveLength(writesBeforeThird);
+        expect(byKey(retry.records)).toEqual(expected);
+      }),
+      { numRuns: 200 }
+    );
+  });
+});

--- a/packages/app/test/registry/remap-bundle-source.test.ts
+++ b/packages/app/test/registry/remap-bundle-source.test.ts
@@ -1,0 +1,420 @@
+/**
+ * Tests for registry/remap-bundle-source.ts — the shared bundle-source
+ * remap use case.
+ *
+ * Cycle A covers the resolve-first-or-throw guarantee: when the
+ * replacement source id is absent from stored sources the call rejects
+ * naming that id, and nothing — neither the repository-scope lockfile nor
+ * a single installation record — has been written. That ordering is what
+ * lets the caller keep an orphan alive instead of deleting a source whose
+ * repository-scope bundles were never migrated.
+ *
+ * Cycle B covers the happy path across the three stores: the
+ * Replacement_Descriptor is built from the resolved replacement's `type`,
+ * `url`, `config?.branch` and `config?.collectionsPath` and handed to the
+ * repository-scope lockfile port exactly once, then user scope and
+ * workspace scope are rewritten — and only for the records that actually
+ * referenced the old source id, leaving every other record and every
+ * other field byte-identical.
+ *
+ * Cycle C covers the absent repository-scope port: no workspace root means
+ * no lockfile port is wired, and that is a valid skip rather than a
+ * failure. Repository-scope bundles only exist inside an open workspace, so
+ * there is nothing to migrate and rejecting here would block an otherwise
+ * valid user-scope and workspace-scope remap.
+ *
+ * Cycle D is a regression guard rather than a red test: retry idempotence
+ * already follows from Cycle B's `sourceId === oldSourceId` filter, since a
+ * record carrying the new id no longer matches. The guard locks that
+ * property in — a run over a partially completed record set finishes the
+ * remainder and leaves finished records byte-identical, and a further run
+ * changes nothing at all.
+ */
+import type {
+  BundleSourceRemap,
+  InstalledBundle,
+  RegistrySource,
+} from '@ai-primitives-hub/core';
+import {
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import {
+  remapBundleSource,
+} from '../../src/registry/remap-bundle-source';
+
+function makeRegistrySource(overrides: Partial<RegistrySource> = {}): RegistrySource {
+  return {
+    id: 'source-old',
+    name: 'Old Source',
+    type: 'awesome-copilot',
+    url: 'https://github.com/github/awesome-copilot',
+    enabled: true,
+    priority: 1,
+    config: { branch: 'main', collectionsPath: 'collections' },
+    ...overrides
+  };
+}
+
+function makeInstalled(overrides: Partial<InstalledBundle> = {}): InstalledBundle {
+  return {
+    bundleId: 'bundle-1',
+    version: '1.0.0',
+    installedAt: '2024-01-01T00:00:00.000Z',
+    scope: 'user',
+    installPath: '/mock/path',
+    sourceId: 'source-old',
+    manifest: {
+      common: { directories: [], files: [], include_patterns: [], exclude_patterns: [] },
+      bundle_settings: {
+        include_common_in_environment_bundles: false,
+        create_common_bundle: false,
+        compression: 'none',
+        naming: { environment_bundle: 'bundle-1' }
+      },
+      metadata: { manifest_version: '1.0.0', description: 'Test' }
+    },
+    ...overrides
+  };
+}
+
+/**
+ * In-memory `BundleSourceRemap` recording every call, with the
+ * repository-scope lockfile port wired by default so its absence can be
+ * asserted separately from its non-invocation.
+ * @param sources
+ * @param installed
+ */
+function makePorts(
+  sources: RegistrySource[] = [],
+  installed: InstalledBundle[] = []
+): BundleSourceRemap & {
+  listSources: ReturnType<typeof vi.fn>;
+  remapLockfileSourceId: ReturnType<typeof vi.fn>;
+  getInstalledBundles: ReturnType<typeof vi.fn>;
+  recordInstallation: ReturnType<typeof vi.fn>;
+  records: InstalledBundle[];
+} {
+  const records = [...installed];
+  return {
+    records,
+    listSources: vi.fn(async () => [...sources]),
+    remapLockfileSourceId: vi.fn(async () => {}),
+    getInstalledBundles: vi.fn(async (scope) => records.filter((r) => r.scope === scope)),
+    recordInstallation: vi.fn(async (bundle: InstalledBundle) => {
+      const index = records.findIndex((r) => r.bundleId === bundle.bundleId && r.scope === bundle.scope);
+      if (index === -1) {
+        records.push(bundle);
+      } else {
+        records[index] = bundle;
+      }
+    })
+  };
+}
+
+describe('remapBundleSource', () => {
+  it('rejects naming the replacement source id when it is absent from stored sources', async () => {
+    const ports = makePorts([makeRegistrySource({ id: 'source-old' })], [makeInstalled()]);
+
+    await expect(remapBundleSource('source-old', 'source-new', ports)).rejects.toThrow(/source-new/);
+  });
+
+  it('writes no installation record when the replacement source id cannot be resolved', async () => {
+    const ports = makePorts(
+      [makeRegistrySource({ id: 'source-old' })],
+      [makeInstalled(), makeInstalled({ bundleId: 'bundle-2', scope: 'workspace' })]
+    );
+
+    await expect(remapBundleSource('source-old', 'source-new', ports)).rejects.toThrow();
+
+    expect(ports.recordInstallation).not.toHaveBeenCalled();
+    expect(ports.records.every((r) => r.sourceId === 'source-old')).toBe(true);
+  });
+
+  it('does not touch the repository-scope lockfile when the replacement source id cannot be resolved', async () => {
+    const ports = makePorts([makeRegistrySource({ id: 'source-old' })], [makeInstalled()]);
+
+    await expect(remapBundleSource('source-old', 'source-new', ports)).rejects.toThrow();
+
+    expect(ports.remapLockfileSourceId).not.toHaveBeenCalled();
+  });
+});
+
+const OLD_ID = 'source-old';
+const NEW_ID = 'source-new';
+
+/**
+ * The replacement source the happy path resolves, carrying distinct
+ * `type`/`url`/`config` values so the descriptor cannot accidentally match
+ * by reusing the orphan's own fields.
+ * @param overrides
+ */
+function makeReplacement(overrides: Partial<RegistrySource> = {}): RegistrySource {
+  return makeRegistrySource({
+    id: NEW_ID,
+    name: 'Renamed Source',
+    type: 'github',
+    url: 'https://github.com/org/renamed',
+    config: { branch: 'release', collectionsPath: 'curated' },
+    ...overrides
+  });
+}
+
+/**
+ * A record set spanning every scope and both referencing states: two
+ * records point at the old source id in user and workspace scope, two do
+ * not, and one repository-scope record belongs to the lockfile port rather
+ * than to `recordInstallation`.
+ */
+function makeMixedRecords(): InstalledBundle[] {
+  return [
+    makeInstalled({ bundleId: 'user-migrating', scope: 'user', sourceId: OLD_ID }),
+    makeInstalled({ bundleId: 'user-unrelated', scope: 'user', sourceId: 'source-other' }),
+    makeInstalled({ bundleId: 'workspace-migrating', scope: 'workspace', sourceId: OLD_ID }),
+    makeInstalled({ bundleId: 'workspace-unrelated', scope: 'workspace', sourceId: undefined }),
+    makeInstalled({ bundleId: 'repository-migrating', scope: 'repository', sourceId: OLD_ID })
+  ];
+}
+
+describe('remapBundleSource — happy path across the three stores', () => {
+  it('builds the replacement descriptor from the resolved source type, url, branch and collectionsPath', async () => {
+    const ports = makePorts(
+      [makeRegistrySource({ id: OLD_ID }), makeReplacement()],
+      makeMixedRecords()
+    );
+
+    await remapBundleSource(OLD_ID, NEW_ID, ports);
+
+    expect(ports.remapLockfileSourceId).toHaveBeenCalledWith(OLD_ID, NEW_ID, {
+      type: 'github',
+      url: 'https://github.com/org/renamed',
+      branch: 'release',
+      collectionsPath: 'curated'
+    });
+  });
+
+  it('calls the repository-scope lockfile port exactly once', async () => {
+    const ports = makePorts(
+      [makeRegistrySource({ id: OLD_ID }), makeReplacement()],
+      makeMixedRecords()
+    );
+
+    await remapBundleSource(OLD_ID, NEW_ID, ports);
+
+    expect(ports.remapLockfileSourceId).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits branch and collectionsPath from the descriptor when the replacement carries no config', async () => {
+    const ports = makePorts(
+      [makeRegistrySource({ id: OLD_ID }), makeReplacement({ config: undefined })],
+      makeMixedRecords()
+    );
+
+    await remapBundleSource(OLD_ID, NEW_ID, ports);
+
+    expect(ports.remapLockfileSourceId).toHaveBeenCalledWith(OLD_ID, NEW_ID, {
+      type: 'github',
+      url: 'https://github.com/org/renamed',
+      branch: undefined,
+      collectionsPath: undefined
+    });
+  });
+
+  it('rewrites only the user-scope and workspace-scope records referencing the old source id', async () => {
+    const ports = makePorts(
+      [makeRegistrySource({ id: OLD_ID }), makeReplacement()],
+      makeMixedRecords()
+    );
+
+    await remapBundleSource(OLD_ID, NEW_ID, ports);
+
+    const rewritten = ports.recordInstallation.mock.calls.map(([bundle]) => bundle as InstalledBundle);
+
+    expect(rewritten.map((b) => b.bundleId).toSorted()).toEqual(['user-migrating', 'workspace-migrating']);
+    expect(rewritten.every((b) => b.sourceId === NEW_ID)).toBe(true);
+  });
+
+  it('reads installation records for the user and workspace scopes only', async () => {
+    const ports = makePorts(
+      [makeRegistrySource({ id: OLD_ID }), makeReplacement()],
+      makeMixedRecords()
+    );
+
+    await remapBundleSource(OLD_ID, NEW_ID, ports);
+
+    const scopes = ports.getInstalledBundles.mock.calls.map(([scope]) => scope as string);
+
+    expect(scopes.toSorted()).toEqual(['user', 'workspace']);
+  });
+
+  it('changes only the sourceId of a rewritten record, leaving every other field untouched', async () => {
+    const ports = makePorts(
+      [makeRegistrySource({ id: OLD_ID }), makeReplacement()],
+      makeMixedRecords()
+    );
+    const before = makeInstalled({ bundleId: 'user-migrating', scope: 'user', sourceId: OLD_ID });
+
+    await remapBundleSource(OLD_ID, NEW_ID, ports);
+
+    expect(ports.records.find((r) => r.bundleId === 'user-migrating' && r.scope === 'user'))
+      .toEqual({ ...before, sourceId: NEW_ID });
+  });
+
+  it('leaves every non-referencing record and every repository-scope record byte-identical', async () => {
+    const ports = makePorts(
+      [makeRegistrySource({ id: OLD_ID }), makeReplacement()],
+      makeMixedRecords()
+    );
+    const before = makeMixedRecords();
+
+    await remapBundleSource(OLD_ID, NEW_ID, ports);
+
+    for (const bundleId of ['user-unrelated', 'workspace-unrelated', 'repository-migrating']) {
+      expect(ports.records.find((r) => r.bundleId === bundleId))
+        .toEqual(before.find((r) => r.bundleId === bundleId));
+    }
+  });
+});
+/**
+ * The same in-memory ports without the repository-scope lockfile port,
+ * modelling a host with no workspace root: `remapLockfileSourceId` is
+ * optional on `BundleSourceRemap`, and its absence must read as "no
+ * repository in scope", not as an error condition.
+ * @param sources
+ * @param installed
+ */
+function makePortsWithoutLockfile(
+  sources: RegistrySource[] = [],
+  installed: InstalledBundle[] = []
+): Omit<ReturnType<typeof makePorts>, 'remapLockfileSourceId'> {
+  const ports = makePorts(sources, installed);
+  delete (ports as Partial<ReturnType<typeof makePorts>>).remapLockfileSourceId;
+
+  return ports;
+}
+
+describe('remapBundleSource — no workspace root', () => {
+  it('resolves rather than rejecting when the repository-scope lockfile port is absent', async () => {
+    const ports = makePortsWithoutLockfile(
+      [makeRegistrySource({ id: OLD_ID }), makeReplacement()],
+      makeMixedRecords()
+    );
+
+    await expect(remapBundleSource(OLD_ID, NEW_ID, ports)).resolves.toBeUndefined();
+  });
+
+  it('still completes the user-scope and workspace-scope remap when the lockfile port is absent', async () => {
+    const ports = makePortsWithoutLockfile(
+      [makeRegistrySource({ id: OLD_ID }), makeReplacement()],
+      makeMixedRecords()
+    );
+
+    await remapBundleSource(OLD_ID, NEW_ID, ports);
+
+    const rewritten = ports.recordInstallation.mock.calls.map(([bundle]) => bundle as InstalledBundle);
+
+    expect(rewritten.map((b) => b.bundleId).toSorted()).toEqual(['user-migrating', 'workspace-migrating']);
+    expect(rewritten.every((b) => b.sourceId === NEW_ID)).toBe(true);
+  });
+
+  it('leaves non-referencing and repository-scope records untouched when the lockfile port is absent', async () => {
+    const ports = makePortsWithoutLockfile(
+      [makeRegistrySource({ id: OLD_ID }), makeReplacement()],
+      makeMixedRecords()
+    );
+    const before = makeMixedRecords();
+
+    await remapBundleSource(OLD_ID, NEW_ID, ports);
+
+    for (const bundleId of ['user-unrelated', 'workspace-unrelated', 'repository-migrating']) {
+      expect(ports.records.find((r) => r.bundleId === bundleId))
+        .toEqual(before.find((r) => r.bundleId === bundleId));
+    }
+  });
+});
+
+/**
+ * The record set a crashed first run leaves behind: `user-done` and
+ * `workspace-done` already carry the new source id, `user-pending` and
+ * `workspace-pending` still carry the old one, and the unrelated and
+ * repository-scope records are there to catch collateral writes.
+ */
+function makePartiallyRemappedRecords(): InstalledBundle[] {
+  return [
+    makeInstalled({ bundleId: 'user-done', scope: 'user', sourceId: NEW_ID }),
+    makeInstalled({ bundleId: 'user-pending', scope: 'user', sourceId: OLD_ID }),
+    makeInstalled({ bundleId: 'workspace-done', scope: 'workspace', sourceId: NEW_ID }),
+    makeInstalled({ bundleId: 'workspace-pending', scope: 'workspace', sourceId: OLD_ID }),
+    makeInstalled({ bundleId: 'user-unrelated', scope: 'user', sourceId: 'source-other' }),
+    makeInstalled({ bundleId: 'repository-pending', scope: 'repository', sourceId: OLD_ID })
+  ];
+}
+
+/**
+ * Ports seeded with that partially completed state, so the invocation under
+ * test is the retry rather than the first attempt.
+ */
+function makeRetryPorts(): ReturnType<typeof makePorts> {
+  return makePorts(
+    [makeRegistrySource({ id: OLD_ID }), makeReplacement()],
+    makePartiallyRemappedRecords()
+  );
+}
+
+describe('remapBundleSource — retry after a partially completed run', () => {
+  it('rewrites only the records that still carry the old source id', async () => {
+    const ports = makeRetryPorts();
+
+    await remapBundleSource(OLD_ID, NEW_ID, ports);
+
+    const rewritten = ports.recordInstallation.mock.calls.map(([bundle]) => bundle as InstalledBundle);
+
+    expect(rewritten.map((b) => b.bundleId).toSorted()).toEqual(['user-pending', 'workspace-pending']);
+    expect(rewritten.every((b) => b.sourceId === NEW_ID)).toBe(true);
+  });
+
+  it('leaves already-remapped records byte-identical', async () => {
+    const ports = makeRetryPorts();
+    const before = makePartiallyRemappedRecords();
+
+    await remapBundleSource(OLD_ID, NEW_ID, ports);
+
+    for (const bundleId of ['user-done', 'workspace-done']) {
+      expect(ports.records.find((r) => r.bundleId === bundleId))
+        .toEqual(before.find((r) => r.bundleId === bundleId));
+    }
+  });
+
+  it('leaves the whole record set fully remapped and otherwise untouched after the retry', async () => {
+    const ports = makeRetryPorts();
+    const expected = makePartiallyRemappedRecords().map((r) =>
+      r.sourceId === OLD_ID && r.scope !== 'repository' ? { ...r, sourceId: NEW_ID } : r);
+
+    await remapBundleSource(OLD_ID, NEW_ID, ports);
+
+    expect(ports.records.toSorted((a, b) => a.bundleId.localeCompare(b.bundleId)))
+      .toEqual(expected.toSorted((a, b) => a.bundleId.localeCompare(b.bundleId)));
+  });
+
+  it('writes no installation record on a third invocation', async () => {
+    const ports = makeRetryPorts();
+
+    await remapBundleSource(OLD_ID, NEW_ID, ports);
+    ports.recordInstallation.mockClear();
+    await remapBundleSource(OLD_ID, NEW_ID, ports);
+
+    expect(ports.recordInstallation).not.toHaveBeenCalled();
+  });
+
+  it('leaves every record identical across a third invocation', async () => {
+    const ports = makeRetryPorts();
+
+    await remapBundleSource(OLD_ID, NEW_ID, ports);
+    const afterSecond = structuredClone(ports.records);
+    await remapBundleSource(OLD_ID, NEW_ID, ports);
+
+    expect(ports.records).toEqual(afterSecond);
+  });
+});

--- a/packages/app/test/stores/json-lockfile-store.test.ts
+++ b/packages/app/test/stores/json-lockfile-store.test.ts
@@ -22,6 +22,7 @@ import {
   LOCKFILE_NAME,
   LOCKFILE_SCHEMA_VERSION,
   readLockfile,
+  remapSourceId,
   removeBundleEntry,
   upsertBundleEntry,
   upsertSource,
@@ -182,5 +183,46 @@ describe('upsertSource / cleanupOrphanedSource', () => {
     const next = cleanupOrphanedSource(lock, 'github-abc');
 
     expect(next.sources['github-abc']).toBeUndefined();
+  });
+});
+
+describe('remapSourceId', () => {
+  it('remaps all bundle entries from old source to new source', () => {
+    let lock = emptyLockfile('cli@1.0.0');
+    lock = upsertSource(lock, 'github-old', { type: 'github', url: 'https://github.com/org/old-repo' });
+    lock = upsertBundleEntry(lock, 'bundle-a', { version: '1.0.0', sourceId: 'github-old', sourceType: 'github', installedAt: 't', files: [] });
+    lock = upsertBundleEntry(lock, 'bundle-b', { version: '2.0.0', sourceId: 'github-old', sourceType: 'github', installedAt: 't', files: [] });
+
+    const next = remapSourceId(lock, 'github-old', 'github-new', { type: 'github', url: 'https://github.com/org/new-repo' });
+
+    expect(next.bundles['bundle-a'].sourceId).toBe('github-new');
+    expect(next.bundles['bundle-b'].sourceId).toBe('github-new');
+    expect(next.sources['github-old']).toBeUndefined();
+    expect(next.sources['github-new'].url).toBe('https://github.com/org/new-repo');
+  });
+
+  it('does not touch bundles referencing a different source', () => {
+    let lock = emptyLockfile('cli@1.0.0');
+    lock = upsertSource(lock, 'github-old', { type: 'github', url: 'https://github.com/org/old-repo' });
+    lock = upsertSource(lock, 'github-other', { type: 'github', url: 'https://github.com/org/other' });
+    lock = upsertBundleEntry(lock, 'bundle-a', { version: '1.0.0', sourceId: 'github-old', sourceType: 'github', installedAt: 't', files: [] });
+    lock = upsertBundleEntry(lock, 'bundle-b', { version: '1.0.0', sourceId: 'github-other', sourceType: 'github', installedAt: 't', files: [] });
+
+    const next = remapSourceId(lock, 'github-old', 'github-new', { type: 'github', url: 'https://github.com/org/new-repo' });
+
+    expect(next.bundles['bundle-a'].sourceId).toBe('github-new');
+    expect(next.bundles['bundle-b'].sourceId).toBe('github-other');
+    expect(next.sources['github-other']).toBeDefined();
+  });
+
+  it('does not mutate the input lockfile', () => {
+    let lock = emptyLockfile('cli@1.0.0');
+    lock = upsertSource(lock, 'github-old', { type: 'github', url: 'https://github.com/org/old-repo' });
+    lock = upsertBundleEntry(lock, 'bundle-a', { version: '1.0.0', sourceId: 'github-old', sourceType: 'github', installedAt: 't', files: [] });
+
+    remapSourceId(lock, 'github-old', 'github-new', { type: 'github', url: 'https://github.com/org/new-repo' });
+
+    expect(lock.bundles['bundle-a'].sourceId).toBe('github-old');
+    expect(lock.sources['github-old']).toBeDefined();
   });
 });

--- a/packages/core/src/domain/source/types.ts
+++ b/packages/core/src/domain/source/types.ts
@@ -39,6 +39,13 @@ export interface RegistrySource {
   token?: string;
   /** Hub identifier, when this source was provisioned by a curated hub. */
   hubId?: string;
+  /**
+   * The hub config `sources[].id` this source was provisioned from — the
+   * stable, author-assigned identity that survives a `url` change. Used to
+   * match a pre-rename orphan to its replacement. Absent on manually-added
+   * sources and on hub sources persisted before this field existed.
+   */
+  hubSourceId?: string;
   metadata?: {
     description?: string;
     homepage?: string;

--- a/packages/core/src/ports/registry-operations.ts
+++ b/packages/core/src/ports/registry-operations.ts
@@ -58,14 +58,90 @@ export interface SourceOperations {
 /**
  * Source read/write operations needed to sync a hub's declared sources
  * into the registry: list existing sources to detect duplicates/updates
- * against, add genuinely new ones, and update ones that already came
- * from the same hub. Deliberately narrower than a full source-CRUD
- * port (no `removeSource`) since hub-source syncing never deletes.
+ * against, add genuinely new ones, update ones that already came from the
+ * same hub, and remove ones this hub previously contributed that have
+ * since disappeared from its config (e.g. a collection whose repository
+ * URL was renamed, which yields a new sourceId and would otherwise leave
+ * the old source lingering as a duplicate).
  */
 export interface HubSourceSync {
   listSources(): Promise<RegistrySource[]>;
   addSource(source: RegistrySource): Promise<void>;
   updateSource(sourceId: string, updates: Partial<RegistrySource>): Promise<void>;
+  removeSource(sourceId: string): Promise<void>;
+  /**
+   * Installed bundles across all scopes, used to guard orphan pruning so a
+   * source with still-installed consumers is preserved or remapped rather
+   * than deleted (which would strand those bundles in an unmanaged state —
+   * see `loadHubSources`).
+   */
+  listInstalledBundles(): Promise<InstalledBundle[]>;
+  /**
+   * Optional: remap installed bundles from an old source to a new one
+   * (e.g. after a collection URL rename). Updates lockfile entries and
+   * installation records so consumers seamlessly track the new source.
+   * When omitted, orphans with installed consumers are kept alive with a
+   * warning rather than remapped.
+   */
+  remapBundleSource?(oldSourceId: string, newSourceId: string): Promise<void>;
+}
+
+/**
+ * The replacement source's descriptor, needed to write a repository-scope
+ * lockfile's `sources` map when installed bundles are moved onto it.
+ *
+ * Structurally the `LockfileSourceEntry` shape that `app`'s pure
+ * `remapSourceId` transform (`stores/json-lockfile-store.ts`) already
+ * consumes, declared here rather than imported because `core` sits at the
+ * bottom of the dependency graph and cannot reach `app`. Kept structural —
+ * a plain shape over `type`/`url` — so both sides stay assignable without
+ * either one owning the other's module.
+ */
+export interface LockfileSourceDescriptor {
+  /** Source type (`github`, `local`, `awesome-copilot`, `apm`, ...). */
+  type: string;
+  /** URL of the replacement source. */
+  url: string;
+  /** Git branch, for git-based sources. */
+  branch?: string;
+  /** Collections subdirectory, for `awesome-copilot`-type sources. */
+  collectionsPath?: string;
+}
+
+/**
+ * The external access a bundle-source remap needs: resolve the replacement
+ * source's descriptor before touching anything, then rewrite the
+ * repository-scope lockfile and the user-scope/workspace-scope
+ * installation records onto the new source id.
+ *
+ * Deliberately separate from `HubSourceSync` rather than an extension of
+ * it (interface segregation): a remap never adds, updates, or removes a
+ * source, and `HubSourceSync.remapBundleSource` — which stays optional and
+ * keeps its `(oldSourceId, newSourceId) => Promise<void>` shape — is the
+ * calling side's view of this operation, not its implementation surface.
+ */
+export interface BundleSourceRemap {
+  /** All stored sources, used to resolve the replacement descriptor. */
+  listSources(): Promise<RegistrySource[]>;
+  /**
+   * Remap repository-scope lockfile entries onto the new source id.
+   *
+   * Optional, and absence is a normal condition rather than an error: the
+   * port is left unwired when the host has no repository in scope (no
+   * workspace root, or a CLI invocation outside a repository). Without a
+   * repository in scope there are no repository-scope bundles to migrate,
+   * so skipping this step is correct and the user-scope/workspace-scope
+   * remap must still complete successfully.
+   */
+  remapLockfileSourceId?(
+    oldSourceId: string,
+    newSourceId: string,
+    descriptor: LockfileSourceDescriptor
+  ): Promise<void>;
+  /** Installation records for one non-repository scope. */
+  getInstalledBundles(scope: InstallationScope): Promise<InstalledBundle[]>;
+  /** Persist one installation record (upsert by bundle id + scope). */
+  recordInstallation(bundle: InstalledBundle): Promise<void>;
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,6 +310,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.10
         version: 4.1.10(vitest@4.1.10)
+      fast-check:
+        specifier: 3.23.2
+        version: 3.23.2
       typescript:
         specifier: ^5.9.3
         version: 5.9.3


### PR DESCRIPTION
## Description
A hub source's ID is derived from its URL, so renaming a collection repository produces a new sourceId while the old source lingers - causing the same collection to appear twice in the registry.

HubManager.loadHubSources() now tracks which sources are still represented in the current hub config (added, updated, or URL-duplicate matched) and removes any source whose hubId matches the hub being loaded but is no longer present. Manually added sources (no hubId) and sources from other hubs are never touched.

Adds unit tests for orphan removal and cross-hub/manual isolation, and documents the behavior in installation-flow.md.
## Type of Change

<!-- Mark relevant items with an [x] -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔧 Configuration/build changes


## Changes Made

<!-- Provide a detailed list of changes -->

A hub source's ID is derived from its URL, so renaming a collection repository produces a new sourceId while the old source lingers - causing the same collection to appear twice in the registry.

HubManager.loadHubSources() now tracks which sources are still represented in the current hub config (added, updated, or URL-duplicate matched) and removes any source whose hubId matches the hub being loaded but is no longer present. Manually added sources (no hubId) and sources from other hubs are never touched.


## Testing

Adds unit tests for orphan removal and cross-hub/manual isolation, and documents the behavior in installation-flow.md.

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

### Manual Testing Steps

1. run the extension in debug mode 
2.  make sure the changes work and don't create any regressions

### Tested On

- [ ] macOS
- [x] Windows
- [ ] Linux

- [x] VS Code Stable
- [ ] VS Code Insiders

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->

## Checklist

<!-- Mark completed items with an [x] -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

<!-- Add any additional notes for reviewers -->

## Reviewer Guidelines

<!-- For reviewers: What should they focus on? -->

Please pay special attention to:

- 
- 

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
