### PR TITLE
feat: local semantic search, one-step init, and SEA bundling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,6 @@
 {
+  "js/ts.tsdk.path": "packages/core/node_modules/typescript/lib",
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true,
   "eslint.codeActionsOnSave.mode": "all",
   "eslint.format.enable": true,
   "eslint.probe": [

--- a/apps/vscode-extension/.vscodeignore.production
+++ b/apps/vscode-extension/.vscodeignore.production
@@ -135,6 +135,7 @@ INTEGRATION_TEST_*.md
 !icon.png
 !dist/extension.js
 !dist/extension.js.LICENSE.txt
+!dist/tern_engine_bg.wasm
 !dist/webview/
 !dist/webview/**
 

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -154,6 +154,18 @@
         "category": "AI Primitives Hub"
       },
       {
+        "command": "promptRegistry.searchPrimitives",
+        "title": "Search Primitives",
+        "category": "AI Primitives Hub",
+        "icon": "$(search)"
+      },
+      {
+        "command": "promptRegistry.rebuildPrimitiveIndex",
+        "title": "Rebuild Primitive Index",
+        "category": "AI Primitives Hub",
+        "icon": "$(refresh)"
+      },
+      {
         "command": "promptRegistry.checkBundleUpdates",
         "title": "Check for Bundle Updates",
         "category": "AI Primitives Hub"
@@ -708,9 +720,10 @@
     "copy-webview": "cpy \"src/ui/webview/marketplace/*\" dist/webview/marketplace && cpy \"src/ui/webview/bundle-details/*\" dist/webview/bundle-details",
     "copy-skill-references": "cd ../.. && cpy docs/README.md apps/vscode-extension/resources/skills/prompt-registry-helper/references/docs-index.md && cpy \"docs/**\" \"!docs/README.md\" \"!docs/contributor-guide\" \"!docs/contributor-guide/**\" \"!docs/reference/adapter-api.md\" \"!docs/AGENTS.md\" apps/vscode-extension/resources/skills/prompt-registry-helper/references",
     "copy-schemas": "node scripts/package-helpers.js expand-schemas",
-    "compile": "webpack --mode production && pnpm run copy-webview && pnpm run copy-skill-references && pnpm run copy-schemas",
+    "copy-ternlight-wasm": "node scripts/package-helpers.js copy-ternlight-wasm",
+    "compile": "webpack --mode production && pnpm run copy-webview && pnpm run copy-skill-references && pnpm run copy-schemas && pnpm run copy-ternlight-wasm",
     "watch": "webpack --mode development --watch",
-    "package": "webpack --mode production --devtool hidden-source-map && pnpm run copy-webview",
+    "package": "webpack --mode production --devtool hidden-source-map && pnpm run copy-webview && pnpm run copy-ternlight-wasm",
     "package:vsix": "vsce package --no-dependencies",
     "compile-tests": "tsc -p tsconfig.test.json && node scripts/copy-test-fixtures.js",
     "watch-tests": "tsc -p tsconfig.test.json -w",

--- a/apps/vscode-extension/resources/skills/prompt-registry-helper/references/reference/commands.md
+++ b/apps/vscode-extension/resources/skills/prompt-registry-helper/references/reference/commands.md
@@ -15,6 +15,15 @@ This document lists all VS Code commands provided by the AI Primitives Hub exten
 | `promptRegistry.enableAutoUpdate` | Enable Auto-Update | Enable automatic updates for a bundle |
 | `promptRegistry.disableAutoUpdate` | Disable Auto-Update | Disable automatic updates for a bundle |
 
+## Index & Search
+
+| Command | Title | Description |
+|---------|-------|-------------|
+| `promptRegistry.searchPrimitives` | Search Primitives | Search indexed prompts, instructions, chat modes, agents, and skills |
+| `promptRegistry.rebuildPrimitiveIndex` | Rebuild Primitive Index | Rebuild the shared primitive index from enabled sources, with progress in a notification and the AI Primitives Hub output channel |
+
+Primitive search reads only a pre-built local index. It does not synchronize sources or rebuild the index. **Rebuild Primitive Index** is the explicit lifecycle operation that may access configured sources; it reports harvest, indexing, and embedding milestones in the **AI Primitives Hub** output channel and shows a completion or failure notification.
+
 ## Scope Management
 
 Commands for managing bundle installation scope. These are available via context menu on installed bundles in the Registry Explorer.

--- a/apps/vscode-extension/resources/skills/prompt-registry-helper/references/user-guide/marketplace.md
+++ b/apps/vscode-extension/resources/skills/prompt-registry-helper/references/user-guide/marketplace.md
@@ -4,11 +4,18 @@ Open via Activity Bar icon or `Ctrl+Shift+P` → "AI Primitives Hub: Focus On Ma
 
 ## Browsing
 
-- **Search** — Filter by name, description, tags
+- **Search** — Filter by name, description, tags, and indexed primitive content
 - **Filter by Type** — Prompts, Instructions, Chat Modes, Agents
 - **Filter by Tags** — Multiple tags use OR logic
 - **Filter by Source** — Show bundles from specific repositories
 - **Installed Only** — Show only installed bundles
+
+The marketplace builds the primitive index on demand when you search. To start a
+rebuild explicitly, open the Command Palette and run **AI Primitives Hub:
+Rebuild Primitive Index**. The index is also rebuilt automatically after source
+syncs and bundle installation changes. `awesome-copilot` and
+`awesome-copilot-plugin` sources are intentionally excluded from primitive
+indexing; they remain available to the regular bundle catalog.
 
 ## Installing
 

--- a/apps/vscode-extension/scripts/package-helpers.js
+++ b/apps/vscode-extension/scripts/package-helpers.js
@@ -16,6 +16,12 @@ const EXTENSION_DIR = path.resolve(__dirname, '..');
 const SCHEMAS_DIR = path.join(EXTENSION_DIR, 'schemas');
 const SCHEMAS_SOURCE = path.resolve(__dirname, '..', '..', '..', 'packages', 'core', 'src', 'public', 'schemas');
 
+const TERNLIGHT_PACKAGE_DIR = path.dirname(require.resolve('@ternlight/mini/package.json', {
+    paths: [path.resolve(__dirname, '..', '..', '..', 'packages', 'infra')]
+}));
+const TERNLIGHT_WASM_SOURCE = path.join(TERNLIGHT_PACKAGE_DIR, 'pkg-node', 'tern_engine_bg.wasm');
+const TERNLIGHT_WASM_DESTINATION = path.join(EXTENSION_DIR, 'dist', 'tern_engine_bg.wasm');
+
 function fileExists(filePath) {
     try {
         return fs.statSync(filePath).isFile();
@@ -139,6 +145,18 @@ function restoreSchemasSymlink() {
     console.log('✅ Schemas symlink restored');
 }
 
+function copyTernlightWasm() {
+    console.log('🧠 Copying ternlight WASM runtime...');
+    if (!fileExists(TERNLIGHT_WASM_SOURCE)) {
+        console.error(`❌ Ternlight WASM file not found: ${TERNLIGHT_WASM_SOURCE}`);
+        process.exit(1);
+    }
+
+    fs.mkdirSync(path.dirname(TERNLIGHT_WASM_DESTINATION), { recursive: true });
+    fs.copyFileSync(TERNLIGHT_WASM_SOURCE, TERNLIGHT_WASM_DESTINATION);
+    console.log('✅ Copied ternlight WASM runtime');
+}
+
 // Command line interface
 const command = process.argv[2];
 
@@ -163,6 +181,9 @@ switch (command) {
     case 'restore-schemas':
         restoreSchemasSymlink();
         break;
+    case 'copy-ternlight-wasm':
+        copyTernlightWasm();
+        break;
     default:
         console.log('Prompt Registry VS Code Extension Packaging Helpers');
         console.log('');
@@ -175,6 +196,7 @@ switch (command) {
         console.log('  status           - Show current ignore mode status');
         console.log('  expand-schemas   - Expand schemas symlink into real files for packaging');
         console.log('  restore-schemas  - Restore the schemas symlink after packaging');
+        console.log('  copy-ternlight-wasm - Copy the embedding engine WASM into dist');
         console.log('');
         console.log('Examples:');
         console.log('  npm run package:prepare  # Switch to production mode');

--- a/apps/vscode-extension/src/adapters/infra-adapter-factory.ts
+++ b/apps/vscode-extension/src/adapters/infra-adapter-factory.ts
@@ -20,6 +20,9 @@ import {
 import type {
   SourceAdapterFactoryDeps,
 } from '@ai-primitives-hub/app';
+import type {
+  SourceAdapter,
+} from '@ai-primitives-hub/core';
 import {
   GhCliTokenProvider,
   NodeFileSystem,
@@ -65,11 +68,15 @@ const silentDeps: SourceAdapterFactoryDeps = {
  * @param source - The source to build an adapter for.
  */
 export function createRegistryAdapter(source: RegistrySource): IRepositoryAdapter {
+  return createCoreRegistryAdapter(source) as IRepositoryAdapter;
+}
+
+/**
+ * Build the shared core adapter for services that consume the app/infra
+ * ports directly, such as primitive indexing.
+ * @param source - The source to build an adapter for.
+ */
+export function createCoreRegistryAdapter(source: RegistrySource): SourceAdapter {
   const deps = source.type === 'skills' ? silentDeps : promptingDeps;
-  // `core`'s `ValidationResult.warnings` is optional (a stricter-than-necessary
-  // port signature); every concrete `infra` adapter always populates it as a
-  // real array (never omits it), so this narrow cast is safe in practice -
-  // same reasoning/precedent as the `InstalledBundle` cast in
-  // `RegistryManager.listInstalledBundles`.
-  return createSourceAdapter(source, deps) as IRepositoryAdapter;
+  return createSourceAdapter(source, deps);
 }

--- a/apps/vscode-extension/src/adapters/vscode-session-token-provider.ts
+++ b/apps/vscode-extension/src/adapters/vscode-session-token-provider.ts
@@ -24,6 +24,10 @@ import {
   Logger,
 } from '../utils/logger';
 
+const TOKEN_CACHE_TTL_MS = 30_000;
+const tokenCache = new Map<boolean, { token: string; expiresAt: number }>();
+const tokenRequests = new Map<boolean, Promise<string | undefined>>();
+
 export class VsCodeSessionTokenProvider implements TokenProvider {
   private readonly logger = Logger.getInstance();
 
@@ -37,15 +41,16 @@ export class VsCodeSessionTokenProvider implements TokenProvider {
    */
   public constructor(private readonly createIfNone = true) {}
 
-  public async getToken(host: string): Promise<string | undefined> {
-    if (!isGitHubHost(host)) {
-      return undefined;
-    }
+  private async resolveToken(): Promise<string | undefined> {
     try {
       this.logger.debug('[VsCodeSessionTokenProvider] Trying VS Code GitHub authentication...');
       const session = await vscode.authentication.getSession('github', ['repo'], { createIfNone: this.createIfNone });
       if (session) {
         this.logger.info('[VsCodeSessionTokenProvider] Using VS Code GitHub authentication');
+        tokenCache.set(this.createIfNone, {
+          token: session.accessToken,
+          expiresAt: Date.now() + TOKEN_CACHE_TTL_MS
+        });
         return session.accessToken;
       }
       this.logger.debug('[VsCodeSessionTokenProvider] VS Code auth session not found');
@@ -53,6 +58,41 @@ export class VsCodeSessionTokenProvider implements TokenProvider {
     } catch (error) {
       this.logger.warn(`[VsCodeSessionTokenProvider] VS Code auth failed: ${error instanceof Error ? error.message : String(error)}`);
       return undefined;
+    }
+  }
+
+  /**
+   * Clear the process-wide session cache after an explicit authentication
+   * reset. The cache is shared because the extension creates one provider per
+   * source, while VS Code exposes one GitHub session for the host.
+   */
+  public static clearCache(): void {
+    tokenCache.clear();
+  }
+
+  public async getToken(host: string): Promise<string | undefined> {
+    if (!isGitHubHost(host)) {
+      return undefined;
+    }
+
+    const cached = tokenCache.get(this.createIfNone);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.token;
+    }
+
+    const pending = tokenRequests.get(this.createIfNone);
+    if (pending) {
+      return pending;
+    }
+
+    const request = this.resolveToken();
+    tokenRequests.set(this.createIfNone, request);
+    try {
+      return await request;
+    } finally {
+      if (tokenRequests.get(this.createIfNone) === request) {
+        tokenRequests.delete(this.createIfNone);
+      }
     }
   }
 }

--- a/apps/vscode-extension/src/commands/primitive-search-command.ts
+++ b/apps/vscode-extension/src/commands/primitive-search-command.ts
@@ -1,0 +1,137 @@
+/**
+ * Primitive search command.
+ *
+ * The command is intentionally a thin VS Code adapter: ranking, filtering,
+ * facets, and persisted-index compatibility are owned by the shared app and
+ * infra packages.
+ */
+import type {
+  Primitive,
+} from '@ai-primitives-hub/core';
+import type {
+  SearchHit,
+} from '@ai-primitives-hub/infra';
+import * as vscode from 'vscode';
+import {
+  PrimitiveIndexService,
+} from '../services/primitive-index-service';
+import {
+  ErrorHandler,
+} from '../utils/error-handler';
+
+interface PrimitivePick extends vscode.QuickPickItem {
+  primitive: Primitive;
+}
+
+/** Presents shared-index primitive search through a VS Code QuickPick. */
+export class PrimitiveSearchCommand {
+  public constructor(private readonly indexService: PrimitiveIndexService) {}
+
+  private createPick(hit: SearchHit): PrimitivePick {
+    const { primitive } = hit;
+    const installed = primitive.bundle.installed;
+    return {
+      label: `${primitive.title}  ${installed ? '$(check)' : ''}`.trim(),
+      description: `${primitive.kind} · ${primitive.bundle.bundleId}@${primitive.bundle.bundleVersion}`,
+      detail: [
+        primitive.description || primitive.bodyPreview,
+        `Source: ${primitive.bundle.sourceId}${installed ? ' · Installed' : ''}`
+      ].filter(Boolean).join(' — '),
+      primitive
+    };
+  }
+
+  private async showActions(primitive: Primitive): Promise<void> {
+    const action = await vscode.window.showQuickPick([
+      ...(primitive.bundle.installed
+        ? []
+        : [{
+          label: '$(cloud-download) Install bundle',
+          description: `${primitive.bundle.bundleId}@${primitive.bundle.bundleVersion}`,
+          value: 'install'
+        }]),
+      {
+        label: '$(info) Show primitive details',
+        description: primitive.path,
+        value: 'details'
+      }
+    ], {
+      title: primitive.title,
+      placeHolder: 'Choose an action',
+      ignoreFocusOut: true
+    });
+
+    if (action?.value === 'install') {
+      await vscode.commands.executeCommand('promptRegistry.installBundle', primitive.bundle.bundleId);
+    } else if (action?.value === 'details') {
+      await vscode.window.showInformationMessage(
+        `${primitive.title}\n\n${primitive.description || primitive.bodyPreview}\n\n${primitive.path}`
+      );
+    }
+  }
+
+  /** Search indexed primitives and present the matching results. */
+  public async search(): Promise<void> {
+    try {
+      const query = await vscode.window.showInputBox({
+        prompt: 'Search indexed primitives',
+        placeHolder: 'e.g., review pull requests',
+        ignoreFocusOut: true
+      });
+      if (!query?.trim()) {
+        return;
+      }
+
+      // Search is read-only. Index construction is handled by the lifecycle
+      // scheduler or the explicit rebuild command, never by a search request.
+      const result = await this.indexService.search({ q: query.trim(), limit: 50 });
+      if (result.hits.length === 0) {
+        await vscode.window.showInformationMessage(`No primitives found for "${query.trim()}"`);
+        return;
+      }
+
+      const selected = await vscode.window.showQuickPick(
+        result.hits.map((hit) => this.createPick(hit)),
+        {
+          title: `Primitive Search (${result.total} matches)`,
+          placeHolder: 'Select a primitive',
+          matchOnDescription: true,
+          matchOnDetail: true,
+          ignoreFocusOut: true
+        }
+      );
+      if (selected) {
+        await this.showActions(selected.primitive);
+      }
+    } catch (error) {
+      await ErrorHandler.handle(error, {
+        operation: 'search primitives',
+        showUserMessage: true,
+        userMessagePrefix: 'Failed to search primitives'
+      });
+    }
+  }
+
+  /** Rebuild the shared primitive index immediately. */
+  public async rebuild(): Promise<void> {
+    try {
+      const result = await vscode.window.withProgress({
+        location: vscode.ProgressLocation.Notification,
+        title: 'Rebuilding Primitive Index',
+        cancellable: false
+      }, async (progress) => {
+        progress.report({ message: `Using ${this.indexService.getProfile()}` });
+        return this.indexService.rebuild();
+      });
+      await vscode.window.showInformationMessage(
+        `Primitive index rebuilt: ${result.primitives} primitives from ${result.bundles} bundles.`
+      );
+    } catch (error) {
+      await ErrorHandler.handle(error, {
+        operation: 'rebuild primitive index',
+        showUserMessage: true,
+        userMessagePrefix: 'Failed to rebuild primitive index'
+      });
+    }
+  }
+}

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -1,3 +1,10 @@
+import {
+  getBundleRefKey,
+} from '@ai-primitives-hub/core';
+import {
+  AppStoragePrimitiveIndexStore,
+  XdgAppStorage,
+} from '@ai-primitives-hub/infra';
 import * as vscode from 'vscode';
 import {
   AddResourceCommand,
@@ -23,6 +30,9 @@ import {
 import {
   HubProfileCommands,
 } from './commands/hub-profile-commands';
+import {
+  PrimitiveSearchCommand,
+} from './commands/primitive-search-command';
 import {
   ProfileCommands,
 } from './commands/profile-commands';
@@ -83,6 +93,9 @@ import {
 import {
   OutputChannelTransport,
 } from './services/output-channel-transport';
+import {
+  PrimitiveIndexService,
+} from './services/primitive-index-service';
 import {
   RegistryManager,
 } from './services/registry-manager';
@@ -145,6 +158,12 @@ export class PromptRegistryExtension {
   private readonly statusBar: StatusBar;
   private readonly notifications: ExtensionNotifications;
   private readonly registryManager: RegistryManager;
+  private readonly primitiveIndexService: PrimitiveIndexService;
+  private readonly primitiveSearchCommand: PrimitiveSearchCommand;
+  private readonly initialSourceSyncReady: Promise<void>;
+  private resolveInitialSourceSyncReady!: () => void;
+  private initialSourceSyncReadyResolved = false;
+  private initialSourceSyncPromise: Promise<void> | undefined;
   private treeProvider: RegistryTreeProvider | undefined;
   private marketplaceProvider: MarketplaceViewProvider | undefined;
   private profileCommands: ProfileCommands | undefined;
@@ -185,6 +204,32 @@ export class PromptRegistryExtension {
     this.statusBar = StatusBar.getInstance();
     this.notifications = ExtensionNotifications.getInstance();
     this.registryManager = RegistryManager.getInstance(context);
+    this.initialSourceSyncReady = new Promise<void>((resolve) => {
+      this.resolveInitialSourceSyncReady = resolve;
+    });
+    const sharedIndexStorage = new XdgAppStorage();
+    this.primitiveIndexService = new PrimitiveIndexService(context, {
+      profile: 'ternlight-dual-v1',
+      indexStore: new AppStoragePrimitiveIndexStore(sharedIndexStorage),
+      indexKeyProvider: () => this.registryManager.getPrimitiveIndexKey('ternlight-dual-v1'),
+      installedBundleKeysProvider: async () => {
+        const installed = await this.registryManager.listInstalledBundles();
+        return installed
+          .filter((bundle) => bundle.sourceId !== undefined)
+          .map((bundle) => getBundleRefKey({
+            sourceId: bundle.sourceId!,
+            bundleId: bundle.bundleId,
+            bundleVersion: bundle.version
+          }));
+      },
+      providerFactory: () => this.registryManager.createPrimitiveBundleProvider(),
+      initializationReady: this.initialSourceSyncReady,
+      searchIndexKeyProvider: () => this.registryManager.getCachedPrimitiveIndexKey('ternlight-dual-v1'),
+      searchIndexSourceIdsProvider: async () => (await this.registryManager.listSources())
+        .filter((source) => source.enabled)
+        .map((source) => source.id)
+    });
+    this.primitiveSearchCommand = new PrimitiveSearchCommand(this.primitiveIndexService);
   }
 
   /**
@@ -241,6 +286,29 @@ export class PromptRegistryExtension {
     }
   }
 
+  /** Rebuild the shared primitive index when registry data or install state changes. */
+  private registerPrimitiveIndexLifecycle(): void {
+    const schedule = (reason: string) => this.primitiveIndexService.scheduleRebuild(reason);
+    const scheduleWhenReady = (reason: string) => {
+      if (!this.initialSourceSyncReadyResolved) {
+        return;
+      }
+      schedule(reason);
+    };
+
+    this.disposables.push(
+      this.registryManager.onSourceAdded(() => scheduleWhenReady('source added')),
+      this.registryManager.onSourceRemoved(() => scheduleWhenReady('source removed')),
+      this.registryManager.onSourceUpdated(() => scheduleWhenReady('source updated')),
+      this.registryManager.onSourceSynced(() => scheduleWhenReady('source synced')),
+      this.registryManager.onBundleInstalled(() => scheduleWhenReady('bundle installed')),
+      this.registryManager.onBundleUninstalled(() => scheduleWhenReady('bundle uninstalled')),
+      this.registryManager.onBundleUpdated(() => scheduleWhenReady('bundle updated')),
+      this.registryManager.onBundlesInstalled(() => scheduleWhenReady('bundles installed')),
+      this.registryManager.onBundlesUninstalled(() => scheduleWhenReady('bundles uninstalled'))
+    );
+  }
+
   /**
    * Register all extension commands
    */
@@ -273,11 +341,17 @@ export class PromptRegistryExtension {
     // This replaces the ad-hoc syncAllSources call that was previously in syncActiveHub().
     this.hubManager.onHubSynced(async (hubId) => {
       this.logger.info(`Hub synced (${hubId}), syncing all sources...`);
+      const sourceSyncPromise = this.sourceCommands!.syncAllSources({ silent: true });
+      if (!this.initialSourceSyncPromise) {
+        this.initialSourceSyncPromise = sourceSyncPromise;
+      }
       try {
-        await this.sourceCommands!.syncAllSources({ silent: true });
+        await sourceSyncPromise;
         vscode.commands.executeCommand('promptRegistry.refresh');
       } catch (error) {
         this.logger.warn('Source sync after hub sync failed', error);
+      } finally {
+        this.markInitialSourceSyncReady(sourceSyncPromise);
       }
     });
 
@@ -319,6 +393,8 @@ export class PromptRegistryExtension {
 
       // Bundle Management Commands
       vscode.commands.registerCommand('promptRegistry.searchBundles', () => this.bundleCommands!.searchAndInstall()),
+      vscode.commands.registerCommand('promptRegistry.searchPrimitives', () => this.primitiveSearchCommand.search()),
+      vscode.commands.registerCommand('promptRegistry.rebuildPrimitiveIndex', () => this.primitiveSearchCommand.rebuild()),
       vscode.commands.registerCommand('promptRegistry.installBundle', (bundleId?) => this.bundleCommands!.installBundle(bundleId)),
       vscode.commands.registerCommand('promptRegistry.uninstallBundle', (arg?) => this.bundleCommands!.uninstallBundle(this.extractBundleId(arg))),
       vscode.commands.registerCommand('promptRegistry.updateBundle', (arg?) => this.bundleCommands!.updateBundle(this.extractBundleId(arg))),
@@ -527,7 +603,12 @@ export class PromptRegistryExtension {
     this.logger.info('Registering Marketplace View...');
 
     // Create marketplace provider
-    this.marketplaceProvider = new MarketplaceViewProvider(this.context, this.registryManager, this.setupStateManager!);
+    this.marketplaceProvider = new MarketplaceViewProvider(
+      this.context,
+      this.registryManager,
+      this.setupStateManager!,
+      this.primitiveIndexService
+    );
 
     // Register webview view
     const marketplaceView = vscode.window.registerWebviewViewProvider(
@@ -621,7 +702,9 @@ export class PromptRegistryExtension {
         async (bundleId: string) => {
           return await this.registryManager.getBundleName(bundleId);
         },
-        this.autoUpdateService
+        this.autoUpdateService,
+        this.initialSourceSyncReady,
+        () => !this.initialSourceSyncPromise
       );
 
       // Wire up update detection to tree provider
@@ -1459,6 +1542,7 @@ export class PromptRegistryExtension {
         description: 'Configure hub later',
         detail: 'You can configure a hub anytime from the toolbar',
         hubConfig: null as any
+
       }
     );
 
@@ -1563,6 +1647,26 @@ export class PromptRegistryExtension {
     await vscode.commands.executeCommand('promptRegistry.refresh');
   }
 
+  /**
+   * Release the automatic update check once the initial source sync is done.
+   * @param completedSync
+   */
+  private markInitialSourceSyncReady(completedSync?: Promise<void>): void {
+    if (completedSync && completedSync !== this.initialSourceSyncPromise) {
+      return;
+    }
+    if (!this.initialSourceSyncReadyResolved) {
+      this.initialSourceSyncReadyResolved = true;
+      this.primitiveIndexService.scheduleRebuild('initial source sync complete', 0);
+      this.resolveInitialSourceSyncReady();
+    }
+  }
+
+  /** Shared primitive index service used by commands and UI adapters. */
+  public getPrimitiveIndexService(): PrimitiveIndexService {
+    return this.primitiveIndexService;
+  }
+
   public async activate(): Promise<void> {
     try {
       this.logger.info('Activating AI Primitives Hub extension...');
@@ -1581,6 +1685,7 @@ export class PromptRegistryExtension {
 
       // Register commands
       this.registerCommands();
+      this.registerPrimitiveIndexLifecycle();
 
       // Initialize UI components
       await this.initializeUI();
@@ -1618,6 +1723,13 @@ export class PromptRegistryExtension {
         await this.syncActiveHub();
       }
 
+      // A hub sync emits the source synchronization asynchronously. Do not let
+      // the automatic update timer race it; activation itself remains
+      // non-blocking while the startup check waits on the readiness promise.
+      if (!this.initialSourceSyncPromise) {
+        this.markInitialSourceSyncReady();
+      }
+
       // Ensure only one profile is active (cleanup any multi-active state)
       await this.ensureSingleActiveProfile();
 
@@ -1645,6 +1757,7 @@ export class PromptRegistryExtension {
       // Dispose of all resources
       this.disposables.forEach((disposable) => disposable.dispose());
       this.disposables = [];
+      this.primitiveIndexService.dispose();
 
       // Dispose telemetry event subscriptions
       this.telemetryService?.dispose();

--- a/apps/vscode-extension/src/services/hub-manager.ts
+++ b/apps/vscode-extension/src/services/hub-manager.ts
@@ -296,6 +296,7 @@ export class HubManager {
    * fresh token on every call, so there is no cache left to clear.
    */
   public clearAuthCache(): void {
+    VsCodeSessionTokenProvider.clearCache();
     this.logger.info('[HubManager] Authentication cache cleared');
   }
 

--- a/apps/vscode-extension/src/services/primitive-index-service.ts
+++ b/apps/vscode-extension/src/services/primitive-index-service.ts
@@ -1,0 +1,421 @@
+/**
+ * VS Code delivery adapter for the shared primitive index.
+ *
+ * The service owns only extension concerns: receiving the resolved index path
+ * or storage adapter and supplying a bundle provider. Index construction and
+ * ranking remain in `@ai-primitives-hub/app`/`@ai-primitives-hub/infra` so
+ * CLI and VS Code use the same profile and persisted-index contract.
+ * @module services/primitive-index-service
+ */
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import {
+  buildIndex,
+  getSearchProfile,
+  searchIndex,
+} from '@ai-primitives-hub/app';
+import type {
+  BuildIndexResult,
+  SearchProfileId,
+} from '@ai-primitives-hub/app';
+import type {
+  AppStorage,
+  BundleProvider,
+  PrimitiveIndexKey,
+  PrimitiveIndexStore,
+} from '@ai-primitives-hub/core';
+import type {
+  SearchQuery,
+  SearchResult,
+} from '@ai-primitives-hub/infra';
+import * as vscode from 'vscode';
+import {
+  VsCodeAppStorage,
+} from '../storage/vscode-app-storage';
+import {
+  Logger,
+} from '../utils/logger';
+
+export interface PrimitiveIndexServiceOptions {
+  /** Provider factory; source-specific enumeration stays outside this service. */
+  providerFactory: () => BundleProvider | Promise<BundleProvider>;
+  /**
+   * Optional explicit path, primarily useful for tests, diagnostics, and
+   * migration compatibility. Prefer `storage` in production composition.
+   */
+  indexPath?: string;
+  /**
+   * Storage seam for the shared semantic cache. The composition root selects
+   * the physical policy; this service must not select a client-specific root.
+   */
+  storage?: Pick<AppStorage, 'getPaths'>;
+  /** Shared namespaced index resolver selected by the composition root. */
+  indexStore?: PrimitiveIndexStore;
+  /** Hub/source/profile key for the shared index resolver. */
+  indexKey?: PrimitiveIndexKey;
+  /** Resolve the active hub and source snapshot for each index operation. */
+  indexKeyProvider?: () => PrimitiveIndexKey | Promise<PrimitiveIndexKey>;
+  /** Resolve a search key without remote revision lookups. */
+  searchIndexKeyProvider?: () => PrimitiveIndexKey | Promise<PrimitiveIndexKey>;
+  /** Resolve the current installation snapshot for query-time filtering. */
+  installedBundleKeysProvider?: () => string[] | Promise<string[]>;
+  /** Resolve locally known source IDs for compatible fallback selection. */
+  searchIndexSourceIdsProvider?: () => string[] | Promise<string[]>;
+  /** Shared ranking profile used for build and search. */
+  profile?: SearchProfileId;
+  /** Delay first-use index work until the initial registry sync is complete. */
+  initializationReady?: Promise<void>;
+}
+
+const INITIALIZATION_READY_TIMEOUT_MS = 5000;
+const INSTALLED_BUNDLE_OVERLAY_TIMEOUT_MS = 1000;
+
+/**
+ * Thin VS Code adapter over the app-level primitive-index use cases.
+ */
+export class PrimitiveIndexService {
+  private readonly indexPath: string;
+  private readonly profile: SearchProfileId;
+  private readonly providerFactory: PrimitiveIndexServiceOptions['providerFactory'];
+  private readonly indexStore?: PrimitiveIndexStore;
+  private readonly indexKey?: PrimitiveIndexKey;
+  private readonly indexKeyProvider?: PrimitiveIndexServiceOptions['indexKeyProvider'];
+  private readonly searchIndexKeyProvider?: PrimitiveIndexServiceOptions['searchIndexKeyProvider'];
+  private readonly installedBundleKeysProvider?: PrimitiveIndexServiceOptions['installedBundleKeysProvider'];
+  private readonly searchIndexSourceIdsProvider?: PrimitiveIndexServiceOptions['searchIndexSourceIdsProvider'];
+  private readonly initializationReady?: Promise<void>;
+  private readonly legacyIndexPath?: string;
+  private readonly logger = Logger.getInstance();
+  private rebuildTimer?: ReturnType<typeof setTimeout>;
+  private rebuildQueue: Promise<void> = Promise.resolve();
+  private disposed = false;
+  private emptyIndexRecoveryAttempted = false;
+  private fallbackIndexPath?: string;
+
+  public constructor(context: vscode.ExtensionContext, options: PrimitiveIndexServiceOptions) {
+    this.profile = options.profile ?? 'ternlight-dual-v1';
+    // Resolve eagerly so invalid profile configuration fails during activation,
+    // rather than on the first search request.
+    getSearchProfile(this.profile);
+
+    const storage = options.storage ?? new VsCodeAppStorage(context);
+    this.indexStore = options.indexStore;
+    this.installedBundleKeysProvider = options.installedBundleKeysProvider;
+    this.searchIndexSourceIdsProvider = options.searchIndexSourceIdsProvider;
+    this.initializationReady = options.initializationReady;
+    this.indexKeyProvider = options.indexKeyProvider;
+    this.searchIndexKeyProvider = options.searchIndexKeyProvider;
+    this.indexKey = options.indexKey ?? (!this.indexKeyProvider && this.indexStore
+      ? {
+        hubId: 'active',
+        sourceRevision: 'current',
+        searchProfileId: this.profile
+      }
+      : undefined);
+    this.legacyIndexPath = this.indexStore && !options.indexPath
+      ? path.join(storage.getPaths().cache, 'primitive-index.json')
+      : undefined;
+    this.indexPath = options.indexPath
+      ?? (this.indexStore && this.indexKey
+        ? this.indexStore.getIndexPath(this.indexKey)
+        : path.join(storage.getPaths().cache, 'primitive-index.json'));
+    this.providerFactory = options.providerFactory;
+  }
+
+  /**
+   * Prefer the legacy cache only until the first namespaced rebuild succeeds.
+   * @param indexKey
+   */
+  private async shouldUseLegacyIndex(indexKey: PrimitiveIndexKey | undefined): Promise<boolean> {
+    if (!this.legacyIndexPath || !this.indexStore || !indexKey) {
+      return false;
+    }
+    try {
+      await fs.access(this.indexStore.getIndexPath(indexKey));
+      return false;
+    } catch {
+      return this.isLegacyIndexCompatible();
+    }
+  }
+
+  private async isLegacyIndexCompatible(): Promise<boolean> {
+    if (!this.legacyIndexPath) {
+      return false;
+    }
+    try {
+      const raw = await fs.readFile(this.legacyIndexPath, 'utf8');
+      const metadata = JSON.parse(raw) as {
+        searchProfileId?: string | null;
+        embeddingsMeta?: { embeddingStrategy?: string } | null;
+      };
+      const persistedProfile = metadata.searchProfileId
+        ?? (metadata.embeddingsMeta
+          ? (metadata.embeddingsMeta.embeddingStrategy === 'dual' ? 'ternlight-dual-v1' : 'ternlight-single-v1')
+          : 'bm25-v1');
+      return persistedProfile === this.profile;
+    } catch {
+      return false;
+    }
+  }
+
+  private async performRebuild(): Promise<BuildIndexResult> {
+    const provider = await this.providerFactory();
+    const indexKey = this.indexKeyProvider ? await this.indexKeyProvider() : this.indexKey;
+    const result = await buildIndex({
+      provider,
+      ...(this.indexStore && indexKey
+        ? { indexStore: this.indexStore, indexKey }
+        : { outFile: this.indexPath }),
+      profile: this.profile,
+      onLog: (message) => this.logger.info(`Primitive index rebuild: ${message}`),
+      // A transient source/network failure must not replace the last-known-good
+      // semantic snapshot with an empty index.
+      persistEmpty: false
+    });
+    if (result.primitives === 0) {
+      await this.resolveFallbackIndexPath(indexKey);
+    }
+    return result;
+  }
+
+  private async resolveFallbackIndexPath(indexKey: PrimitiveIndexKey | undefined): Promise<string | undefined> {
+    this.fallbackIndexPath = undefined;
+    if (!this.indexStore || !indexKey?.hubId || !this.indexStore.findLatestIndexPath) {
+      return undefined;
+    }
+    const sourceIds = this.searchIndexSourceIdsProvider
+      ? await this.searchIndexSourceIdsProvider()
+      : undefined;
+    const candidate = await this.indexStore.findLatestIndexPath(indexKey.hubId, this.profile, sourceIds);
+    if (candidate && candidate !== this.indexStore.getIndexPath(indexKey)) {
+      this.fallbackIndexPath = candidate;
+      this.logger.warn(`Using last-known-good primitive index snapshot: ${candidate}`);
+      return candidate;
+    }
+    return undefined;
+  }
+
+  private async hasPrimitives(indexPath: string): Promise<boolean> {
+    try {
+      const raw = await fs.readFile(indexPath, 'utf8');
+      const parsed = JSON.parse(raw) as { primitives?: unknown[] };
+      return Array.isArray(parsed.primitives) && parsed.primitives.length > 0;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * The installed overlay enriches hits but is not required for ranking. Keep
+   * slow repository/lockfile reads from blocking semantic Marketplace search.
+   */
+  private async resolveInstalledBundleKeys(): Promise<string[] | undefined> {
+    if (!this.installedBundleKeysProvider) {
+      return undefined;
+    }
+
+    let timedOut = false;
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const installedBundleKeys = await Promise.race([
+        this.installedBundleKeysProvider(),
+        new Promise<undefined>((resolve) => {
+          timeoutHandle = setTimeout(() => {
+            timedOut = true;
+            resolve(undefined);
+          }, INSTALLED_BUNDLE_OVERLAY_TIMEOUT_MS);
+        })
+      ]);
+      if (timedOut) {
+        this.logger.warn(
+          `Installed bundle overlay timed out after ${String(INSTALLED_BUNDLE_OVERLAY_TIMEOUT_MS)}ms; continuing without overlay`
+        );
+      }
+      return installedBundleKeys;
+    } catch (error) {
+      this.logger.warn(`Installed bundle overlay failed; continuing without overlay: ${String(error)}`);
+      return undefined;
+    } finally {
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+    }
+  }
+
+  /**
+   * Wait for the initial source sync without allowing Marketplace searches to
+   * remain pending forever when the sync lifecycle has stalled.
+   */
+  private async waitForInitializationReady(): Promise<boolean> {
+    if (!this.initializationReady) {
+      return true;
+    }
+
+    let timedOut = false;
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        this.initializationReady,
+        new Promise<void>((resolve) => {
+          timeoutHandle = setTimeout(() => {
+            timedOut = true;
+            resolve();
+          }, INITIALIZATION_READY_TIMEOUT_MS);
+        })
+      ]);
+    } catch (error) {
+      this.logger.warn(`Initial source sync readiness failed; continuing with cached index: ${String(error)}`);
+      return false;
+    } finally {
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+    }
+
+    if (timedOut) {
+      this.logger.warn(`Initial source sync readiness timed out after ${String(INITIALIZATION_READY_TIMEOUT_MS)}ms`);
+    }
+    return !timedOut;
+  }
+
+  /** Absolute path of the persisted extension index. */
+  public getIndexPath(): string {
+    return this.indexPath;
+  }
+
+  /** Profile shared by build and search operations. */
+  public getProfile(): SearchProfileId {
+    return this.profile;
+  }
+
+  /** Rebuild and persist the index from the configured source provider. */
+  public async rebuild(): Promise<BuildIndexResult> {
+    this.logger.info(`Primitive index rebuild started (profile=${this.profile})`);
+    let result!: BuildIndexResult;
+    const operation = this.rebuildQueue.then(async () => {
+      result = await this.performRebuild();
+    });
+    this.rebuildQueue = operation.then(() => undefined, () => undefined);
+    try {
+      await operation;
+      this.logger.info(
+        `Primitive index rebuild completed: ${result.primitives} primitive${result.primitives === 1 ? '' : 's'} `
+        + `from ${result.bundles} bundle${result.bundles === 1 ? '' : 's'} (${result.outFile})`
+      );
+      return result;
+    } catch (error) {
+      this.logger.error('Primitive index rebuild failed', error as Error);
+      throw error;
+    }
+  }
+
+  /**
+   * Search the persisted index using the same profile used to build it.
+   * @param query
+   */
+  public async search(query: SearchQuery): Promise<SearchResult> {
+    const installedBundleKeys = await this.resolveInstalledBundleKeys();
+    const indexKey = this.searchIndexKeyProvider
+      ? await this.searchIndexKeyProvider()
+      : (this.indexKeyProvider ? await this.indexKeyProvider() : this.indexKey);
+    const currentIndexPath = this.indexStore && indexKey
+      ? this.indexStore.getIndexPath(indexKey)
+      : this.indexPath;
+    let useFallbackIndex = false;
+    if (!(await this.hasPrimitives(currentIndexPath))) {
+      await this.resolveFallbackIndexPath(indexKey);
+      useFallbackIndex = Boolean(this.fallbackIndexPath);
+    }
+    const useLegacyIndex = !useFallbackIndex && await this.shouldUseLegacyIndex(indexKey);
+    let location: {
+      indexPath?: string;
+      indexStore?: PrimitiveIndexStore;
+      indexKey?: PrimitiveIndexKey;
+    };
+    if (useFallbackIndex) {
+      location = { indexPath: this.fallbackIndexPath! };
+    } else if (useLegacyIndex) {
+      location = { indexPath: this.legacyIndexPath! };
+    } else if (this.indexStore && indexKey) {
+      location = { indexStore: this.indexStore, indexKey };
+    } else {
+      location = { indexPath: this.indexPath };
+    }
+    return searchIndex({
+      ...location,
+      query: installedBundleKeys ? { ...query, installedBundleKeys } : query,
+      profile: this.profile
+    });
+  }
+
+  /** Build the index on first use when no persisted index exists yet. */
+  public async ensureBuilt(): Promise<void> {
+    const initializationReady = await this.waitForInitializationReady();
+    if (!initializationReady) {
+      // Do not start a competing full rebuild while the initial source sync is
+      // still running. Search can use the current or last-known-good snapshot;
+      // if neither exists, search will report the normal metadata fallback.
+      this.logger.warn('Primitive index initialization is still in progress; using an existing snapshot if available');
+      return;
+    }
+    const indexKey = this.indexKeyProvider ? await this.indexKeyProvider() : this.indexKey;
+    const indexPath = this.indexStore && indexKey
+      ? this.indexStore.getIndexPath(indexKey)
+      : this.indexPath;
+    try {
+      await fs.access(indexPath);
+      if (!this.emptyIndexRecoveryAttempted) {
+        const raw = await fs.readFile(indexPath, 'utf8');
+        const parsed = JSON.parse(raw) as { primitives?: unknown[] };
+        if (Array.isArray(parsed.primitives) && parsed.primitives.length === 0) {
+          this.emptyIndexRecoveryAttempted = true;
+          await this.rebuild();
+        }
+      }
+    } catch {
+      if (await this.isLegacyIndexCompatible()) {
+        return;
+      }
+      await this.rebuild();
+    }
+  }
+
+  /**
+   * Schedule a debounced rebuild after a registry lifecycle event.
+   * Rebuilds are serialized so a burst of source-sync events cannot corrupt or
+   * overwrite the persisted index out of order.
+   * @param reason
+   * @param delayMs
+   */
+  public scheduleRebuild(reason: string, delayMs = 500): void {
+    if (this.disposed) {
+      return;
+    }
+
+    if (this.rebuildTimer) {
+      clearTimeout(this.rebuildTimer);
+    }
+    this.rebuildTimer = setTimeout(() => {
+      this.rebuildTimer = undefined;
+      this.rebuildQueue = this.rebuildQueue.then(async () => {
+        try {
+          const result = await this.performRebuild();
+          this.logger.info(
+            `Primitive index rebuilt after ${reason}: ${result.primitives} primitives from ${result.bundles} bundles`
+          );
+        } catch (error) {
+          this.logger.error(`Primitive index rebuild failed after ${reason}`, error as Error);
+        }
+      });
+    }, delayMs);
+  }
+
+  /** Cancel pending rebuild work when the extension is deactivated. */
+  public dispose(): void {
+    this.disposed = true;
+    if (this.rebuildTimer) {
+      clearTimeout(this.rebuildTimer);
+      this.rebuildTimer = undefined;
+    }
+  }
+}

--- a/apps/vscode-extension/src/services/registry-manager.ts
+++ b/apps/vscode-extension/src/services/registry-manager.ts
@@ -4,7 +4,12 @@
  */
 
 import {
+  createHash,
+} from 'node:crypto';
+import * as path from 'node:path';
+import {
   activateRegistryProfile,
+  canonicalizeIndexHubId,
   createLocalProfile,
   deactivateRegistryProfile,
   deleteLocalProfile,
@@ -28,16 +33,35 @@ import {
 import type {
   LogEvent,
 } from '@ai-primitives-hub/app';
+import type {
+  BundleProvider,
+  PrimitiveIndexKey,
+} from '@ai-primitives-hub/core';
 import {
+  BlobCache,
+  CompositeBundleProvider,
+  CompositeTokenProvider,
+  createRegistrySourceBundleProvider,
+  createSourceRevision,
+  GhCliTokenProvider,
+  GitHubApiClient,
   GitHubAdapter as InfraGitHubAdapter,
+  NodeHttpClient,
+  SourceAdapterBundleProvider,
+  StaticTokenProvider,
+  XdgAppStorage,
 } from '@ai-primitives-hub/infra';
 import * as vscode from 'vscode';
 import {
+  createCoreRegistryAdapter,
   createRegistryAdapter,
 } from '../adapters/infra-adapter-factory';
 import {
   IRepositoryAdapter,
 } from '../adapters/repository-adapter';
+import {
+  VsCodeSessionTokenProvider,
+} from '../adapters/vscode-session-token-provider';
 import {
   RegistryStorage,
 } from '../storage/registry-storage';
@@ -146,6 +170,8 @@ export class RegistryManager {
   private readonly adapters = new Map<string, IRepositoryAdapter>();
   private readonly versionConsolidator: VersionConsolidator;
   private sourcesCache: RegistrySource[] = [];
+  private readonly primitiveIndexKeyCache = new Map<string, { key: PrimitiveIndexKey; expiresAt: number }>();
+  private readonly primitiveIndexKeyRequests = new Map<string, Promise<PrimitiveIndexKey>>();
 
   // Event emitters
   private readonly _onBundleInstalled = new vscode.EventEmitter<InstalledBundle>();
@@ -195,6 +221,77 @@ export class RegistryManager {
     // Initialize version consolidator with source type resolver
     this.versionConsolidator = new VersionConsolidator();
     this.versionConsolidator.setSourceTypeResolver((sourceId: string) => this.getSourceType(sourceId));
+  }
+
+  private invalidatePrimitiveIndexKeyCache(): void {
+    this.primitiveIndexKeyCache.clear();
+  }
+
+  private async buildPrimitiveIndexKey(
+    searchProfileId: string,
+    resolveRemoteRevision = true
+  ): Promise<PrimitiveIndexKey> {
+    const sources = (await this.storage.getSources()).filter((source) => source.enabled);
+    const blobCache = new BlobCache(path.join(new XdgAppStorage().getPaths().cache, 'primitive-index-blobs'));
+    const snapshot = await Promise.all(sources.map(async (source) => {
+      const bundles = await this.storage.getCachedSourceBundles(source.id);
+      let fallbackRevision = createHash('sha256').update(JSON.stringify(bundles
+        .map((bundle) => ({
+          id: bundle.id,
+          version: bundle.version,
+          lastUpdated: bundle.lastUpdated,
+          readmeRevision: bundle.readmeRevision,
+          checksum: bundle.checksum
+        }))
+        .toSorted((a, b) => `${a.id}@${a.version}`.localeCompare(`${b.id}@${b.version}`)))).digest('hex');
+
+      if (resolveRemoteRevision) {
+        // Native GitHub harvesters use the repository head commit as the source
+        // revision. Resolve the same revision here so CLI and VS Code converge
+        // on one namespaced index instead of creating client-specific copies.
+        try {
+          const enrichedSource = this.enrichSourceWithGlobalToken(source);
+          const tokenProviders = [
+            ...(enrichedSource.token ? [new StaticTokenProvider(enrichedSource.token)] : []),
+            new VsCodeSessionTokenProvider(true),
+            new GhCliTokenProvider()
+          ];
+          const nativeProvider = createRegistrySourceBundleProvider({
+            source: enrichedSource,
+            client: new GitHubApiClient(new NodeHttpClient(), {
+              tokenProvider: new CompositeTokenProvider(tokenProviders)
+            }),
+            cache: blobCache
+          });
+          if (nativeProvider && 'getCommitSha' in nativeProvider
+            && typeof (nativeProvider as { getCommitSha?: unknown }).getCommitSha === 'function') {
+            fallbackRevision = await (nativeProvider as { getCommitSha: () => Promise<string> }).getCommitSha();
+          }
+        } catch (error) {
+          this.logger.debug(`Could not resolve primitive revision for source '${source.id}'; using cached catalog revision`, error);
+        }
+      }
+      return {
+        id: source.id,
+        type: source.type,
+        url: source.url,
+        hubId: source.hubId,
+        config: source.config,
+        revision: fallbackRevision
+      };
+    }));
+    const hubId = this.hubManager ? await this.hubManager.getActiveHubId() : null;
+    const sourceRevision = createSourceRevision(snapshot.map((source) => ({
+      sourceId: source.id,
+      url: source.url,
+      branch: typeof source.config?.branch === 'string' ? source.config.branch : 'main',
+      revision: source.revision
+    })));
+    return {
+      hubId: canonicalizeIndexHubId(hubId ?? 'registry'),
+      sourceRevision,
+      searchProfileId
+    };
   }
 
   /**
@@ -644,6 +741,7 @@ export class RegistryManager {
    */
   public setHubManager(hubManager: HubManager): void {
     this.hubManager = hubManager;
+    hubManager.onActiveHubChanged(() => this.invalidatePrimitiveIndexKeyCache());
   }
 
   /**
@@ -759,6 +857,7 @@ export class RegistryManager {
 
     // Update cache
     this.sourcesCache = await this.storage.getSources();
+    this.invalidatePrimitiveIndexKeyCache();
 
     this._onSourceAdded.fire(source);
     this.logger.info(`Source '${source.name}' added successfully`);
@@ -776,6 +875,7 @@ export class RegistryManager {
 
     // Update cache
     this.sourcesCache = await this.storage.getSources();
+    this.invalidatePrimitiveIndexKeyCache();
 
     this._onSourceRemoved.fire(sourceId);
     this.logger.info(`Source '${sourceId}' removed successfully`);
@@ -795,6 +895,7 @@ export class RegistryManager {
     this.adapters.delete(sourceId);
     const sources = await this.storage.getSources();
     this.sourcesCache = sources; // Update cache
+    this.invalidatePrimitiveIndexKeyCache();
 
     const updatedSource = sources.find((s) => s.id === sourceId);
 
@@ -813,6 +914,138 @@ export class RegistryManager {
    */
   public async listSources(): Promise<RegistrySource[]> {
     return await this.storage.getSources();
+  }
+
+  /**
+   * Return the identity of the currently searchable source snapshot.
+   * Cached bundle coordinates and source revisions make this change when a
+   * source sync changes the catalog, while the active hub keeps separate hub
+   * caches from being reused accidentally.
+   * @param searchProfileId
+   */
+  public async getPrimitiveIndexKey(searchProfileId: string): Promise<PrimitiveIndexKey> {
+    const cached = this.primitiveIndexKeyCache.get(searchProfileId);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.key;
+    }
+
+    const pending = this.primitiveIndexKeyRequests.get(searchProfileId);
+    if (pending) {
+      return pending;
+    }
+
+    const request = this.buildPrimitiveIndexKey(searchProfileId);
+    this.primitiveIndexKeyRequests.set(searchProfileId, request);
+    try {
+      const key = await request;
+      this.primitiveIndexKeyCache.set(searchProfileId, {
+        key,
+        // Coalesce repeated search/rebuild calls without allowing a source
+        // change to remain visible after the explicit invalidations above.
+        expiresAt: Date.now() + 30_000
+      });
+      return key;
+    } finally {
+      if (this.primitiveIndexKeyRequests.get(searchProfileId) === request) {
+        this.primitiveIndexKeyRequests.delete(searchProfileId);
+      }
+    }
+  }
+
+  /**
+   * Return an index key from locally cached source metadata only.
+   *
+   * Search uses this variant so resolving the physical persisted-index path
+   * never performs a GitHub/API revision lookup. Rebuilds continue to use
+   * `getPrimitiveIndexKey`, which resolves remote revisions for CLI/extension
+   * namespace convergence.
+   * @param searchProfileId
+   */
+  public async getCachedPrimitiveIndexKey(searchProfileId: string): Promise<PrimitiveIndexKey> {
+    const cacheKey = `${searchProfileId}:cached`;
+    const cached = this.primitiveIndexKeyCache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.key;
+    }
+
+    const pending = this.primitiveIndexKeyRequests.get(cacheKey);
+    if (pending) {
+      return pending;
+    }
+
+    const request = this.buildPrimitiveIndexKey(searchProfileId, false);
+    this.primitiveIndexKeyRequests.set(cacheKey, request);
+    try {
+      const key = await request;
+      this.primitiveIndexKeyCache.set(cacheKey, {
+        key,
+        expiresAt: Date.now() + 30_000
+      });
+      return key;
+    } finally {
+      if (this.primitiveIndexKeyRequests.get(cacheKey) === request) {
+        this.primitiveIndexKeyRequests.delete(cacheKey);
+      }
+    }
+  }
+
+  /**
+   * Create a shared primitive-harvest provider over all enabled sources.
+   * Source catalog metadata and archive extraction are translated by infra;
+   * the index/search strategy remains in the shared app packages.
+   */
+  public async createPrimitiveBundleProvider(): Promise<BundleProvider> {
+    const sources = await this.storage.getSources();
+    const blobCache = new BlobCache(path.join(new XdgAppStorage().getPaths().cache, 'primitive-index-blobs'));
+    const entries = sources
+      .filter((source) => source.enabled)
+      .flatMap((source) => {
+        // Plugin sources are not part of the extension registry source union
+        // yet; do not route them through the catalog adapter as a semantic
+        // primitive provider until their native plugin tree is implemented.
+        if ((source.type as string) === 'awesome-copilot-plugin') {
+          return [];
+        }
+        try {
+          const enrichedSource = this.enrichSourceWithGlobalToken(source);
+          const tokenProviders = [
+            ...(enrichedSource.token ? [new StaticTokenProvider(enrichedSource.token)] : []),
+            new VsCodeSessionTokenProvider(true),
+            new GhCliTokenProvider()
+          ];
+          const nativeProvider = createRegistrySourceBundleProvider({
+            source: enrichedSource,
+            client: new GitHubApiClient(new NodeHttpClient(), {
+              tokenProvider: new CompositeTokenProvider(tokenProviders)
+            }),
+            cache: blobCache
+          });
+          if (nativeProvider) {
+            return [{ sourceId: source.id, provider: nativeProvider }];
+          }
+          return [{
+            sourceId: source.id,
+            provider: new SourceAdapterBundleProvider({
+              adapter: createCoreRegistryAdapter(enrichedSource),
+              // Installation state is deliberately applied at query time so the
+              // persisted semantic index remains reusable after install changes.
+              isInstalled: () => false
+            })
+          }];
+        } catch (error) {
+          this.logger.warn(
+            `Skipping source '${source.id}' from primitive index: ${error instanceof Error ? error.message : String(error)}`
+          );
+          return [];
+        }
+      });
+    return new CompositeBundleProvider(entries, {
+      onSourceError: (sourceId, error) => {
+        this.logger.warn(
+          `Skipping source '${sourceId}' during primitive indexing: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    });
   }
 
   /**
@@ -850,6 +1083,7 @@ export class RegistryManager {
 
     // Cache bundles
     await this.storage.cacheSourceBundles(sourceId, bundles);
+    this.invalidatePrimitiveIndexKeyCache();
 
     this.logger.info(`Source '${sourceId}' synced. Found ${bundles.length} bundles.`);
 

--- a/apps/vscode-extension/src/services/update-checker.ts
+++ b/apps/vscode-extension/src/services/update-checker.ts
@@ -84,9 +84,10 @@ export class UpdateChecker {
    * Uses cache if available and valid, otherwise queries RegistryManager
    * Enriches results with auto-update preferences
    * @param bypassCache
+   * @param syncSources
    */
-  public async checkForUpdates(bypassCache = false): Promise<UpdateCheckResult[]> {
-    return this.core.checkForUpdates(bypassCache);
+  public async checkForUpdates(bypassCache = false, syncSources = true): Promise<UpdateCheckResult[]> {
+    return this.core.checkForUpdates(bypassCache, syncSources);
   }
 
   /**

--- a/apps/vscode-extension/src/services/update-scheduler.ts
+++ b/apps/vscode-extension/src/services/update-scheduler.ts
@@ -71,7 +71,9 @@ export class UpdateScheduler {
     private readonly context: vscode.ExtensionContext,
     updateChecker: UpdateChecker,
     bundleNameResolver?: (bundleId: string) => Promise<string>,
-    autoUpdateService?: AutoUpdateService
+    autoUpdateService?: AutoUpdateService,
+    private readonly startupCheckReady?: Promise<void>,
+    private readonly startupSourceSyncRequired: () => boolean = () => true
   ) {
     this.updateChecker = updateChecker;
     this.bundleNotifications = new BundleUpdateNotifications(bundleNameResolver);
@@ -114,8 +116,12 @@ export class UpdateScheduler {
 
     this.startupCheckTimer = setTimeout(async () => {
       try {
+        // The initial hub sync updates the same GitHub source cache used by the
+        // update checker. Wait for it before checking so activation cannot start
+        // a second, overlapping source synchronization pass.
+        await this.startupCheckReady;
         this.logger.info('Performing startup update check');
-        await this.performUpdateCheck();
+        await this.performUpdateCheck(false, this.startupSourceSyncRequired());
       } catch (error) {
         this.logger.error('Startup update check failed', error as Error);
       } finally {
@@ -128,14 +134,15 @@ export class UpdateScheduler {
    * Perform an update check with timeout protection
    * CRITICAL: Triggers notifications when updates are detected
    * @param bypassCache
+   * @param syncSources
    */
-  private async performUpdateCheck(bypassCache = false): Promise<void> {
+  private async performUpdateCheck(bypassCache = false, syncSources = true): Promise<void> {
     let timeoutHandle: NodeJS.Timeout | undefined;
     let checkPromise: Promise<any>;
 
     if (this.isTestEnvironment) {
       // In test environment, avoid creating long-lived timers that can cause test hangs
-      checkPromise = this.updateChecker.checkForUpdates(bypassCache);
+      checkPromise = this.updateChecker.checkForUpdates(bypassCache, syncSources);
     } else {
       // Add timeout protection for update checks in normal operation
       const timeoutPromise = new Promise<never>((_, reject) => {
@@ -146,7 +153,7 @@ export class UpdateScheduler {
       });
 
       checkPromise = Promise.race([
-        this.updateChecker.checkForUpdates(bypassCache),
+        this.updateChecker.checkForUpdates(bypassCache, syncSources),
         timeoutPromise
       ]);
     }

--- a/apps/vscode-extension/src/ui/marketplace-view-provider.ts
+++ b/apps/vscode-extension/src/ui/marketplace-view-provider.ts
@@ -5,9 +5,15 @@
  */
 
 import * as fs from 'node:fs';
+import {
+  resolveBundleSearchKeys,
+} from '@ai-primitives-hub/app';
 import MarkdownIt from 'markdown-it';
 import sanitizeHtml from 'sanitize-html';
 import * as vscode from 'vscode';
+import {
+  PrimitiveIndexService,
+} from '../services/primitive-index-service';
 import {
   RegistryManager,
 } from '../services/registry-manager';
@@ -47,7 +53,7 @@ import {
  * Message types sent from webview to extension
  */
 interface WebviewMessage {
-  type: 'ready' | 'refresh' | 'install' | 'update' | 'uninstall' | 'openDetails' | 'openPromptFile' | 'installVersion'
+  type: 'ready' | 'refresh' | 'search' | 'install' | 'update' | 'uninstall' | 'openDetails' | 'openPromptFile' | 'installVersion'
     | 'getVersions' | 'toggleAutoUpdate' | 'openSourceRepository' | 'completeSetup' | 'openExternalLink';
   bundleId?: string;
   installPath?: string;
@@ -56,6 +62,7 @@ interface WebviewMessage {
   enabled?: boolean;
   sourceId?: string;
   url?: string;
+  query?: string;
 }
 
 /**
@@ -81,6 +88,20 @@ interface BundlesLoadedMessage {
   sourcesCount: number;
 }
 
+interface PrimitiveSearchDiagnostics {
+  profile: string;
+  ranking: string;
+  embeddings: boolean;
+  primitiveHits: number;
+  bundleHits: number;
+  error?: string;
+}
+
+interface MarketplaceBundleIdentity {
+  sourceId: string;
+  bundleId: string;
+}
+
 export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
   public static readonly viewType = 'promptregistry.marketplace';
 
@@ -96,6 +117,7 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
 
   private isLoadingBundles = false;
   private loadBundlesPending = false;
+  private primitiveSearchGeneration = 0;
   private disposables: vscode.Disposable[] = [];
   private markDownIt: InstanceType<typeof MarkdownIt> | undefined;
   private readonly sanitizeOptions: sanitizeHtml.IOptions = {
@@ -133,7 +155,8 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
   constructor(
     private readonly context: vscode.ExtensionContext,
     private readonly registryManager: RegistryManager,
-    private readonly setupStateManager: SetupStateManager
+    private readonly setupStateManager: SetupStateManager,
+    private readonly primitiveIndexService?: PrimitiveIndexService
   ) {
     this.logger = Logger.getInstance();
 
@@ -160,7 +183,10 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
       this.registryManager.onAutoUpdatePreferenceChanged(() => this.loadBundles()),
       // Repository bundle changes (lockfile changes, workspace folder changes)
       this.registryManager.onRepositoryBundlesChanged(() => this.loadBundles()),
-      this.registryManager.onReadmeDownloaded(() => this.loadBundles())
+      // README hydration emits one event per completed download batch. Route
+      // those events through the same throttle as source syncs so progressive
+      // hydration cannot start a marketplace load for every batch.
+      this.registryManager.onReadmeDownloaded(() => this.sourceSyncThrottle.trigger())
     );
   }
 
@@ -543,6 +569,12 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
    * @param message
    */
   private async handleMessage(message: WebviewMessage): Promise<void> {
+    if (message.type === 'search') {
+      this.logger.info(
+        `Marketplace search event received query="${message.query ?? ''}" `
+        + `service=${String(this.primitiveIndexService !== undefined)} view=${String(this._view !== undefined)}`
+      );
+    }
     switch (message.type) {
       case 'ready': {
         this.webviewReady = true;
@@ -552,6 +584,10 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
       }
       case 'refresh': {
         await this.loadBundles();
+        break;
+      }
+      case 'search': {
+        await this.handlePrimitiveSearch(message.query ?? '');
         break;
       }
       case 'install': {
@@ -623,6 +659,110 @@ export class MarketplaceViewProvider implements vscode.WebviewViewProvider {
         this.logger.warn(`Unknown message type: ${message.type}`);
       }
     }
+  }
+
+  /**
+   * Resolve free-text marketplace search to ranked bundle identities.
+   * @param query
+   */
+  private async handlePrimitiveSearch(query: string): Promise<void> {
+    const searchGeneration = ++this.primitiveSearchGeneration;
+    if (!this.primitiveIndexService || !this._view) {
+      this.logger.warn(
+        `Marketplace semantic search skipped service=${String(this.primitiveIndexService !== undefined)} `
+        + `view=${String(this._view !== undefined)}`
+      );
+      return;
+    }
+
+    const normalizedQuery = query.trim();
+    if (!normalizedQuery) {
+      await this._view.webview.postMessage({
+        type: 'primitiveSearchResults',
+        query,
+        bundleKeys: null
+      });
+      return;
+    }
+
+    try {
+      this.logger.info(`Marketplace semantic search started profile=${this.primitiveIndexService.getProfile()} query="${normalizedQuery}"`);
+      // Marketplace search is deliberately read-only: source synchronization
+      // and index rebuilds are owned by the extension lifecycle. Do not call
+      // ensureBuilt() here because a missing snapshot must not trigger a
+      // provider enumeration or remote-source interaction on a keystroke.
+      const result = await this.primitiveIndexService.search({ q: normalizedQuery, limit: 200 });
+      this.logger.info(`Marketplace semantic search query completed profile=${this.primitiveIndexService.getProfile()} query="${normalizedQuery}"`);
+      if (searchGeneration !== this.primitiveSearchGeneration) {
+        this.logger.debug(`Ignoring stale Marketplace semantic search result query="${normalizedQuery}"`);
+        return;
+      }
+      const catalogBundles = this.getMarketplaceBundleIdentities();
+      const bundleKeys = resolveBundleSearchKeys(
+        result.hits.map((hit) => ({
+          sourceId: hit.primitive.bundle.sourceId,
+          bundleId: hit.primitive.bundle.bundleId
+        })),
+        catalogBundles
+      );
+      const diagnostics: PrimitiveSearchDiagnostics = {
+        profile: result.searchProfileId ?? this.primitiveIndexService.getProfile(),
+        ranking: result.ranking ?? 'unknown',
+        embeddings: result.embeddingUsed === true,
+        primitiveHits: result.hits.length,
+        bundleHits: bundleKeys.length
+      };
+      this.logger.info(
+        `Primitive semantic search profile=${result.searchProfileId ?? this.primitiveIndexService.getProfile()} `
+        + `ranking=${result.ranking ?? 'unknown'} embeddings=${String(result.embeddingUsed === true)} query="${normalizedQuery}" `
+        + `primitiveHits=${String(result.hits.length)} bundleHits=${String(bundleKeys.length)}`
+      );
+      const delivered = await this._view.webview.postMessage({
+        type: 'primitiveSearchResults',
+        query,
+        bundleKeys,
+        diagnostics
+      });
+      this.logger.info(
+        `Marketplace semantic search results delivered=${String(delivered)} query="${normalizedQuery}" `
+        + `catalogBundles=${String(catalogBundles.length)} bundleHits=${String(bundleKeys.length)}`
+      );
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      this.logger.warn(`Marketplace indexed search unavailable; using metadata search: ${reason}`);
+      await this._view.webview.postMessage({
+        type: 'primitiveSearchResults',
+        query,
+        bundleKeys: null,
+        diagnostics: {
+          profile: this.primitiveIndexService.getProfile(),
+          ranking: 'unavailable',
+          embeddings: false,
+          primitiveHits: 0,
+          bundleHits: 0,
+          error: reason
+        }
+      });
+    }
+  }
+
+  /**
+   * Return the exact catalog snapshot currently rendered by the webview.
+   * Searching the registry again here can produce a different consolidated
+   * version/source snapshot from `latestBundlesMessage`, making valid semantic
+   * keys invisible to the UI. Keep projection on the rendered snapshot.
+   */
+  private getMarketplaceBundleIdentities(): MarketplaceBundleIdentity[] {
+    const bundles = this.latestBundlesMessage?.bundles ?? [];
+    return bundles.flatMap((bundle) => {
+      if (!bundle || typeof bundle !== 'object') {
+        return [];
+      }
+      const candidate = bundle as { sourceId?: unknown; id?: unknown };
+      return typeof candidate.sourceId === 'string' && typeof candidate.id === 'string'
+        ? [{ sourceId: candidate.sourceId, bundleId: candidate.id }]
+        : [];
+    });
   }
 
   /**

--- a/apps/vscode-extension/src/ui/webview/marketplace/marketplace.css
+++ b/apps/vscode-extension/src/ui/webview/marketplace/marketplace.css
@@ -55,6 +55,25 @@ body {
     outline-offset: -1px;
 }
 
+.search-status {
+    min-height: 16px;
+    margin: -12px 0 12px;
+    color: var(--vscode-descriptionForeground);
+    font-size: 11px;
+}
+
+.search-status.active {
+    color: var(--vscode-testing-iconPassed);
+}
+
+.search-status.searching {
+    color: var(--vscode-charts-blue);
+}
+
+.search-status.unavailable {
+    color: var(--vscode-editorWarning-foreground);
+}
+
 .filter-group {
     display: flex;
     align-items: center;

--- a/apps/vscode-extension/src/ui/webview/marketplace/marketplace.html
+++ b/apps/vscode-extension/src/ui/webview/marketplace/marketplace.html
@@ -64,6 +64,8 @@
         <button class="refresh-btn" id="refreshBtn">Refresh</button>
     </div>
 
+    <div id="searchStatus" class="search-status" role="status" aria-live="polite"></div>
+
     <div id="marketplace" class="marketplace-grid">
         <div class="loading">
             <div class="spinner"></div>

--- a/apps/vscode-extension/src/ui/webview/marketplace/marketplace.js
+++ b/apps/vscode-extension/src/ui/webview/marketplace/marketplace.js
@@ -8,6 +8,9 @@
   let selectedSource = 'all';
   let selectedTags = [];
   let showInstalledOnly = false;
+  let indexedBundleKeys = null;
+  let indexedSearchQuery = null;
+  let searchRequestTimer;
   let setupState = 'complete'; // Default to complete to avoid showing setup prompt unnecessarily
   let sourcesCount = 0;
 
@@ -22,6 +25,15 @@
       sourcesCount = message.sourcesCount || 0;
       updateFilterUI();
       renderBundles();
+    }
+    if (message.type === 'primitiveSearchResults') {
+      var currentQuery = document.querySelector('#searchBox').value;
+      if (message.query === currentQuery) {
+        indexedBundleKeys = message.bundleKeys;
+        indexedSearchQuery = message.bundleKeys === null ? null : currentQuery;
+        renderSearchStatus(message.diagnostics, currentQuery);
+        renderBundles();
+      }
     }
   });
 
@@ -170,9 +182,44 @@
   });
 
   // Search functionality
-  document.querySelector('#searchBox').addEventListener('input', () => {
+  document.querySelector('#searchBox').addEventListener('input', (event) => {
+    indexedBundleKeys = null;
+    indexedSearchQuery = null;
+    renderSearchStatus({ state: 'searching' }, event.target.value);
     renderBundles();
+    clearTimeout(searchRequestTimer);
+    searchRequestTimer = setTimeout(() => {
+      vscode.postMessage({ type: 'search', query: event.target.value });
+    }, 250);
   });
+
+  const renderSearchStatus = (diagnostics, query) => {
+    var status = document.querySelector('#searchStatus');
+    if (!status) {
+      return;
+    }
+    if (!query || query.trim() === '') {
+      status.textContent = '';
+      status.className = 'search-status';
+      return;
+    }
+    if (diagnostics?.state === 'searching') {
+      status.textContent = 'Semantic search: searching…';
+      status.className = 'search-status searching';
+      return;
+    }
+    if (diagnostics?.ranking === 'unavailable') {
+      status.textContent = 'Semantic search unavailable; using metadata search';
+      status.className = 'search-status unavailable';
+      return;
+    }
+    var embeddingLabel = diagnostics?.embeddings ? 'embeddings on' : 'BM25 only';
+    status.textContent = 'Semantic search: ' + (diagnostics?.profile || 'unknown')
+      + ' • ' + (diagnostics?.ranking || 'unknown')
+      + ' • ' + embeddingLabel
+      + ' • ' + String(diagnostics?.bundleHits ?? 0) + ' bundles';
+    status.className = 'search-status active';
+  };
 
   // Source selector button click
   document.querySelector('#sourceSelectorBtn').addEventListener('click', (e) => {
@@ -347,15 +394,22 @@
 
     // Apply search filter
     if (searchTerm && searchTerm.trim() !== '') {
-      var term = searchTerm.toLowerCase();
-      filteredBundles = filteredBundles.filter((bundle) => {
-        return bundle.name.toLowerCase().includes(term)
-          || bundle.description.toLowerCase().includes(term)
-          || (bundle.tags && bundle.tags.some((tag) => {
-            return tag.toLowerCase().includes(term);
-          }))
-          || (bundle.author && bundle.author.toLowerCase().includes(term));
-      });
+      if (indexedSearchQuery === searchTerm && indexedBundleKeys !== null) {
+        var indexedOrder = new Map(indexedBundleKeys.map((key, index) => [key, index]));
+        filteredBundles = filteredBundles
+          .filter((bundle) => indexedOrder.has(bundle.sourceId + '\u0000' + bundle.id))
+          .toSorted((left, right) => indexedOrder.get(left.sourceId + '\u0000' + left.id) - indexedOrder.get(right.sourceId + '\u0000' + right.id));
+      } else {
+        var term = searchTerm.toLowerCase();
+        filteredBundles = filteredBundles.filter((bundle) => {
+          return bundle.name.toLowerCase().includes(term)
+            || bundle.description.toLowerCase().includes(term)
+            || (bundle.tags && bundle.tags.some((tag) => {
+              return tag.toLowerCase().includes(term);
+            }))
+            || (bundle.author && bundle.author.toLowerCase().includes(term));
+        });
+      }
     }
 
     if (filteredBundles.length === 0) {

--- a/apps/vscode-extension/test/adapters/vscode-session-token-provider.test.ts
+++ b/apps/vscode-extension/test/adapters/vscode-session-token-provider.test.ts
@@ -15,10 +15,12 @@ suite('VsCodeSessionTokenProvider', () => {
 
   setup(() => {
     sandbox = sinon.createSandbox();
+    VsCodeSessionTokenProvider.clearCache();
     getSessionStub = sandbox.stub(vscode.authentication, 'getSession');
   });
 
   teardown(() => {
+    VsCodeSessionTokenProvider.clearCache();
     sandbox.restore();
   });
 
@@ -92,5 +94,29 @@ suite('VsCodeSessionTokenProvider', () => {
     await provider.getToken('github.com');
 
     assert.ok(getSessionStub.calledWith('github', ['repo'], { createIfNone: false }));
+  });
+
+  test('deduplicates concurrent GitHub session requests across provider instances', async () => {
+    let release!: () => void;
+    const sessionReady = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    getSessionStub.callsFake(async () => {
+      await sessionReady;
+      return {
+        accessToken: 'gho_shared',
+        account: { id: 'test', label: 'test' },
+        id: 'session-id',
+        scopes: ['repo']
+      };
+    });
+
+    const requests = Array.from({ length: 20 }, () => new VsCodeSessionTokenProvider().getToken('github.com'));
+    await Promise.resolve();
+    assert.strictEqual(getSessionStub.callCount, 1);
+    release();
+
+    const tokens = await Promise.all(requests);
+    assert.ok(tokens.every((token) => token === 'gho_shared'));
   });
 });

--- a/apps/vscode-extension/test/commands/primitive-search-command.test.ts
+++ b/apps/vscode-extension/test/commands/primitive-search-command.test.ts
@@ -1,0 +1,60 @@
+import * as assert from 'node:assert';
+import type {
+  BuildIndexResult,
+} from '@ai-primitives-hub/app';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import {
+  PrimitiveSearchCommand,
+} from '../../src/commands/primitive-search-command';
+import type {
+  PrimitiveIndexService,
+} from '../../src/services/primitive-index-service';
+
+suite('PrimitiveSearchCommand', () => {
+  let sandbox: sinon.SinonSandbox;
+
+  setup(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  teardown(() => {
+    sandbox.restore();
+  });
+
+  test('shows progress and completion feedback while rebuilding the index', async () => {
+    const result: BuildIndexResult = {
+      outFile: '/tmp/primitive-index.v2.json',
+      primitives: 12,
+      bundles: 3,
+      report: {
+        state: 'ready',
+        sourceCoverage: [],
+        primitives: 12,
+        bundles: 3,
+        elapsedMs: 0
+      }
+    };
+    const rebuild = sandbox.stub().resolves(result);
+    const indexService = {
+      getProfile: () => 'ternlight-dual-v1',
+      rebuild
+    } as unknown as PrimitiveIndexService;
+    const withProgress = sandbox.stub(vscode.window, 'withProgress').callsFake(async (options, task) => {
+      assert.strictEqual(options.location, vscode.ProgressLocation.Notification);
+      assert.strictEqual(options.title, 'Rebuilding Primitive Index');
+      assert.strictEqual(options.cancellable, false);
+      return task({ report: sandbox.stub() }, {} as vscode.CancellationToken);
+    });
+    const showInformationMessage = sandbox.stub(vscode.window, 'showInformationMessage').resolves();
+
+    await new PrimitiveSearchCommand(indexService).rebuild();
+
+    assert.strictEqual(withProgress.callCount, 1);
+    assert.strictEqual(rebuild.callCount, 1);
+    assert.strictEqual(
+      showInformationMessage.firstCall.args[0],
+      'Primitive index rebuilt: 12 primitives from 3 bundles.'
+    );
+  });
+});

--- a/apps/vscode-extension/test/services/primitive-index-service.test.ts
+++ b/apps/vscode-extension/test/services/primitive-index-service.test.ts
@@ -1,0 +1,265 @@
+import * as assert from 'node:assert';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  LocalFolderBundleProvider,
+} from '@ai-primitives-hub/infra';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import {
+  PrimitiveIndexService,
+} from '../../src/services/primitive-index-service';
+import {
+  Logger,
+} from '../../src/utils/logger';
+
+suite('PrimitiveIndexService', () => {
+  let tempDir: string;
+  let bundleDir: string;
+  let context: vscode.ExtensionContext;
+
+  setup(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'primitive-index-service-'));
+    bundleDir = path.join(tempDir, 'local-bundle');
+    await fs.mkdir(path.join(bundleDir, 'prompts'), { recursive: true });
+    await fs.writeFile(
+      path.join(bundleDir, 'deployment-manifest.yml'),
+      'id: local-bundle\nversion: 1.0.0\nname: Local Bundle\nitems:\n  - path: prompts/hello.prompt.md\n    kind: prompt\n'
+    );
+    await fs.writeFile(
+      path.join(bundleDir, 'prompts', 'hello.prompt.md'),
+      '# Hello Prompt\n\nA diagnostic prompt.\n'
+    );
+    context = {
+      globalStorageUri: vscode.Uri.file(path.join(tempDir, 'extension-storage')),
+      globalState: {} as any,
+      subscriptions: []
+    } as any as vscode.ExtensionContext;
+  });
+
+  teardown(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  test('uses the app search use cases with one configured profile', async () => {
+    const indexPath = path.join(tempDir, 'index.json');
+    const service = new PrimitiveIndexService(context, {
+      profile: 'bm25-v1',
+      indexPath,
+      providerFactory: () => new LocalFolderBundleProvider({ root: tempDir, sourceId: 'local' })
+    });
+
+    const build = await service.rebuild();
+    const result = await service.search({ q: 'hello', limit: 5 });
+
+    assert.strictEqual(service.getProfile(), 'bm25-v1');
+    assert.strictEqual(service.getIndexPath(), indexPath);
+    assert.strictEqual(build.primitives, 1);
+    assert.strictEqual(result.hits.length, 1);
+    assert.strictEqual(result.hits[0]?.primitive.title, 'Hello Prompt');
+  });
+
+  test('logs rebuild start, build progress, and completion', async () => {
+    const info = sinon.stub(Logger.getInstance(), 'info');
+    const indexPath = path.join(tempDir, 'index-with-progress.json');
+    const service = new PrimitiveIndexService(context, {
+      profile: 'bm25-v1',
+      indexPath,
+      providerFactory: () => new LocalFolderBundleProvider({ root: tempDir, sourceId: 'local' })
+    });
+
+    try {
+      await service.rebuild();
+
+      assert.ok(info.calledWith('Primitive index rebuild started (profile=bm25-v1)'));
+      assert.ok(info.args.some(([message]) => String(message).includes('harvested 1 primitive from 1 bundle')));
+      assert.ok(info.args.some(([message]) => String(message).includes('building BM25 index and facet maps')));
+      assert.ok(info.args.some(([message]) => String(message).includes('Primitive index rebuild completed: 1 primitive from 1 bundle')));
+    } finally {
+      info.restore();
+    }
+  });
+
+  test('searches a prebuilt index without invoking the bundle provider', async () => {
+    const indexPath = path.join(tempDir, 'prebuilt-index.json');
+    const builder = new PrimitiveIndexService(context, {
+      profile: 'bm25-v1',
+      indexPath,
+      providerFactory: () => new LocalFolderBundleProvider({ root: tempDir, sourceId: 'local' })
+    });
+    await builder.rebuild();
+
+    let providerCalls = 0;
+    const searcher = new PrimitiveIndexService(context, {
+      profile: 'bm25-v1',
+      indexPath,
+      providerFactory: () => {
+        providerCalls += 1;
+        throw new Error('provider must not be called during search');
+      }
+    });
+
+    const result = await searcher.search({ q: 'hello', limit: 5 });
+
+    assert.strictEqual(providerCalls, 0);
+    assert.strictEqual(result.hits.length, 1);
+    assert.strictEqual(result.hits[0]?.primitive.title, 'Hello Prompt');
+  });
+
+  test('uses the local-only search key provider instead of the rebuild key provider', async () => {
+    const indexPath = path.join(tempDir, 'prebuilt-namespaced-index.json');
+    const builder = new PrimitiveIndexService(context, {
+      profile: 'bm25-v1',
+      indexPath,
+      providerFactory: () => new LocalFolderBundleProvider({ root: tempDir, sourceId: 'local' })
+    });
+    await builder.rebuild();
+
+    const searcher = new PrimitiveIndexService(context, {
+      profile: 'bm25-v1',
+      indexStore: {
+        getIndexPath: () => indexPath
+      },
+      indexKeyProvider: async () => {
+        throw new Error('remote-aware key provider must not be called during search');
+      },
+      searchIndexKeyProvider: async () => ({
+        hubId: 'my-hub-id',
+        sourceRevision: 'cached',
+        searchProfileId: 'bm25-v1'
+      }),
+      providerFactory: () => {
+        throw new Error('provider must not be called during search');
+      }
+    });
+
+    const result = await searcher.search({ q: 'hello', limit: 5 });
+
+    assert.strictEqual(result.hits.length, 1);
+    assert.strictEqual(result.hits[0]?.primitive.title, 'Hello Prompt');
+  });
+
+  test('uses the extension app-storage cache by default', () => {
+    const service = new PrimitiveIndexService(context, {
+      profile: 'bm25-v1',
+      providerFactory: () => new LocalFolderBundleProvider({ root: bundleDir, sourceId: 'local' })
+    });
+
+    assert.strictEqual(
+      service.getIndexPath(),
+      path.join(tempDir, 'extension-storage', 'cache', 'primitive-index.json')
+    );
+  });
+
+  test('uses an injected namespaced index store', () => {
+    const indexPath = path.join(tempDir, 'shared', 'primitive-index.v2.json');
+    const service = new PrimitiveIndexService(context, {
+      profile: 'bm25-v1',
+      indexStore: {
+        getIndexPath: () => indexPath
+      },
+      providerFactory: () => new LocalFolderBundleProvider({ root: bundleDir, sourceId: 'local' })
+    });
+
+    assert.strictEqual(service.getIndexPath(), indexPath);
+  });
+
+  test('reads the legacy cache until a namespaced index is available', async () => {
+    const legacyService = new PrimitiveIndexService(context, {
+      profile: 'bm25-v1',
+      providerFactory: () => new LocalFolderBundleProvider({ root: tempDir, sourceId: 'local' })
+    });
+    await legacyService.rebuild();
+    const legacyResult = await legacyService.search({ q: 'hello', limit: 5 });
+    assert.strictEqual(legacyResult.hits.length, 1);
+
+    const namespacedService = new PrimitiveIndexService(context, {
+      profile: 'bm25-v1',
+      indexStore: {
+        getIndexPath: () => path.join(tempDir, 'shared', 'primitive-index.v2.json')
+      },
+      providerFactory: () => new LocalFolderBundleProvider({ root: tempDir, sourceId: 'local' })
+    });
+
+    await namespacedService.ensureBuilt();
+    const result = await namespacedService.search({ q: 'hello', limit: 5 });
+
+    assert.strictEqual(result.hits.length, 1);
+    assert.strictEqual(result.hits[0]?.primitive.title, 'Hello Prompt');
+  });
+
+  test('does not use a legacy BM25 cache for an embedding profile', async () => {
+    const legacyService = new PrimitiveIndexService(context, {
+      profile: 'bm25-v1',
+      providerFactory: () => new LocalFolderBundleProvider({ root: tempDir, sourceId: 'local' })
+    });
+    await legacyService.rebuild();
+
+    const embeddingService = new PrimitiveIndexService(context, {
+      profile: 'ternlight-dual-v1',
+      indexStore: {
+        getIndexPath: () => path.join(tempDir, 'dual', 'primitive-index.v2.json')
+      },
+      providerFactory: () => new LocalFolderBundleProvider({ root: tempDir, sourceId: 'local' })
+    });
+
+    await assert.rejects(
+      embeddingService.search({ q: 'hello', limit: 5 }),
+      (error: unknown) => error instanceof Error && error.message.includes('primitive-index.v2.json')
+    );
+  });
+
+  test('uses the newest non-empty snapshot when the current snapshot is empty', async () => {
+    const fallbackService = new PrimitiveIndexService(context, {
+      profile: 'bm25-v1',
+      providerFactory: () => new LocalFolderBundleProvider({ root: tempDir, sourceId: 'local' })
+    });
+    await fallbackService.rebuild();
+
+    const currentPath = path.join(tempDir, 'current', 'primitive-index.v2.json');
+    await fs.mkdir(path.dirname(currentPath), { recursive: true });
+    await fs.writeFile(currentPath, JSON.stringify({ primitives: [] }));
+    const service = new PrimitiveIndexService(context, {
+      profile: 'bm25-v1',
+      indexStore: {
+        getIndexPath: () => currentPath,
+        findLatestIndexPath: async () => fallbackService.getIndexPath()
+      },
+      providerFactory: () => new LocalFolderBundleProvider({ root: tempDir, sourceId: 'local' })
+    });
+
+    const result = await service.search({ q: 'hello', limit: 5 });
+
+    assert.strictEqual(result.hits.length, 1);
+    assert.strictEqual(result.hits[0]?.primitive.title, 'Hello Prompt');
+  });
+
+  test('waits for initial source sync and recovers an empty persisted index', async () => {
+    const indexPath = path.join(tempDir, 'empty-index.json');
+    await fs.writeFile(indexPath, JSON.stringify({ primitives: [] }));
+    let releaseReady!: () => void;
+    const ready = new Promise<void>((resolve) => {
+      releaseReady = resolve;
+    });
+    let buildCalls = 0;
+    const service = new PrimitiveIndexService(context, {
+      profile: 'bm25-v1',
+      indexPath,
+      initializationReady: ready,
+      providerFactory: () => {
+        buildCalls += 1;
+        return new LocalFolderBundleProvider({ root: tempDir, sourceId: 'local' });
+      }
+    });
+
+    const ensure = service.ensureBuilt();
+    await Promise.resolve();
+    assert.strictEqual(buildCalls, 0);
+    releaseReady();
+    await ensure;
+    assert.strictEqual(buildCalls, 1);
+    const result = await service.search({ q: 'hello', limit: 5 });
+    assert.strictEqual(result.hits.length, 1);
+  });
+});

--- a/apps/vscode-extension/test/services/registry-manager.test.ts
+++ b/apps/vscode-extension/test/services/registry-manager.test.ts
@@ -6,6 +6,9 @@
  */
 
 import * as assert from 'node:assert';
+import {
+  GitHubApiClient,
+} from '@ai-primitives-hub/infra';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import * as InfraAdapterFactory from '../../src/adapters/infra-adapter-factory';
@@ -1238,5 +1241,99 @@ suite('RegistryManager - Adapter Cache Clearing', () => {
       registryManager.clearAdapterCache('source-1');
       registryManager.clearAdapterCache('');
     });
+  });
+});
+
+suite('RegistryManager - Primitive Index Source Selection', () => {
+  let sandbox: sinon.SinonSandbox;
+  let mockContext: vscode.ExtensionContext;
+  let registryManager: RegistryManager;
+  let mockStorage: sinon.SinonStubbedInstance<RegistryStorage>;
+
+  setup(() => {
+    sandbox = sinon.createSandbox();
+    mockContext = {
+      globalState: {
+        get: sandbox.stub(),
+        update: sandbox.stub().resolves(),
+        keys: sandbox.stub().returns([]),
+        setKeysForSync: sandbox.stub()
+      } as any,
+      workspaceState: {
+        get: sandbox.stub(),
+        update: sandbox.stub().resolves(),
+        keys: sandbox.stub().returns([]),
+        setKeysForSync: sandbox.stub()
+      } as any,
+      subscriptions: [],
+      extensionPath: '/mock/path',
+      extensionUri: vscode.Uri.file('/mock/path'),
+      storageUri: vscode.Uri.file('/mock/storage'),
+      globalStorageUri: vscode.Uri.file('/mock/global'),
+      asAbsolutePath: (p: string) => `/mock/path/${p}`
+    } as any;
+
+    registryManager = RegistryManager.getInstance(mockContext);
+    mockStorage = sandbox.createStubInstance(RegistryStorage);
+    (registryManager as any).storage = mockStorage;
+  });
+
+  teardown(() => {
+    sandbox.restore();
+  });
+
+  test('uses native primitive providers for supported GitHub source types', async () => {
+    const sources = [
+      {
+        id: 'awesome-copilot',
+        name: 'Awesome Copilot',
+        type: 'awesome-copilot' as const,
+        url: 'https://github.com/github/awesome-copilot',
+        enabled: true,
+        priority: 0
+      },
+      {
+        id: 'awesome-copilot-plugin',
+        name: 'Awesome Copilot Plugin',
+        type: 'awesome-copilot-plugin' as RegistrySource['type'],
+        url: 'https://github.com/example/plugins',
+        enabled: true,
+        priority: 0
+      },
+      {
+        id: 'supported-source',
+        name: 'Supported Source',
+        type: 'github' as const,
+        url: 'https://github.com/example/supported',
+        enabled: true,
+        priority: 0
+      }
+    ] as RegistrySource[];
+    mockStorage.getSources.resolves(sources);
+    sandbox.stub(GitHubApiClient.prototype, 'getJson').callsFake(async (url) => {
+      if (url.includes('/commits/')) {
+        return { sha: 'test-sha' };
+      }
+      return { tree: [] };
+    });
+
+    const createdSourceIds: string[] = [];
+    sandbox.stub(InfraAdapterFactory, 'createCoreRegistryAdapter').callsFake((source) => {
+      createdSourceIds.push(source.id);
+      return {
+        source,
+        fetchBundles: async () => [{ id: 'bundle', version: '1.0.0' }]
+      } as any;
+    });
+
+    const provider = await registryManager.createPrimitiveBundleProvider();
+    const refs = [];
+    for await (const ref of provider.listBundles()) {
+      refs.push(ref);
+    }
+
+    assert.deepStrictEqual(createdSourceIds, []);
+    assert.strictEqual(refs.length, 1);
+    assert.strictEqual(refs[0].sourceId, 'supported-source');
   });
 });

--- a/apps/vscode-extension/test/services/update-system-integration.test.ts
+++ b/apps/vscode-extension/test/services/update-system-integration.test.ts
@@ -112,6 +112,61 @@ suite('Update System Integration', () => {
     updateScheduler.dispose();
   });
 
+  test('startup update check waits for the initial source sync', async () => {
+    const previousTimerOverride = process.env.UPDATE_SCHEDULER_ALLOW_TIMERS_IN_TESTS;
+    process.env.UPDATE_SCHEDULER_ALLOW_TIMERS_IN_TESTS = 'true';
+    const clock = sinon.useFakeTimers({ shouldAdvanceTime: false, shouldClearNativeTimers: true });
+
+    try {
+      const mockConfig = sandbox.stub(vscode.workspace, 'getConfiguration');
+      mockConfig.withArgs('promptregistry.updateCheck').returns({
+        get: sandbox.stub().callsFake((key: string, defaultValue?: any) => {
+          if (key === 'enabled') {
+            return true;
+          }
+          if (key === 'frequency') {
+            return 'manual';
+          }
+          return defaultValue;
+        })
+      } as any);
+
+      const mockUpdateChecker = sandbox.createStubInstance(UpdateChecker);
+      mockUpdateChecker.checkForUpdates.resolves([]);
+      let releaseInitialSync!: () => void;
+      const initialSyncReady = new Promise<void>((resolve) => {
+        releaseInitialSync = resolve;
+      });
+      const scheduler = new UpdateScheduler(
+        mockContext,
+        mockUpdateChecker,
+        undefined,
+        undefined,
+        initialSyncReady,
+        () => false
+      );
+
+      await scheduler.initialize();
+      await clock.tickAsync(5000);
+      assert.strictEqual(mockUpdateChecker.checkForUpdates.callCount, 0);
+
+      releaseInitialSync();
+      await Promise.resolve();
+      await Promise.resolve();
+      assert.strictEqual(mockUpdateChecker.checkForUpdates.callCount, 1);
+      assert.deepStrictEqual(mockUpdateChecker.checkForUpdates.firstCall.args, [false, false]);
+
+      scheduler.dispose();
+    } finally {
+      clock.restore();
+      if (previousTimerOverride === undefined) {
+        delete process.env.UPDATE_SCHEDULER_ALLOW_TIMERS_IN_TESTS;
+      } else {
+        process.env.UPDATE_SCHEDULER_ALLOW_TIMERS_IN_TESTS = previousTimerOverride;
+      }
+    }
+  });
+
   test('Complete update system can be wired together', async () => {
     // Mock configuration
     const mockConfig = sandbox.stub(vscode.workspace, 'getConfiguration');

--- a/apps/vscode-extension/test/ui/marketplace-view-provider.eventHandling.test.ts
+++ b/apps/vscode-extension/test/ui/marketplace-view-provider.eventHandling.test.ts
@@ -59,6 +59,7 @@ suite('MarketplaceViewProvider - Event Handling', () => {
   let onBundleInstalledCallback: ((installation: InstalledBundle) => void) | undefined;
   let onBundleUninstalledCallback: ((bundleId: string) => void) | undefined;
   let onBundleUpdatedCallback: ((installation: InstalledBundle) => void) | undefined;
+  let onReadmeDownloadedCallback: (() => void) | undefined;
 
   setup(() => {
     sandbox = sinon.createSandbox();
@@ -90,6 +91,9 @@ suite('MarketplaceViewProvider - Event Handling', () => {
       },
       onBundleUpdated: (cb) => {
         onBundleUpdatedCallback = cb;
+      },
+      onReadmeDownloaded: (cb) => {
+        onReadmeDownloadedCallback = cb;
       }
     });
 
@@ -128,6 +132,35 @@ suite('MarketplaceViewProvider - Event Handling', () => {
 
       assert.ok(mockRegistryManager.onBundleUpdated.calledOnce, 'Should register onBundleUpdated listener');
       assert.ok(onBundleUpdatedCallback, 'Should have callback for onBundleUpdated');
+    });
+
+    test('should register listener for onReadmeDownloaded event', () => {
+      assert.ok(mockRegistryManager.onReadmeDownloaded.calledOnce, 'Should register onReadmeDownloaded listener');
+      assert.ok(onReadmeDownloadedCallback, 'Should have callback for onReadmeDownloaded');
+    });
+  });
+
+  suite('README hydration refreshes', () => {
+    test('should coalesce README download refreshes with source sync refreshes', async () => {
+      const initialSearchCount = mockRegistryManager.searchBundles.callCount;
+
+      onReadmeDownloadedCallback?.();
+      onReadmeDownloadedCallback?.();
+      onReadmeDownloadedCallback?.();
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      assert.strictEqual(
+        mockRegistryManager.searchBundles.callCount,
+        initialSearchCount + 1,
+        'README batches should trigger one leading marketplace refresh'
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 550));
+      assert.strictEqual(
+        mockRegistryManager.searchBundles.callCount,
+        initialSearchCount + 2,
+        'README batches should trigger one trailing marketplace refresh'
+      );
     });
   });
 

--- a/docs/contributor-guide/architecture/adr/0006-shared-semantic-cache-and-client-owned-state.md
+++ b/docs/contributor-guide/architecture/adr/0006-shared-semantic-cache-and-client-owned-state.md
@@ -1,0 +1,127 @@
+# ADR-0006: Shared Semantic Cache and Client-Owned State
+
+**Status:** Accepted
+
+## Context
+
+ADR-0005 established `AppStorage` as the framework-independent storage port
+and deliberately preserved the VS Code extension's existing
+`globalStorageUri` layout for compatibility. That decision correctly prevents
+an undiscoverable relocation of existing user data, but it leaves an important
+long-term policy ambiguous: whether every artifact accessed by the extension
+should remain physically inside VS Code global storage.
+
+The CLI and VS Code extension are two delivery mechanisms for the same
+application. They should be able to reuse compatible semantic artifacts such
+as source metadata, downloaded bundle archives, embedding models, and
+primitive indexes. Keeping those artifacts in separate client roots creates
+duplicate downloads, duplicate indexes, and different freshness behavior.
+
+At the same time, not all persisted data is reusable. Activation migrations,
+UI preferences, extension lifecycle state, and state whose meaning depends on
+VS Code are correctly owned by the extension. Moving that state to a shared
+cache would couple unrelated clients and make lifecycle cleanup unsafe.
+
+The primitive index makes the boundary concrete. It is a semantic cache, but
+it must not be treated as one global file: indexes from different hubs, source
+snapshots, or ranking profiles are not interchangeable.
+
+This ADR narrows only the physical-placement assumption in ADR-0005's
+decision 3. It does not supersede the `AppStorage` port, the compatibility
+adapter, or the requirement to preserve existing user data.
+
+## Decision
+
+1. **Keep ADR-0005 in force for the storage abstraction and compatibility
+   promise.** `AppStorage` remains an injected port. Existing VS Code data
+   under `globalStorageUri` remains readable, and no accepted storage decision
+   is silently invalidated by this ADR.
+
+2. **Separate logical storage from physical placement.** An `AppStorage`
+   implementation resolves logical application namespaces, but the choice of
+   physical root is a policy of the composition root. Application use cases
+   and shared index/search code must not depend on `vscode` or construct a
+   client-specific storage adapter.
+
+3. **Use a shared XDG-compatible cache policy for reusable semantic
+   artifacts.** Where the platform supports it, the CLI and VS Code extension
+   use the same application cache namespace for:
+
+   - source and bundle metadata;
+   - downloaded archives and extracted content caches;
+   - embedding/model artifacts; and
+   - persisted primitive indexes.
+
+   On platforms without XDG, `infra` may map the same policy to the platform's
+   standard shared per-user cache location. The policy is shared; callers do
+   not assume a Unix-specific absolute path.
+
+4. **Keep client-owned state in client-owned stores.** VS Code
+   `globalStorage` remains the home for activation migrations, UI preferences,
+   extension lifecycle state, and VS Code-specific installation or workspace
+   state. CLI/application configuration and persistent non-cache data remain
+   in their appropriate XDG data/config roots.
+
+5. **Namespace semantic indexes by their compatibility inputs.** A persisted
+   primitive index must be addressed by a stable representation of at least:
+
+   ```text
+   <cache>/ai-primitives-hub/indexes/<hub-key>/<source-revision>/<profile-id>/primitive-index.v2.json
+   ```
+
+   The exact path encoding is implementation-defined, but the key must prevent
+   one hub, source snapshot, or ranking/embedding profile from loading another
+   one's index. Coverage and profile metadata remain authoritative at load
+   time; the filename alone is never sufficient for compatibility.
+
+6. **Migrate conservatively.** Existing extension-local cache entries are
+   read-compatible during migration. New shared entries are introduced only
+   with explicit ownership and invalidation rules. Writes are atomic, failed
+   refreshes retain the last-known-good index, and concurrent writers must use
+   a defined lock or single-writer policy. Migration must not silently delete
+   or move existing data.
+
+7. **Retain Option B from the cross-delivery index/search design.** The app
+   layer owns index lifecycle and search use cases; the CLI and VS Code
+   extension remain thin delivery adapters. This ADR changes the physical cache
+   policy, not the dependency direction or the shared ranking/search contract.
+
+8. **Expose read-only search through a typed application contract.** Delivery
+   adapters use `PrimitiveSearchRequest` and `PrimitiveSearchResponse` rather
+   than inferring an index condition from file-system or embedding errors.
+   The response distinguishes ready, degraded, and unavailable search, while
+   `IndexStatus` distinguishes missing, refreshing, partial, incompatible, and
+   failed snapshots. The query operation only reads a persisted index; it never
+   enumerates providers, resolves remote revisions, or initiates a rebuild.
+
+## Consequences
+
+- **Positive:** the CLI and VS Code extension can reuse compatible semantic
+  caches, reducing duplicate downloads and avoiding divergent index behavior.
+- **Positive:** the index remains client-agnostic while still being scoped to
+  the active hub, source revision, and search profile.
+- **Positive:** VS Code lifecycle state remains isolated from cache eviction
+  and from other delivery mechanisms.
+- **Negative:** cache ownership, locking, migration, and invalidation require
+  explicit implementation work; simply changing a path is not sufficient.
+- **Negative:** existing VS Code cache files temporarily require a
+  compatibility read path while the namespaced shared-cache migration is
+  rolled out.
+- **Unaffected:** repository-relative lockfiles and target installation roots
+  remain governed by their existing contracts; they are not semantic caches
+  and must not be moved by this ADR.
+
+## Implementation implications
+
+The implementation should proceed in this order:
+
+1. Add a narrow shared-cache/index storage port or extend `AppStorage` with
+   logical cache namespaces; preserve explicit path overrides for diagnostics.
+2. Move hub/source/profile-aware index path resolution to the application or
+   composition boundary, not `PrimitiveIndexService`.
+3. Add atomic persistence, last-known-good retention, compatibility checks,
+   and a migration reader for the existing VS Code cache layout.
+4. Add cross-delivery contract tests proving equivalent corpus/profile/query
+   inputs produce equivalent results from CLI and VS Code.
+5. Remove the compatibility reader only in a separately documented breaking
+   change after the supported migration window has elapsed.

--- a/docs/contributor-guide/architecture/adr/adr-index.md
+++ b/docs/contributor-guide/architecture/adr/adr-index.md
@@ -12,6 +12,7 @@ focused on one decision.
 | [0003](./0003-primitive-index-search-and-multi-target-in-scope.md) | Primitive Index/Search/Harvest and Full Multi-Target Support In Scope | Accepted |
 | [0004](./0004-cli-only-rebrand-keep-lockfile-and-extension-identity-stable.md) | CLI-Only Rebrand — Keep Lockfile and Extension Identity Stable | Accepted |
 | [0005](./0005-universal-xdg-based-app-storage.md) | Universal, XDG-Based Application Storage Port | Accepted |
+| [0006](./0006-shared-semantic-cache-and-client-owned-state.md) | Shared Semantic Cache and Client-Owned State | Accepted |
 
 ## When to add a new ADR
 

--- a/docs/contributor-guide/architecture/library-centric-architecture/cli-user-flows.md
+++ b/docs/contributor-guide/architecture/library-centric-architecture/cli-user-flows.md
@@ -303,8 +303,11 @@ flowchart LR
 
 **Commands:**
 - `index harvest` (auto-detects active hub)
+- `index harvest --embed` (harvest and embed primitive text for hybrid search)
 - `index build --root <path> --out <file>`
+- `index build --root <path> --out <file> --embed` (build and embed primitive text)
 - `index search --query <text> [--kinds <kinds>] [--sources <ids>] [--tags <tags>]`
+- `index search --query <text> --ranking hybrid` (requires an embedded index)
 - `index search --query <text> --install` (interactive install)
 
 ---
@@ -614,9 +617,9 @@ flowchart LR
 ### Index Commands
 | Command | Purpose | Key Options |
 |---------|---------|------------|
-| `index build` | Build index | `--root <path>`, `--out <file>`, `--source-id <id>` |
-| `index harvest` | Harvest from hub | `--hub-repo <repo>`, `--hub-config-file <file>`, `--dry-run` |
-| `index search` | Search primitives | `--query <text>`, `--index <file>`, `--kinds <kinds>`, `--sources <ids>`, `--bundles <ids>`, `--tags <tags>`, `--limit <n>`, `--offset <n>`, `--installed-only`, `--install` |
+| `index build` | Build index | `--root <path>`, `--out <file>`, `--source-id <id>`, `--embed` |
+| `index harvest` | Harvest from hub | `--hub-repo <repo>`, `--hub-config-file <file>`, `--dry-run`, `--embed` |
+| `index search` | Search primitives | `--query <text>`, `--index <file>`, `--kinds <kinds>`, `--sources <ids>`, `--bundles <ids>`, `--tags <tags>`, `--limit <n>`, `--offset <n>`, `--installed-only`, `--install`, `--ranking <bm25\|hybrid>` |
 | `search` | Search alias | Same as `index search` |
 | `index shortlist new` | Create shortlist | `--name <name>`, `--index <file>` |
 | `index shortlist add` | Add to shortlist | `--id <shortlist-id>`, `--primitive <primitive-id>`, `--index <file>` |

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -15,6 +15,15 @@ This document lists all VS Code commands provided by the AI Primitives Hub exten
 | `promptRegistry.enableAutoUpdate` | Enable Auto-Update | Enable automatic updates for a bundle |
 | `promptRegistry.disableAutoUpdate` | Disable Auto-Update | Disable automatic updates for a bundle |
 
+## Index & Search
+
+| Command | Title | Description |
+|---------|-------|-------------|
+| `promptRegistry.searchPrimitives` | Search Primitives | Search indexed prompts, instructions, chat modes, agents, and skills |
+| `promptRegistry.rebuildPrimitiveIndex` | Rebuild Primitive Index | Rebuild the shared primitive index from enabled sources, with progress in a notification and the AI Primitives Hub output channel |
+
+Primitive search reads only a pre-built local index. It does not synchronize sources or rebuild the index. **Rebuild Primitive Index** is the explicit lifecycle operation that may access configured sources; it reports harvest, indexing, and embedding milestones in the **AI Primitives Hub** output channel and shows a completion or failure notification.
+
 ## Scope Management
 
 Commands for managing bundle installation scope. These are available via context menu on installed bundles in the Registry Explorer.

--- a/docs/user-guide/marketplace.md
+++ b/docs/user-guide/marketplace.md
@@ -4,11 +4,18 @@ Open via Activity Bar icon or `Ctrl+Shift+P` → "AI Primitives Hub: Focus On Ma
 
 ## Browsing
 
-- **Search** — Filter by name, description, tags
+- **Search** — Filter by name, description, tags, and indexed primitive content
 - **Filter by Type** — Prompts, Instructions, Chat Modes, Agents
 - **Filter by Tags** — Multiple tags use OR logic
 - **Filter by Source** — Show bundles from specific repositories
 - **Installed Only** — Show only installed bundles
+
+The marketplace builds the primitive index on demand when you search. To start a
+rebuild explicitly, open the Command Palette and run **AI Primitives Hub:
+Rebuild Primitive Index**. The index is also rebuilt automatically after source
+syncs and bundle installation changes. `awesome-copilot` and
+`awesome-copilot-plugin` sources are intentionally excluded from primitive
+indexing; they remain available to the regular bundle catalog.
 
 ## Installing
 

--- a/packages/app/src/search/build-index.ts
+++ b/packages/app/src/search/build-index.ts
@@ -1,0 +1,195 @@
+/**
+ * Build-index use case.
+ *
+ * Orchestrates `PrimitiveIndex` construction + persistence for the CLI.
+ * Kept logic-free: all search/indexing concerns stay in `@ai-primitives-hub/infra`.
+ * @module search/build-index
+ */
+import type {
+  BundleProvider,
+  PrimitiveIndexKey,
+  PrimitiveIndexStore,
+} from '@ai-primitives-hub/core';
+import {
+  PrimitiveIndex,
+  saveIndex,
+} from '@ai-primitives-hub/infra';
+import {
+  resolveIndexPath,
+} from './index-location';
+import type {
+  SourceCoverage,
+} from './primitive-search';
+import {
+  createEmbeddingProvider,
+  getSearchProfile,
+  type SearchProfileId,
+} from './search-profile';
+
+interface SourceCoverageProvider extends BundleProvider {
+  getSourceIds(): readonly string[];
+  getSourceErrors(): readonly { sourceId: string; error: unknown }[];
+}
+
+type SourceOutcome = {
+  bundles: number;
+  primitives: number;
+  error?: unknown;
+};
+
+/**
+ * Options for building a local primitive index.
+ */
+export interface BuildIndexOptions {
+  /** Bundle provider to harvest primitives from. */
+  provider: BundleProvider;
+  /** Destination file path for the persisted index (legacy override). */
+  outFile?: string;
+  /** Shared namespaced index location resolver. */
+  indexStore?: PrimitiveIndexStore;
+  /** Compatibility key used by `indexStore`. */
+  indexKey?: PrimitiveIndexKey;
+  /** Optional hub/source identifier stored in index metadata. */
+  hubId?: string;
+  /** When true, embed primitive text using the local ternlight model. */
+  embed?: boolean;
+  /** Embedding strategy when `embed` is true. */
+  embedStrategy?: 'single' | 'dual';
+  /** Optional shared profile; takes precedence over embed/embedStrategy. */
+  profile?: SearchProfileId;
+  /** Optional progress/diagnostic log sink. */
+  onLog?: (msg: string) => void;
+  /** Persist an empty result. Defaults to true for explicit empty-index builds. */
+  persistEmpty?: boolean;
+}
+
+/**
+ * Result of a successful index build.
+ */
+export interface BuildIndexResult {
+  outFile: string;
+  primitives: number;
+  bundles: number;
+  embeddings?: { provider: string; dim: number };
+  report: BuildReport;
+}
+
+/** Structured outcome of one explicit or scheduled index lifecycle build. */
+export interface BuildReport {
+  state: 'ready' | 'partial';
+  sourceCoverage: SourceCoverage[];
+  primitives: number;
+  bundles: number;
+  elapsedMs: number;
+}
+
+function isSourceCoverageProvider(provider: BundleProvider): provider is SourceCoverageProvider {
+  return 'getSourceIds' in provider
+    && typeof provider.getSourceIds === 'function'
+    && 'getSourceErrors' in provider
+    && typeof provider.getSourceErrors === 'function';
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function buildReport(
+  provider: BundleProvider,
+  primitives: number,
+  bundles: number,
+  elapsedMs: number,
+  outcomes: ReadonlyMap<string, SourceOutcome>
+): BuildReport {
+  if (!isSourceCoverageProvider(provider)) {
+    return {
+      state: 'ready',
+      sourceCoverage: [],
+      primitives,
+      bundles,
+      elapsedMs
+    };
+  }
+
+  const errors = new Map(provider.getSourceErrors().map(({ sourceId, error }) => [sourceId, error]));
+  const sourceCoverage = provider.getSourceIds().map((sourceId) => {
+    const outcome = outcomes.get(sourceId);
+    const error = errors.get(sourceId) ?? outcome?.error;
+    return error === undefined
+      ? {
+        sourceId,
+        state: 'indexed' as const,
+        bundles: outcome?.bundles ?? 0,
+        primitives: outcome?.primitives ?? 0
+      }
+      : {
+        sourceId,
+        state: 'failed' as const,
+        bundles: outcome?.bundles ?? 0,
+        primitives: outcome?.primitives ?? 0,
+        message: errorMessage(error)
+      };
+  });
+  return {
+    state: sourceCoverage.some(({ state }) => state !== 'indexed') ? 'partial' : 'ready',
+    sourceCoverage,
+    primitives,
+    bundles,
+    elapsedMs
+  };
+}
+
+/**
+ * Build a primitive index and persist it to disk.
+ * @param options Build options.
+ * @returns Build summary.
+ */
+export async function buildIndex(options: BuildIndexOptions): Promise<BuildIndexResult> {
+  const startedAt = Date.now();
+  const sourceOutcomes = new Map<string, SourceOutcome>();
+  const profile = options.profile ? getSearchProfile(options.profile) : undefined;
+  const outFile = resolveIndexPath({
+    indexPath: options.outFile,
+    indexStore: options.indexStore,
+    indexKey: options.indexKey
+  });
+  const embed = profile ? profile.embeddingProvider !== undefined : options.embed;
+  const embeddingStrategy = profile?.embeddingStrategy ?? options.embedStrategy;
+  const embeddings = embed
+    ? createEmbeddingProvider(profile ?? getSearchProfile('ternlight-single-v1'))
+    : undefined;
+  const idx = await PrimitiveIndex.buildFrom(options.provider, {
+    hubId: options.hubId ?? options.indexKey?.hubId,
+    sourceRevision: options.indexKey?.sourceRevision,
+    searchProfileId: profile?.id,
+    embeddings,
+    embeddingStrategy,
+    onLog: options.onLog,
+    onBundle: (ref, produced) => {
+      const outcome = sourceOutcomes.get(ref.sourceId) ?? { bundles: 0, primitives: 0 };
+      outcome.bundles += 1;
+      outcome.primitives += produced;
+      sourceOutcomes.set(ref.sourceId, outcome);
+    },
+    onHarvestError: (ref, error) => {
+      if (!ref) {
+        return;
+      }
+      const outcome = sourceOutcomes.get(ref.sourceId) ?? { bundles: 0, primitives: 0 };
+      outcome.error = error;
+      sourceOutcomes.set(ref.sourceId, outcome);
+    }
+  });
+  const stats = idx.stats();
+  if (stats.primitives > 0 || options.persistEmpty !== false) {
+    saveIndex(idx, outFile);
+  }
+  const meta = idx.toJSON() as { embeddingsMeta?: { provider: string; dim: number } | null };
+  return {
+    outFile,
+    primitives: stats.primitives,
+    bundles: stats.bundles,
+    embeddings: meta.embeddingsMeta ?? undefined,
+    report: buildReport(options.provider, stats.primitives, stats.bundles, Date.now() - startedAt, sourceOutcomes)
+  };
+}

--- a/packages/app/src/search/bundle-search-keys.ts
+++ b/packages/app/src/search/bundle-search-keys.ts
@@ -1,0 +1,64 @@
+/**
+ * Shared bridge between primitive-index identities and catalog bundle keys.
+ *
+ * Native GitHub primitive providers index one repository as a source-level
+ * bundle (`bundleId === sourceId`), while catalog adapters expose the same
+ * repository as a versioned bundle ID. This projection keeps ranked semantic
+ * results compatible with both representations without changing the
+ * client-agnostic persisted index.
+ * @module search/bundle-search-keys
+ */
+
+export interface IndexedBundleIdentity {
+  sourceId: string;
+  bundleId: string;
+}
+
+export interface CatalogBundleIdentity {
+  sourceId: string;
+  bundleId: string;
+}
+
+const BUNDLE_KEY_SEPARATOR = '\u0000';
+
+/**
+ * Convert a catalog bundle identity to the opaque key used by the marketplace.
+ * @param bundle
+ */
+export function toBundleSearchKey(bundle: CatalogBundleIdentity): string {
+  return `${bundle.sourceId}${BUNDLE_KEY_SEPARATOR}${bundle.bundleId}`;
+}
+
+/**
+ * Resolve ranked primitive identities to catalog identities.
+ *
+ * The input order is semantic ranking order. Exact bundle IDs are preferred;
+ * a source-level index identity expands to all catalog bundles from that
+ * source, which is the representation used by the native GitHub provider.
+ * Results are deduplicated while preserving that order.
+ * @param indexedBundles Ranked identities emitted by the primitive index.
+ * @param catalogBundles Current client/catalog bundle snapshot.
+ */
+export function resolveBundleSearchKeys(
+  indexedBundles: readonly IndexedBundleIdentity[],
+  catalogBundles: readonly CatalogBundleIdentity[]
+): string[] {
+  const result: string[] = [];
+  const seen = new Set<string>();
+
+  for (const indexed of indexedBundles) {
+    const matches = catalogBundles.filter((catalog) =>
+      catalog.sourceId === indexed.sourceId
+      && (catalog.bundleId === indexed.bundleId || indexed.bundleId === indexed.sourceId)
+    );
+    for (const match of matches) {
+      const key = toBundleSearchKey(match);
+      if (!seen.has(key)) {
+        seen.add(key);
+        result.push(key);
+      }
+    }
+  }
+
+  return result;
+}

--- a/packages/app/src/search/index-location.ts
+++ b/packages/app/src/search/index-location.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared resolution of explicit and namespaced primitive-index locations.
+ * @module search/index-location
+ */
+import type {
+  PrimitiveIndexKey,
+  PrimitiveIndexStore,
+} from '@ai-primitives-hub/core';
+
+export interface IndexLocationOptions {
+  /** Explicit path for diagnostics, tests, and legacy CLI compatibility. */
+  indexPath?: string;
+  /** Injected resolver for shared, namespaced semantic-cache paths. */
+  indexStore?: PrimitiveIndexStore;
+  /** Key used when resolving through `indexStore`. */
+  indexKey?: PrimitiveIndexKey;
+}
+
+/**
+ * Resolve the stable namespace used for a hub's persisted primitive indexes.
+ *
+ * Older app imports generated user-facing hub ids with a six-digit timestamp
+ * suffix (for example, `amadeus-hub-788228`), while the legacy CLI commonly
+ * used the stable base id (`amadeus-hub`). Keep those public ids untouched but
+ * converge their client-agnostic index namespace during the migration.
+ * @param hubId User-facing hub identifier.
+ */
+export function canonicalizeIndexHubId(hubId: string): string {
+  const normalized = hubId.trim();
+  const canonical = normalized.replace(/-\d{6}$/u, '');
+  return canonical.length > 0 ? canonical : normalized;
+}
+
+/**
+ * Resolve an explicit path or an injected namespaced index store.
+ * @param options
+ */
+export function resolveIndexPath(options: IndexLocationOptions): string {
+  if (options.indexPath) {
+    return options.indexPath;
+  }
+  if (options.indexStore && options.indexKey) {
+    return options.indexStore.getIndexPath(options.indexKey);
+  }
+  throw new Error('An explicit indexPath or indexStore/indexKey pair is required');
+}

--- a/packages/app/src/search/index.ts
+++ b/packages/app/src/search/index.ts
@@ -2,4 +2,10 @@
  * Search subsystem barrel export.
  * @module search
  */
+export * from './build-index';
+export * from './bundle-search-keys';
 export * from './export-profile';
+export * from './index-location';
+export * from './primitive-search';
+export * from './search-index';
+export * from './search-profile';

--- a/packages/app/src/search/primitive-search.ts
+++ b/packages/app/src/search/primitive-search.ts
@@ -1,0 +1,225 @@
+/**
+ * Typed primitive-search application contract.
+ *
+ * This facade keeps delivery layers independent from raw index errors while
+ * preserving `searchIndex()` for callers that need its low-level behavior.
+ * It never builds an index or resolves remote source state.
+ * @module search/primitive-search
+ */
+import type {
+  PrimitiveIndexKey,
+  PrimitiveIndexStore,
+  PrimitiveKind,
+} from '@ai-primitives-hub/core';
+import type {
+  SearchResult,
+} from '@ai-primitives-hub/infra';
+import {
+  searchIndex,
+  SearchIndexError,
+} from './search-index';
+import type {
+  SearchProfileId,
+} from './search-profile';
+
+/** Ranking modes supported by the shared primitive index. */
+export type RankingMode = 'bm25' | 'hybrid' | 'multi';
+
+/** Lifecycle state of the persisted index selected for a request. */
+export type PrimitiveIndexState =
+  | 'missing'
+  | 'ready'
+  | 'refreshing'
+  | 'partial'
+  | 'incompatible'
+  | 'failed';
+
+/** Search availability exposed to delivery layers. */
+export type PrimitiveSearchAvailability = 'ready' | 'degraded' | 'unavailable';
+
+/** Per-source coverage reported by an index lifecycle operation. */
+export interface SourceCoverage {
+  sourceId: string;
+  state: 'indexed' | 'skipped' | 'unsupported' | 'failed';
+  bundles?: number;
+  primitives?: number;
+  revision?: string;
+  message?: string;
+}
+
+/** Compatibility metadata carried by a persisted primitive index. */
+export interface IndexCompatibility {
+  schemaVersion?: number;
+  extractionVersion?: string;
+  primitiveIdentityVersion?: string;
+  tokenizerVersion?: string;
+  bm25Profile?: string;
+  rankingProfile?: string;
+  embeddingProvider?: string;
+  embeddingModel?: string;
+  embeddingDimension?: number;
+  embeddingStrategy?: 'single' | 'dual';
+  sourceRevision?: string;
+}
+
+/** Status and coverage of the persisted primitive index. */
+export interface IndexStatus {
+  state: PrimitiveIndexState;
+  searchProfileId?: string;
+  ranking?: RankingMode;
+  builtAt?: string;
+  sourceCoverage?: SourceCoverage[];
+  compatibility?: IndexCompatibility;
+  usingFallbackSnapshot?: boolean;
+}
+
+/** Serializable primitive search request shared by all delivery layers. */
+export interface PrimitiveSearchRequest {
+  q?: string;
+  kinds?: PrimitiveKind[];
+  sources?: string[];
+  bundles?: string[];
+  tags?: string[];
+  installedOnly?: boolean;
+  limit?: number;
+  offset?: number;
+  explain?: boolean;
+  ranking?: RankingMode;
+  profile?: SearchProfileId;
+}
+
+/** Actionable warning returned when the persisted index cannot be searched. */
+export interface PrimitiveSearchWarning {
+  code: 'INDEX_MISSING' | 'INDEX_INCOMPATIBLE' | 'SEARCH_FAILED';
+  message: string;
+  causeCode?: string;
+}
+
+/** Typed search response for CLI and UI delivery adapters. */
+export interface PrimitiveSearchResponse {
+  status: PrimitiveSearchAvailability;
+  index: IndexStatus;
+  result?: SearchResult;
+  warning?: PrimitiveSearchWarning;
+}
+
+/** Options for the typed primitive-search facade. */
+export interface SearchPrimitivesOptions {
+  /** Path to the persisted primitive index (legacy override). */
+  indexPath?: string;
+  /** Shared namespaced index location resolver. */
+  indexStore?: PrimitiveIndexStore;
+  /** Compatibility key used by `indexStore`. */
+  indexKey?: PrimitiveIndexKey;
+  /** Serializable query and filtering options. */
+  request: PrimitiveSearchRequest;
+  /** Current installed bundle snapshot; resolved outside the read-only search use case. */
+  installedBundleKeys?: string[];
+  /** Lifecycle status supplied by the caller when it is already known. */
+  indexStatus?: IndexStatus;
+}
+
+const INCOMPATIBLE_INDEX_CODES = new Set([
+  'EMBEDDING_UNAVAILABLE',
+  'HUB_MISMATCH',
+  'NO_EMBEDDINGS',
+  'PROFILE_MISMATCH',
+  'SOURCE_REVISION_MISMATCH'
+]);
+
+function initialIndexStatus(options: SearchPrimitivesOptions): IndexStatus {
+  return options.indexStatus ?? { state: 'ready' };
+}
+
+function isDegraded(state: PrimitiveIndexState): boolean {
+  return state === 'partial' || state === 'refreshing';
+}
+
+function errorCode(error: unknown): string | undefined {
+  if (error && typeof error === 'object' && 'code' in error && typeof error.code === 'string') {
+    return error.code;
+  }
+  return undefined;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isMissingIndex(error: unknown): boolean {
+  return errorCode(error) === 'ENOENT' || /ENOENT|no such file/i.test(errorMessage(error));
+}
+
+function unavailableResponse(
+  index: IndexStatus,
+  state: Extract<PrimitiveIndexState, 'missing' | 'incompatible' | 'failed'>,
+  warning: PrimitiveSearchWarning
+): PrimitiveSearchResponse {
+  return {
+    status: 'unavailable',
+    index: { ...index, state },
+    warning
+  };
+}
+
+/**
+ * Search a pre-built primitive index through a serializable, status-aware
+ * application contract. This operation is read-only: callers must schedule
+ * lifecycle rebuilds separately.
+ * @param options Persisted-index location, request, and optional lifecycle state.
+ */
+export async function searchPrimitives(options: SearchPrimitivesOptions): Promise<PrimitiveSearchResponse> {
+  const index = initialIndexStatus(options);
+  try {
+    const result = await searchIndex({
+      indexPath: options.indexPath,
+      indexStore: options.indexStore,
+      indexKey: options.indexKey,
+      profile: options.request.profile,
+      ranking: options.request.ranking,
+      query: {
+        q: options.request.q,
+        kinds: options.request.kinds,
+        sources: options.request.sources,
+        bundles: options.request.bundles,
+        tags: options.request.tags,
+        installedOnly: options.request.installedOnly,
+        installedBundleKeys: options.installedBundleKeys,
+        limit: options.request.limit,
+        offset: options.request.offset,
+        explain: options.request.explain,
+        ranking: options.request.ranking
+      }
+    });
+    const responseIndex: IndexStatus = {
+      ...index,
+      searchProfileId: result.searchProfileId,
+      ranking: result.ranking
+    };
+    return {
+      status: isDegraded(responseIndex.state) ? 'degraded' : 'ready',
+      index: responseIndex,
+      result
+    };
+  } catch (error) {
+    if (isMissingIndex(error)) {
+      return unavailableResponse(index, 'missing', {
+        code: 'INDEX_MISSING',
+        message: 'No compatible primitive index is available. Rebuild the primitive index and try again.',
+        causeCode: errorCode(error)
+      });
+    }
+    if (error instanceof SearchIndexError && INCOMPATIBLE_INDEX_CODES.has(error.code)) {
+      return unavailableResponse(index, 'incompatible', {
+        code: 'INDEX_INCOMPATIBLE',
+        message: error.message,
+        causeCode: error.code
+      });
+    }
+    return unavailableResponse(index, 'failed', {
+      code: 'SEARCH_FAILED',
+      message: errorMessage(error),
+      causeCode: errorCode(error)
+    });
+  }
+}

--- a/packages/app/src/search/search-index.ts
+++ b/packages/app/src/search/search-index.ts
@@ -1,0 +1,176 @@
+/**
+ * Search-index use case.
+ *
+ * Loads a persisted primitive index and runs a search, optionally using a
+ * local embedding model for hybrid or multi-vector ranking.
+ * @module search/search-index
+ */
+import type {
+  PrimitiveIndexKey,
+  PrimitiveIndexStore,
+} from '@ai-primitives-hub/core';
+import type {
+  SearchQuery,
+  SearchResult,
+} from '@ai-primitives-hub/infra';
+import {
+  loadIndex,
+} from '@ai-primitives-hub/infra';
+import {
+  resolveIndexPath,
+} from './index-location';
+import {
+  createEmbeddingProvider,
+  getSearchProfile,
+  SEARCH_PROFILES,
+  type SearchProfileId,
+} from './search-profile';
+
+/**
+ * Options for searching a primitive index.
+ */
+export interface SearchIndexOptions {
+  /** Path to the persisted primitive index (legacy override). */
+  indexPath?: string;
+  /** Shared namespaced index location resolver. */
+  indexStore?: PrimitiveIndexStore;
+  /** Compatibility key used by `indexStore`. */
+  indexKey?: PrimitiveIndexKey;
+  /** Search query and filters. */
+  query: SearchQuery;
+  /**
+   * Ranking strategy. `bm25` (default) is keyword-only; `hybrid` adds dense
+   * similarity with a single combined embedding; `multi` uses the named
+   * embedding streams stored in the index. May also be set on `query.ranking`;
+   * this field takes precedence.
+   */
+  ranking?: 'bm25' | 'hybrid' | 'multi';
+  /** Optional shared profile; takes precedence over ranking. */
+  profile?: SearchProfileId;
+}
+
+/**
+ * Search error for unsupported hybrid search.
+ */
+export class SearchIndexError extends Error {
+  public readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'SearchIndexError';
+    this.code = code;
+  }
+}
+
+function validateIndexKey(
+  key: PrimitiveIndexKey | undefined,
+  metadata: { hubId?: string; sourceRevision?: string }
+): void {
+  if (!key) {
+    return;
+  }
+  if (metadata.hubId && metadata.hubId !== key.hubId) {
+    throw new SearchIndexError('HUB_MISMATCH', `Index hub ${metadata.hubId} is incompatible with requested hub ${key.hubId}`);
+  }
+  if (metadata.sourceRevision && metadata.sourceRevision !== key.sourceRevision) {
+    throw new SearchIndexError('SOURCE_REVISION_MISMATCH', 'Index source revision is incompatible with the requested source snapshot');
+  }
+}
+
+function streamNames(strategy: string | undefined, hasEmbeddings: boolean): string[] {
+  if (!hasEmbeddings) {
+    return [];
+  }
+  if (strategy === 'dual') {
+    return ['metadata', 'body'];
+  }
+  return ['combined'];
+}
+
+/**
+ * Load a primitive index and run a search.
+ * @param options Search options.
+ * @returns Search result.
+ * @throws {SearchIndexError} if hybrid/multi ranking is requested on a non-embedded index.
+ */
+export async function searchIndex(options: SearchIndexOptions): Promise<SearchResult> {
+  const indexPath = resolveIndexPath(options);
+  const idx = loadIndex(indexPath);
+  const indexMetadata = idx.toJSON() as {
+    hubId?: string;
+    sourceRevision?: string | null;
+    searchProfileId?: string | null;
+    embeddingsMeta?: { provider: string; dim: number; embeddingStrategy?: string } | null;
+  };
+  validateIndexKey(options.indexKey, {
+    hubId: indexMetadata.hubId,
+    sourceRevision: indexMetadata.sourceRevision ?? undefined
+  });
+  const query: SearchQuery = { ...options.query };
+  const persistedProfileId = indexMetadata.searchProfileId
+    ?? (indexMetadata.embeddingsMeta
+      ? (indexMetadata.embeddingsMeta.embeddingStrategy === 'dual' ? 'ternlight-dual-v1' : 'ternlight-single-v1')
+      : 'bm25-v1');
+  const persistedProfile = Object.prototype.hasOwnProperty.call(SEARCH_PROFILES, persistedProfileId)
+    ? getSearchProfile(persistedProfileId)
+    : undefined;
+  const profile = options.profile
+    ? getSearchProfile(options.profile)
+    : (!options.ranking && !query.ranking ? persistedProfile : undefined);
+  const ranking = profile?.ranking ?? options.ranking ?? query.ranking ?? 'bm25';
+  const searchProfileId = profile?.id
+    ?? (ranking === 'multi' ? 'ternlight-dual-v1' : (ranking === 'hybrid' ? 'ternlight-single-v1' : 'bm25-v1'));
+
+  if ((ranking === 'hybrid' || ranking === 'multi') && !query.q) {
+    throw new SearchIndexError('MISSING_QUERY', `${String(ranking)} ranking requires a text query`);
+  }
+
+  if (ranking === 'hybrid' || ranking === 'multi') {
+    const meta = indexMetadata;
+    if (!meta.embeddingsMeta) {
+      throw new SearchIndexError(
+        'NO_EMBEDDINGS',
+        `${String(ranking)} ranking requires an embedded index. Run \`index build --embed\` or \`index harvest --embed\` first.`
+      );
+    }
+    const expectedProfileId = profile?.id
+      ?? (ranking === 'multi' ? 'ternlight-dual-v1' : 'ternlight-single-v1');
+    if (persistedProfileId !== expectedProfileId) {
+      throw new SearchIndexError(
+        'PROFILE_MISMATCH',
+        `Search profile ${expectedProfileId} is incompatible with index profile ${persistedProfileId}. Rebuild the index with the requested profile.`
+      );
+    }
+
+    const provider = createEmbeddingProvider(
+      profile ?? getSearchProfile(ranking === 'multi' ? 'ternlight-dual-v1' : 'ternlight-single-v1')
+    );
+    if (!provider) {
+      throw new SearchIndexError('EMBEDDING_UNAVAILABLE', `No embedding provider is registered for ${String(ranking)} ranking`);
+    }
+
+    if (ranking === 'hybrid') {
+      const [queryEmbedding] = await provider.embed([query.q!]);
+      query.ranking = 'hybrid';
+      query.queryEmbedding = queryEmbedding;
+    } else {
+      const names = streamNames(meta.embeddingsMeta.embeddingStrategy, true);
+      const inputs = names.map(() => query.q!);
+      const vectors = await provider.embed(inputs);
+      const queryEmbeddings: Record<string, Float32Array> = {};
+      for (const [i, name] of names.entries()) {
+        queryEmbeddings[name] = vectors[i]!;
+      }
+      query.ranking = 'multi';
+      query.queryEmbeddings = queryEmbeddings;
+    }
+  }
+
+  const result = idx.search(query);
+  return {
+    ...result,
+    searchProfileId,
+    ranking,
+    embeddingUsed: ranking === 'hybrid' || ranking === 'multi'
+  };
+}

--- a/packages/app/src/search/search-profile.ts
+++ b/packages/app/src/search/search-profile.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared search profiles used by every delivery layer.
+ *
+ * The profile is the compatibility boundary between a persisted index and a
+ * query. CLI commands and the VS Code extension must resolve the same profile
+ * rather than constructing embedding providers independently.
+ * @module search/search-profile
+ */
+import {
+  TernlightEmbeddingProvider,
+} from '@ai-primitives-hub/infra';
+import type {
+  EmbeddingProvider,
+} from '@ai-primitives-hub/infra';
+
+export interface SearchProfile {
+  id: string;
+  ranking: 'bm25' | 'hybrid' | 'multi';
+  embeddingProvider?: string;
+  embeddingStrategy?: 'single' | 'dual';
+}
+
+export const SEARCH_PROFILES = {
+  'bm25-v1': {
+    id: 'bm25-v1',
+    ranking: 'bm25',
+    embeddingProvider: undefined,
+    embeddingStrategy: undefined
+  },
+  'ternlight-single-v1': {
+    id: 'ternlight-single-v1',
+    ranking: 'hybrid',
+    embeddingProvider: 'ternlight-mini',
+    embeddingStrategy: 'single'
+  },
+  'ternlight-dual-v1': {
+    id: 'ternlight-dual-v1',
+    ranking: 'multi',
+    embeddingProvider: 'ternlight-mini',
+    embeddingStrategy: 'dual'
+  }
+} as const satisfies Record<string, SearchProfile>;
+
+export type SearchProfileId = keyof typeof SEARCH_PROFILES;
+
+/**
+ * Resolve a named profile or throw an actionable configuration error.
+ * @param profileId - Stable profile identifier.
+ * @returns The shared profile definition.
+ */
+export function getSearchProfile(profileId = 'bm25-v1'): SearchProfile {
+  const profile = SEARCH_PROFILES[profileId as SearchProfileId];
+  if (!profile) {
+    throw new Error(`Unknown search profile: ${profileId}`);
+  }
+  return profile;
+}
+
+/**
+ * Create the embedding provider required by a profile.
+ * @param profile - Shared profile definition.
+ * @returns The profile provider, or undefined for BM25-only search.
+ */
+export function createEmbeddingProvider(profile: SearchProfile): EmbeddingProvider | undefined {
+  if (profile.embeddingProvider === undefined) {
+    return undefined;
+  }
+  if (profile.embeddingProvider === 'ternlight-mini') {
+    return new TernlightEmbeddingProvider();
+  }
+  throw new Error(`No embedding provider registered for: ${profile.embeddingProvider}`);
+}

--- a/packages/app/src/update/check-updates.ts
+++ b/packages/app/src/update/check-updates.ts
@@ -189,8 +189,9 @@ export class UpdateCheckerCore {
    * unless bypassed, otherwise syncs GitHub release sources and queries
    * the registry, enriching results with auto-update preferences.
    * @param bypassCache - Skip the cache and force a fresh check.
+   * @param syncSources
    */
-  public async checkForUpdates(bypassCache = false): Promise<UpdateCheckResult[]> {
+  public async checkForUpdates(bypassCache = false, syncSources = true): Promise<UpdateCheckResult[]> {
     this.log('info', 'Checking for bundle updates');
 
     if (!bypassCache) {
@@ -201,7 +202,7 @@ export class UpdateCheckerCore {
       }
     }
 
-    if (bypassCache || !this.opts.cache.isValid()) {
+    if (syncSources && (bypassCache || !this.opts.cache.isValid())) {
       await this.syncGitHubReleaseSources();
     }
 

--- a/packages/app/test/search/build-index.test.ts
+++ b/packages/app/test/search/build-index.test.ts
@@ -1,0 +1,122 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type {
+  BundleManifest,
+  BundleProvider,
+  BundleRef,
+} from '@ai-primitives-hub/core';
+import {
+  CompositeBundleProvider,
+  LocalFolderBundleProvider,
+} from '@ai-primitives-hub/infra';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  buildIndex,
+} from '../../src/search/build-index';
+
+describe('buildIndex', () => {
+  let tempDir: string;
+  let bundleDir: string;
+  let outFile: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'app-build-index-test-'));
+    bundleDir = path.join(tempDir, 'local-foo');
+    await fs.promises.mkdir(path.join(bundleDir, 'prompts'), { recursive: true });
+    await fs.promises.writeFile(
+      path.join(bundleDir, 'deployment-manifest.yml'),
+      'id: local-foo\nversion: 1.0.0\nname: Local Foo\nitems:\n  - path: prompts/hello.prompt.md\n    kind: prompt\n'
+    );
+    await fs.promises.writeFile(
+      path.join(bundleDir, 'prompts', 'hello.prompt.md'),
+      '# Hello Prompt\n\nA diagnostic prompt.\n'
+    );
+    outFile = path.join(tempDir, 'primitive-index.json');
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('builds and persists an index without embeddings by default', async () => {
+    const provider = new LocalFolderBundleProvider({ root: tempDir, sourceId: 'local' });
+    const result = await buildIndex({ provider, outFile });
+    expect(result.outFile).toBe(outFile);
+    expect(result.primitives).toBe(1);
+    expect(result.bundles).toBe(1);
+    expect(result.embeddings).toBeUndefined();
+    expect(fs.existsSync(outFile)).toBe(true);
+  });
+
+  it('embeds primitive text when embed is true', async () => {
+    const provider = new LocalFolderBundleProvider({ root: tempDir, sourceId: 'local' });
+    const result = await buildIndex({ provider, outFile, embed: true });
+    expect(result.primitives).toBe(1);
+    expect(result.embeddings).toBeTruthy();
+    expect(result.embeddings?.dim).toBe(384);
+    expect(fs.existsSync(outFile)).toBe(true);
+
+    const raw = JSON.parse(await fs.promises.readFile(outFile, 'utf8')) as {
+      embeddingsMeta?: { provider: string; dim: number } | null;
+    };
+    expect(raw.embeddingsMeta).toBeTruthy();
+  });
+
+  it('resolves the output path through an injected index store', async () => {
+    const provider = new LocalFolderBundleProvider({ root: tempDir, sourceId: 'local' });
+    const storedIndex = path.join(tempDir, 'shared', 'primitive-index.v2.json');
+    const indexStore = {
+      getIndexPath: () => storedIndex
+    };
+
+    const result = await buildIndex({
+      provider,
+      indexStore,
+      indexKey: {
+        hubId: 'local',
+        sourceRevision: 'current',
+        searchProfileId: 'bm25-v1'
+      }
+    });
+
+    expect(result.outFile).toBe(storedIndex);
+    expect(fs.existsSync(storedIndex)).toBe(true);
+  });
+
+  it('reports partial coverage when a configured source cannot enumerate bundles', async () => {
+    const healthy = new LocalFolderBundleProvider({ root: tempDir, sourceId: 'healthy' });
+    const broken: BundleProvider = {
+      async* listBundles(): AsyncIterable<BundleRef> {
+        yield* [];
+        throw new Error('source is unavailable');
+      },
+      readManifest: async (): Promise<BundleManifest> => ({ id: 'broken', version: '1.0.0', name: 'Broken' }),
+      readFile: async (): Promise<string> => ''
+    };
+    const provider = new CompositeBundleProvider([
+      { sourceId: 'healthy', provider: healthy },
+      { sourceId: 'broken', provider: broken }
+    ]);
+
+    const result = await buildIndex({ provider, outFile });
+
+    expect(result.primitives).toBe(1);
+    expect(result.report).toMatchObject({
+      state: 'partial',
+      primitives: 1,
+      bundles: 1,
+      sourceCoverage: [
+        { sourceId: 'healthy', state: 'indexed' },
+        { sourceId: 'broken', state: 'failed', message: 'source is unavailable' }
+      ]
+    });
+    expect(result.report.elapsedMs).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/packages/app/test/search/bundle-search-keys.test.ts
+++ b/packages/app/test/search/bundle-search-keys.test.ts
@@ -1,0 +1,41 @@
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  resolveBundleSearchKeys,
+} from '../../src/search';
+
+describe('resolveBundleSearchKeys', () => {
+  it('maps source-level index records to catalog bundle identities', () => {
+    const keys = resolveBundleSearchKeys(
+      [
+        { sourceId: 'github-source', bundleId: 'github-source' },
+        { sourceId: 'awesome-source', bundleId: 'collection-b' }
+      ],
+      [
+        { sourceId: 'github-source', bundleId: 'owner-repo-v1.2.3' },
+        { sourceId: 'awesome-source', bundleId: 'collection-a' },
+        { sourceId: 'awesome-source', bundleId: 'collection-b' }
+      ]
+    );
+
+    expect(keys).toEqual([
+      'github-source\u0000owner-repo-v1.2.3',
+      'awesome-source\u0000collection-b'
+    ]);
+  });
+
+  it('preserves ranked order and removes duplicate catalog identities', () => {
+    const keys = resolveBundleSearchKeys(
+      [
+        { sourceId: 'source', bundleId: 'bundle' },
+        { sourceId: 'source', bundleId: 'bundle' }
+      ],
+      [{ sourceId: 'source', bundleId: 'bundle' }]
+    );
+
+    expect(keys).toEqual(['source\u0000bundle']);
+  });
+});

--- a/packages/app/test/search/search-index.test.ts
+++ b/packages/app/test/search/search-index.test.ts
@@ -1,0 +1,303 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  getBundleRefKey,
+} from '@ai-primitives-hub/core';
+import {
+  LocalFolderBundleProvider,
+} from '@ai-primitives-hub/infra';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  buildIndex,
+  canonicalizeIndexHubId,
+  searchIndex,
+  SearchIndexError,
+  searchPrimitives,
+} from '../../src/search';
+
+describe('canonicalizeIndexHubId', () => {
+  it('converges generated timestamp-suffixed ids with their stable base id', () => {
+    expect(canonicalizeIndexHubId('amadeus-hub-788228')).toBe('amadeus-hub');
+  });
+
+  it('preserves explicit ids that do not use the generated suffix format', () => {
+    expect(canonicalizeIndexHubId('team-hub')).toBe('team-hub');
+  });
+});
+
+describe('searchIndex', () => {
+  let tempDir: string;
+  let bundleDir: string;
+  let embeddedIndex: string;
+  let plainIndex: string;
+  let keyedIndex: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'app-search-index-test-'));
+    bundleDir = path.join(tempDir, 'local-foo');
+    await fs.promises.mkdir(path.join(bundleDir, 'prompts'), { recursive: true });
+    await fs.promises.writeFile(
+      path.join(bundleDir, 'deployment-manifest.yml'),
+      'id: local-foo\nversion: 1.0.0\nname: Local Foo\nitems:\n  - path: prompts/hello.prompt.md\n    kind: prompt\n'
+    );
+    await fs.promises.writeFile(
+      path.join(bundleDir, 'prompts', 'hello.prompt.md'),
+      '# Hello Prompt\n\nA diagnostic prompt.\n'
+    );
+
+    const provider = new LocalFolderBundleProvider({ root: tempDir, sourceId: 'local' });
+    embeddedIndex = path.join(tempDir, 'embedded.json');
+    plainIndex = path.join(tempDir, 'plain.json');
+    keyedIndex = path.join(tempDir, 'keyed.json');
+    await buildIndex({ provider, outFile: embeddedIndex, embed: true });
+    await buildIndex({ provider, outFile: plainIndex, embed: false });
+    await buildIndex({
+      provider,
+      outFile: keyedIndex,
+      indexKey: {
+        hubId: 'local-hub',
+        sourceRevision: 'source-revision-1',
+        searchProfileId: 'bm25-v1'
+      }
+    });
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('performs keyword search with bm25 ranking', async () => {
+    const result = await searchIndex({
+      indexPath: embeddedIndex,
+      query: { q: 'hello', limit: 5 }
+    });
+    expect(result.hits.length).toBeGreaterThan(0);
+    expect(result.hits[0].primitive.title.toLowerCase()).toContain('hello');
+  });
+
+  it('performs hybrid search on an embedded index', async () => {
+    const result = await searchIndex({
+      indexPath: embeddedIndex,
+      query: { q: 'diagnostic prompt', limit: 5 },
+      ranking: 'hybrid'
+    });
+    expect(result.hits.length).toBeGreaterThan(0);
+  });
+
+  it('rejects hybrid ranking on a non-embedded index', async () => {
+    await expect(searchIndex({
+      indexPath: plainIndex,
+      query: { q: 'diagnostic prompt', limit: 5 },
+      ranking: 'hybrid'
+    })).rejects.toBeInstanceOf(SearchIndexError);
+  });
+
+  it('rejects hybrid ranking without a text query', async () => {
+    await expect(searchIndex({
+      indexPath: embeddedIndex,
+      query: { limit: 5 },
+      ranking: 'hybrid'
+    })).rejects.toBeInstanceOf(SearchIndexError);
+  });
+
+  it('rejects a profile that is incompatible with the persisted index', async () => {
+    await expect(searchIndex({
+      indexPath: embeddedIndex,
+      query: { q: 'diagnostic prompt', limit: 5 },
+      profile: 'ternlight-dual-v1'
+    })).rejects.toMatchObject({
+      code: 'PROFILE_MISMATCH'
+    });
+  });
+
+  it('rejects a namespaced index with an incompatible source revision', async () => {
+    await expect(searchIndex({
+      indexPath: keyedIndex,
+      indexKey: {
+        hubId: 'local-hub',
+        sourceRevision: 'source-revision-2',
+        searchProfileId: 'bm25-v1'
+      },
+      query: { q: 'hello', limit: 5 }
+    })).rejects.toMatchObject({
+      code: 'SOURCE_REVISION_MISMATCH'
+    });
+  });
+
+  it('reports the shared profile and embedding mode used for a query', async () => {
+    const result = await searchIndex({
+      indexPath: embeddedIndex,
+      query: { q: 'diagnostic prompt', limit: 5 },
+      profile: 'ternlight-single-v1'
+    });
+    expect(result.searchProfileId).toBe('ternlight-single-v1');
+    expect(result.ranking).toBe('hybrid');
+    expect(result.embeddingUsed).toBe(true);
+  });
+
+  it('infers the persisted embedding profile when no ranking is supplied', async () => {
+    const result = await searchIndex({
+      indexPath: embeddedIndex,
+      query: { q: 'diagnostic prompt', limit: 5 }
+    });
+    expect(result.searchProfileId).toBe('ternlight-single-v1');
+    expect(result.ranking).toBe('hybrid');
+    expect(result.embeddingUsed).toBe(true);
+  });
+
+  it('keeps CLI-style and extension-style searches equivalent', async () => {
+    const cliResult = await searchIndex({
+      indexPath: embeddedIndex,
+      query: { q: 'diagnostic prompt', limit: 5 }
+    });
+    const extensionResult = await searchIndex({
+      indexPath: embeddedIndex,
+      query: { q: 'diagnostic prompt', limit: 5 },
+      profile: 'ternlight-single-v1'
+    });
+
+    expect(cliResult.hits.map((hit) => hit.primitive.id))
+      .toEqual(extensionResult.hits.map((hit) => hit.primitive.id));
+    expect(cliResult.searchProfileId).toBe(extensionResult.searchProfileId);
+    expect(cliResult.ranking).toBe(extensionResult.ranking);
+    expect(cliResult.embeddingUsed).toBe(extensionResult.embeddingUsed);
+  });
+});
+
+describe('searchPrimitives', () => {
+  let tempDir: string;
+  let bundleDir: string;
+  let embeddedIndex: string;
+  let plainIndex: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'app-search-primitives-test-'));
+    bundleDir = path.join(tempDir, 'local-foo');
+    await fs.promises.mkdir(path.join(bundleDir, 'prompts'), { recursive: true });
+    await fs.promises.writeFile(
+      path.join(bundleDir, 'deployment-manifest.yml'),
+      'id: local-foo\nversion: 1.0.0\nname: Local Foo\nitems:\n  - path: prompts/hello.prompt.md\n    kind: prompt\n'
+    );
+    await fs.promises.writeFile(
+      path.join(bundleDir, 'prompts', 'hello.prompt.md'),
+      '# Hello Prompt\n\nA diagnostic prompt.\n'
+    );
+
+    const provider = new LocalFolderBundleProvider({ root: tempDir, sourceId: 'local' });
+    embeddedIndex = path.join(tempDir, 'embedded.json');
+    plainIndex = path.join(tempDir, 'plain.json');
+    await buildIndex({ provider, outFile: embeddedIndex, embed: true });
+    await buildIndex({ provider, outFile: plainIndex, embed: false });
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns a typed ready response for a compatible persisted index', async () => {
+    const response = await searchPrimitives({
+      indexPath: plainIndex,
+      request: { q: 'hello', limit: 5 }
+    });
+
+    expect(response.status).toBe('ready');
+    expect(response.index.state).toBe('ready');
+    expect(response.index.searchProfileId).toBe('bm25-v1');
+    expect(response.result?.hits[0]?.primitive.title).toBe('Hello Prompt');
+    expect(response.warning).toBeUndefined();
+  });
+
+  it('preserves lifecycle partial and refreshing states while returning indexed results', async () => {
+    const partial = await searchPrimitives({
+      indexPath: plainIndex,
+      indexStatus: {
+        state: 'partial',
+        sourceCoverage: [{ sourceId: 'unsupported-source', state: 'unsupported' }]
+      },
+      request: { q: 'hello', limit: 5 }
+    });
+    const refreshing = await searchPrimitives({
+      indexPath: plainIndex,
+      indexStatus: { state: 'refreshing' },
+      request: { q: 'hello', limit: 5 }
+    });
+
+    expect(partial.status).toBe('degraded');
+    expect(partial.index.state).toBe('partial');
+    expect(partial.result?.hits).toHaveLength(1);
+    expect(refreshing.status).toBe('degraded');
+    expect(refreshing.index.state).toBe('refreshing');
+    expect(refreshing.result?.hits).toHaveLength(1);
+  });
+
+  it('applies the installed bundle overlay without rebuilding the index', async () => {
+    const initial = await searchPrimitives({
+      indexPath: plainIndex,
+      request: { q: 'hello', limit: 5 }
+    });
+    const bundle = initial.result?.hits[0]?.primitive.bundle;
+    expect(bundle).toBeDefined();
+
+    const response = await searchPrimitives({
+      indexPath: plainIndex,
+      installedBundleKeys: [getBundleRefKey(bundle!)],
+      request: { q: 'hello', installedOnly: true, limit: 5 }
+    });
+
+    expect(response.status).toBe('ready');
+    expect(response.result?.hits).toHaveLength(1);
+    expect(response.result?.hits[0]?.primitive.bundle.installed).toBe(true);
+  });
+
+  it('maps a missing persisted index to an unavailable response', async () => {
+    const response = await searchPrimitives({
+      indexPath: path.join(tempDir, 'missing.json'),
+      request: { q: 'hello' }
+    });
+
+    expect(response).toMatchObject({
+      status: 'unavailable',
+      index: { state: 'missing' },
+      warning: { code: 'INDEX_MISSING' }
+    });
+  });
+
+  it('maps an incompatible profile to an unavailable response with a typed cause', async () => {
+    const response = await searchPrimitives({
+      indexPath: embeddedIndex,
+      request: { q: 'diagnostic prompt', profile: 'ternlight-dual-v1' }
+    });
+
+    expect(response).toMatchObject({
+      status: 'unavailable',
+      index: { state: 'incompatible' },
+      warning: {
+        code: 'INDEX_INCOMPATIBLE',
+        causeCode: 'PROFILE_MISMATCH'
+      }
+    });
+  });
+
+  it('maps an unreadable persisted index to a failed response', async () => {
+    const malformedIndex = path.join(tempDir, 'malformed.json');
+    await fs.promises.writeFile(malformedIndex, '{ not-json }');
+
+    const response = await searchPrimitives({
+      indexPath: malformedIndex,
+      request: { q: 'hello' }
+    });
+
+    expect(response).toMatchObject({
+      status: 'unavailable',
+      index: { state: 'failed' },
+      warning: { code: 'SEARCH_FAILED' }
+    });
+  });
+});

--- a/packages/app/test/search/search-profile.test.ts
+++ b/packages/app/test/search/search-profile.test.ts
@@ -1,0 +1,45 @@
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  createEmbeddingProvider,
+  getSearchProfile,
+} from '../../src/search/search-profile';
+
+describe('search profiles', () => {
+  it('exposes stable BM25 and TernLite profiles', () => {
+    expect(getSearchProfile('bm25-v1')).toMatchObject({
+      id: 'bm25-v1',
+      ranking: 'bm25',
+      embeddingStrategy: undefined
+    });
+    expect(getSearchProfile('ternlight-single-v1')).toMatchObject({
+      id: 'ternlight-single-v1',
+      ranking: 'hybrid',
+      embeddingProvider: 'ternlight-mini',
+      embeddingStrategy: 'single'
+    });
+    expect(getSearchProfile('ternlight-dual-v1')).toMatchObject({
+      id: 'ternlight-dual-v1',
+      ranking: 'multi',
+      embeddingProvider: 'ternlight-mini',
+      embeddingStrategy: 'dual'
+    });
+  });
+
+  it('uses the same TernLite provider contract for embedded profiles', () => {
+    const provider = createEmbeddingProvider(getSearchProfile('ternlight-single-v1'));
+    expect(provider.name).toBe('ternlight-mini');
+    expect(provider.dim).toBe(384);
+  });
+
+  it('does not create an embedding provider for BM25', () => {
+    expect(createEmbeddingProvider(getSearchProfile('bm25-v1'))).toBeUndefined();
+  });
+
+  it('rejects unknown profiles', () => {
+    expect(() => getSearchProfile('unknown-v1')).toThrow(/Unknown search profile/);
+  });
+});

--- a/packages/app/test/update/check-updates.test.ts
+++ b/packages/app/test/update/check-updates.test.ts
@@ -123,6 +123,20 @@ describe('UpdateCheckerCore.checkForUpdates', () => {
     expect(checkUpdatesCalls).toBe(2);
   });
 
+  it('can query freshly synchronized sources without syncing them again', async () => {
+    let syncSourceCalls = 0;
+    const registry = makeRegistry({
+      syncSource: async () => {
+        syncSourceCalls++;
+      }
+    });
+    const checker = new UpdateCheckerCore({ registry, preferences, cache });
+
+    await checker.checkForUpdates(false, false);
+
+    expect(syncSourceCalls).toBe(0);
+  });
+
   it('enriches a raw BundleUpdate with bundle metadata and the auto-update preference', async () => {
     const update: BundleUpdate = { bundleId: 'bundle-1', currentVersion: '1.0.0', latestVersion: '2.0.0', changelog: 'notes' };
     const registry = makeRegistry({

--- a/packages/cli/esbuild.config.mjs
+++ b/packages/cli/esbuild.config.mjs
@@ -1,9 +1,42 @@
 import esbuild from 'esbuild';
+import fs from 'node:fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+/**
+ * Inline the ternlight WASM so the SEA bundle is self-contained.
+ *
+ * `@ternlight/mini/pkg-node/tern_engine.js` loads `tern_engine_bg.wasm` from
+ * disk at module initialization. In a single-executable bundle there is no
+ * stable filesystem to load from, so we replace the `readFileSync` call with a
+ * base64-encoded buffer. The 7.5 MB WASM becomes ~10 MB of base64 in the
+ * bundle but keeps the executable portable.
+ */
+const ternlightWasmPlugin = {
+  name: 'ternlight-wasm-inline',
+  setup(build) {
+    build.onLoad({ filter: /pkg-node[\\/]tern_engine\.js$/ }, async (args) => {
+      const source = await fs.promises.readFile(args.path, 'utf8');
+      const wasmPath = path.join(path.dirname(args.path), 'tern_engine_bg.wasm');
+      const wasmBytes = await fs.promises.readFile(wasmPath);
+      const base64 = wasmBytes.toString('base64');
+
+      const needle = `const wasmPath = \`\${__dirname}/tern_engine_bg.wasm\`;\nconst wasmBytes = require('fs').readFileSync(wasmPath);`;
+      if (!source.includes(needle)) {
+        throw new Error(
+          `ternlight-wasm-inline: could not locate wasm loader in ${args.path}`
+        );
+      }
+
+      const replacement = `const wasmBytes = Buffer.from('${base64}', 'base64');`;
+      const contents = source.replace(needle, replacement);
+      return { contents, loader: 'js' };
+    });
+  }
+};
 
 await esbuild.build({
   entryPoints: ['src/sea-entry.ts'],
@@ -20,5 +53,6 @@ await esbuild.build({
   sourcemap: false,
   treeShaking: true,
   metafile: true,
-  absWorkingDir: __dirname
+  absWorkingDir: __dirname,
+  plugins: [ternlightWasmPlugin]
 });

--- a/packages/cli/src/commands/index-build.ts
+++ b/packages/cli/src/commands/index-build.ts
@@ -2,19 +2,20 @@
  * `index build` — build a primitive index from a local folder of
  * bundles.
  *
- * Wraps `LocalFolderBundleProvider` + `PrimitiveIndex.buildFrom` and
- * persists via `saveIndex`. Output goes through `formatOutput` so
- * callers get a stable JSON envelope on `-o json`.
+ * Delegates to the `buildIndex` use case in `@ai-primitives-hub/app`;
+ * this file only parses flags, validates required options, and formats
+ * output.
  * @module commands/index-build
  */
-import * as path from 'node:path';
 import type {
-  IndexStats,
-} from '@ai-primitives-hub/infra';
+  BuildIndexResult,
+} from '@ai-primitives-hub/app';
 import {
+  buildIndex,
+} from '@ai-primitives-hub/app';
+import {
+  defaultIndexFile,
   LocalFolderBundleProvider,
-  PrimitiveIndex,
-  saveIndex,
 } from '@ai-primitives-hub/infra';
 import {
   Command,
@@ -25,11 +26,6 @@ import {
   type OutputFormat,
   RegistryError,
 } from '../framework';
-
-interface BuildResult {
-  outFile: string;
-  stats: IndexStats;
-}
 
 /**
  * Index build command class.
@@ -42,15 +38,20 @@ export class IndexBuildCommand extends Command {
     description: 'Build a primitive index from a local folder of bundles.',
     category: 'Index & Search',
     details: `
-      Usage: ai-primitives-hub index build --root <DIR> [options]
+      Usage: ai-primitives-hub index build [options]
 
       Options:
-        --root <dir>              Root directory containing bundles (required)
-        --out, --out-file <path>  Output index file path
+        --root <dir>              Root directory containing bundles (default: current directory)
+        --out, --out-file <path>  Output index file path (default: <XDG cache>/primitive-index.json)
         --source-id <id>          Source ID for the index
+        --embed                   Embed primitive text using the local ternlight model
+        --embed-strategy <name>   Embedding strategy: single (default) or dual
         -o, --output <format>     Output format (text, json, yaml, ndjson)
 
       Examples:
+        ai-primitives-hub index build
+        ai-primitives-hub index build --embed
+        ai-primitives-hub index build --embed --embed-strategy dual
         ai-primitives-hub index build --root ./bundles
         ai-primitives-hub index build --root ./bundles --out /tmp/index.json
         ai-primitives-hub index build --root ./bundles --source-id my-source
@@ -60,6 +61,8 @@ export class IndexBuildCommand extends Command {
   public root = Option.String('--root');
   public out = Option.String('--out,--out-file');
   public sourceId = Option.String('--source-id');
+  public embed = Option.Boolean('--embed', false);
+  public embedStrategy = Option.String('--embed-strategy');
   public output = Option.String('-o,--output');
   public commandContext!: { ctx: Context };
 
@@ -67,26 +70,24 @@ export class IndexBuildCommand extends Command {
     const { ctx } = this.commandContext;
 
     const fmt = (this.output ?? 'text') as OutputFormat;
-
-    if (!this.root || this.root.length === 0) {
-      return failWith(ctx, fmt, 'index.build', new RegistryError({
-        code: 'USAGE.MISSING_FLAG',
-        message: 'index build: --root <DIR> is required'
-      }));
-    }
+    const root = this.root ?? ctx.cwd();
 
     try {
-      const outFile = this.out ?? path.join(this.root, 'primitive-index.json');
+      const outFile = this.out ?? defaultIndexFile(ctx.env);
       const provider = new LocalFolderBundleProvider({
-        root: this.root,
+        root,
         sourceId: this.sourceId
       });
-      const idx = await PrimitiveIndex.buildFrom(provider, {
-        hubId: this.sourceId
+      const data: BuildIndexResult = await buildIndex({
+        provider,
+        outFile,
+        hubId: this.sourceId,
+        embed: this.embed,
+        embedStrategy: this.embedStrategy as 'single' | 'dual' | undefined,
+        onLog: (msg): void => {
+          ctx.stderr.write(`[index build] ${msg}\n`);
+        }
       });
-      saveIndex(idx, outFile);
-      const stats = idx.stats();
-      const data: BuildResult = { outFile, stats };
       formatOutput({
         ctx,
         command: 'index.build',
@@ -94,8 +95,9 @@ export class IndexBuildCommand extends Command {
         status: 'ok',
         data,
         textRenderer: (d) =>
-          `built ${String(d.stats.primitives)} primitives `
-          + `from ${String(d.stats.bundles)} bundles → ${d.outFile}\n`
+          `built ${String(d.primitives)} primitives `
+          + `from ${String(d.bundles)} bundles → ${d.outFile}`
+          + `${d.embeddings ? ` (embeddings: ${d.embeddings.provider} dim=${d.embeddings.dim})` : ''}\n`
       });
       return 0;
     } catch (cause) {

--- a/packages/cli/src/commands/index-harvest.ts
+++ b/packages/cli/src/commands/index-harvest.ts
@@ -9,14 +9,19 @@
  */
 import * as path from 'node:path';
 import {
+  canonicalizeIndexHubId,
+  createEmbeddingProvider,
+  getSearchProfile,
   resolveUserConfigPaths,
 } from '@ai-primitives-hub/app';
 import {
   ActiveHubStore,
+  AppStoragePrimitiveIndexStore,
   harvestHub as defaultHarvestHub,
   type HubHarvestPipelineOptions,
   type HubHarvestPipelineResult,
   HubStore,
+  XdgAppStorage,
 } from '@ai-primitives-hub/infra';
 import {
   Command,
@@ -35,14 +40,15 @@ import {
  * Falls back to the legacy `prompt-registry` config directory so the
  * `ai-primitives-hub` CLI can reuse an active hub configured by the
  * `gh prompt-registry` extension.
- * @param cmd IndexHarvestCommand instance (mutated).
+ * @param cmd Command instance (mutated).
  * @param cmd.hubRepo
+ * @param cmd.hubId
  * @param cmd.hubBranch
  * @param cmd.hubConfigFile
  * @param ctx CLI context.
  */
 async function autoDetectHubFromActive(
-  cmd: { hubRepo?: string; hubBranch?: string; hubConfigFile?: string },
+  cmd: { hubRepo?: string; hubBranch?: string; hubConfigFile?: string; hubId?: string },
   ctx: Context
 ): Promise<void> {
   try {
@@ -63,6 +69,7 @@ async function autoDetectHubFromActive(
       }
       const saved = await new HubStore(candidate.hubs, ctx.fs).load(activeId);
       const hubConfigFile = path.join(candidate.hubs, `${activeId}.yml`);
+      cmd.hubId = cmd.hubId ?? activeId;
       applyHubRef(cmd, saved.reference, hubConfigFile);
       return;
     }
@@ -119,14 +126,21 @@ export class IndexHarvestCommand extends Command {
     details: `
       Usage: ai-primitives-hub index harvest [options]
 
+      Options:
+        --embed              Embed primitive text using the local ternlight model
+        --embed-strategy     Embedding strategy: single (default) or dual
+
       Examples:
         ai-primitives-hub index harvest --hub-repo OWNER/REPO
+        ai-primitives-hub index harvest --hub-repo OWNER/REPO --embed
+        ai-primitives-hub index harvest --hub-repo OWNER/REPO --embed --embed-strategy dual
         ai-primitives-hub index harvest --hub-config-file hub-config.yml
         ai-primitives-hub index harvest --no-hub-config --extra-source 'local:/path/to/bundles'
     `
   });
 
   public hubRepo = Option.String('--hub-repo');
+  public hubId = Option.String('--hub-id');
   public hubBranch = Option.String('--hub-branch');
   public hubConfigFile = Option.String('--hub-config-file');
   public noHubConfig = Option.Boolean('--no-hub-config');
@@ -140,6 +154,8 @@ export class IndexHarvestCommand extends Command {
   public extraSources = Option.Array('--extra-source');
   public force = Option.Boolean('--force');
   public dryRun = Option.Boolean('--dry-run');
+  public embed = Option.Boolean('--embed', false);
+  public embedStrategy = Option.String('--embed-strategy');
   public verbose = Option.Boolean('--verbose');
   public output = Option.String('-o,--output');
   public commandContext!: { ctx: Context };
@@ -176,6 +192,8 @@ export class IndexHarvestCommand extends Command {
       cacheDir: this.cacheDir,
       progressFile: this.progressFile,
       outFile: this.outFile,
+      indexStore: new AppStoragePrimitiveIndexStore(new XdgAppStorage(ctx.env)),
+      hubId: this.hubId === undefined ? undefined : canonicalizeIndexHubId(this.hubId),
       concurrency: this.concurrency ? Number.parseInt(this.concurrency, 10) : undefined,
       explicitToken,
       sourcesInclude: this.sourcesInclude,
@@ -190,7 +208,14 @@ export class IndexHarvestCommand extends Command {
         : undefined,
       onLog: (msg): void => {
         ctx.stderr.write(`[index harvest] ${msg}\n`);
-      }
+      },
+      embeddings: this.embed
+        ? createEmbeddingProvider(getSearchProfile(this.embedStrategy === 'dual' ? 'ternlight-dual-v1' : 'ternlight-single-v1'))
+        : undefined,
+      embeddingStrategy: this.embedStrategy as 'single' | 'dual' | undefined,
+      searchProfileId: this.embed
+        ? (this.embedStrategy === 'dual' ? 'ternlight-dual-v1' : 'ternlight-single-v1')
+        : 'bm25-v1'
     };
 
     const runner = defaultHarvestHub;

--- a/packages/cli/src/commands/index-search.ts
+++ b/packages/cli/src/commands/index-search.ts
@@ -11,7 +11,10 @@
  */
 import * as path from 'node:path';
 import {
+  canonicalizeIndexHubId,
   resolveUserConfigPaths,
+  searchIndex,
+  SearchIndexError,
 } from '@ai-primitives-hub/app';
 import {
   generateSourceId,
@@ -24,19 +27,22 @@ import type {
 } from '@ai-primitives-hub/core';
 import {
   ActiveHubStore,
+  AppStoragePrimitiveIndexStore,
   defaultIndexFile,
   defaultTokenProvider,
   HubStore,
-  loadIndex,
   NodeHttpClient,
   readTargets,
+  XdgAppStorage,
 } from '@ai-primitives-hub/infra';
 import type {
   PrimitiveKind,
   SearchQuery,
   SearchResult,
 } from '@ai-primitives-hub/infra';
-import inquirer from 'inquirer';
+import {
+  loadInquirer,
+} from '../framework';
 import {
   Command,
   type Context,
@@ -101,6 +107,8 @@ function buildSearchCandidates(sources: RegistrySource[], hits: SearchResult['hi
 }
 
 async function selectBundleIds(candidates: SearchCandidate[], interactive: boolean, ctx: Context): Promise<string[] | null> {
+  const inquirer = await loadInquirer();
+
   if (!interactive) {
     return candidates.map((c) => c.bundleId);
   }
@@ -159,6 +167,7 @@ async function searchAndInstall(
   ctx: Context,
   fmt: OutputFormat
 ): Promise<number> {
+  const inquirer = await loadInquirer();
   const http = opts.http ?? new NodeHttpClient();
   const tokens = opts.tokens ?? defaultTokenProvider(ctx.env);
   const mgr = createHubManager({ ctx, http, tokens });
@@ -238,7 +247,10 @@ const classifyError = (cause: unknown, indexPath: string): RegistryError => {
 };
 
 const renderSearchText = (r: SearchResult): string => {
-  const lines: string[] = [`total: ${String(r.total)}  took: ${String(r.tookMs)}ms`];
+  const lines: string[] = [
+    `total: ${String(r.total)}  took: ${String(r.tookMs)}ms`,
+    `profile: ${r.searchProfileId ?? 'unknown'}  ranking: ${r.ranking ?? 'unknown'}  embeddings: ${String(r.embeddingUsed === true)}`
+  ];
   for (const hit of r.hits) {
     const p = hit.primitive;
     lines.push(
@@ -251,6 +263,34 @@ const renderSearchText = (r: SearchResult): string => {
   }
   return lines.join('\n') + '\n';
 };
+
+async function resolveDefaultIndexPath(ctx: Context, ranking: string | undefined): Promise<string> {
+  const profileIds = ranking === 'hybrid'
+    ? ['ternlight-single-v1']
+    : (ranking === 'multi'
+      ? ['ternlight-dual-v1']
+      : ['ternlight-dual-v1', 'ternlight-single-v1', 'bm25-v1']);
+  const userPaths = resolveUserConfigPaths(ctx.env);
+  const legacyRoot = path.join(path.dirname(userPaths.root), 'prompt-registry');
+  const activePointers = [
+    userPaths.activeHub,
+    path.join(legacyRoot, 'active-hub.json')
+  ];
+  const store = new AppStoragePrimitiveIndexStore(new XdgAppStorage(ctx.env));
+  for (const activePointer of activePointers) {
+    const activeHubId = await new ActiveHubStore(activePointer, ctx.fs).get();
+    if (activeHubId !== null) {
+      const indexHubId = canonicalizeIndexHubId(activeHubId);
+      for (const profileId of profileIds) {
+        const latest = await store.findLatestIndexPath(indexHubId, profileId);
+        if (latest !== undefined) {
+          return latest;
+        }
+      }
+    }
+  }
+  return defaultIndexFile(ctx.env);
+}
 
 /**
  * Index search command class.
@@ -276,6 +316,7 @@ export class IndexSearchCommand extends Command {
         --limit <n>              Limit number of results
         --offset <n>             Skip first n results
         --explain                 Show search scoring explanation
+        --ranking <bm25|hybrid|multi>  Ranking strategy (default: bm25)
         --install                Install matching primitives
         --interactive            Interactive mode for installation
         --install-target <name>  Target name for installation
@@ -284,6 +325,7 @@ export class IndexSearchCommand extends Command {
       Examples:
         ai-primitives-hub index search "docker"
         ai-primitives-hub index search --query "docker" --kinds skill
+        ai-primitives-hub index search --query "docker" --ranking hybrid
         ai-primitives-hub index search --sources github --limit 10
     `
   });
@@ -299,6 +341,7 @@ export class IndexSearchCommand extends Command {
   public limit = Option.String('--limit');
   public offset = Option.String('--offset');
   public explain = Option.Boolean('--explain');
+  public ranking = Option.String('--ranking');
   public install = Option.Boolean('--install', false);
   public interactive = Option.Boolean('--interactive', false);
   public installTarget = Option.String('--install-target');
@@ -308,10 +351,17 @@ export class IndexSearchCommand extends Command {
     const { ctx } = this.commandContext;
 
     const fmt = (this.output ?? 'text') as OutputFormat;
-    const indexPath = this.index ?? defaultIndexFile(ctx.env);
+    const indexPath = this.index ?? await resolveDefaultIndexPath(ctx, this.ranking);
+
+    if (this.ranking !== undefined && this.ranking !== 'bm25' && this.ranking !== 'hybrid' && this.ranking !== 'multi') {
+      return failWith(ctx, fmt, 'index.search', new RegistryError({
+        code: 'USAGE.INVALID_FLAG',
+        message: `Invalid --ranking value: ${this.ranking}`,
+        hint: 'Use `bm25` (default), `hybrid`, or `multi`.'
+      }));
+    }
 
     try {
-      const idx = loadIndex(indexPath);
       const query: SearchQuery = {
         q: this.query,
         kinds: this.kinds as PrimitiveKind[],
@@ -321,9 +371,10 @@ export class IndexSearchCommand extends Command {
         installedOnly: this.installedOnly,
         limit: this.limit ? Number.parseInt(this.limit, 10) : undefined,
         offset: this.offset ? Number.parseInt(this.offset, 10) : undefined,
-        explain: this.explain
+        explain: this.explain,
+        ranking: this.ranking
       };
-      const result = idx.search(query);
+      const result = await searchIndex({ indexPath, query, ranking: query.ranking });
       formatOutput({
         ctx,
         command: 'index.search',
@@ -342,6 +393,12 @@ export class IndexSearchCommand extends Command {
       }
       return 0;
     } catch (cause) {
+      if (cause instanceof SearchIndexError) {
+        return failWith(ctx, fmt, 'index.search', new RegistryError({
+          code: `INDEX.${cause.code}`,
+          message: cause.message
+        }));
+      }
       return failWith(ctx, fmt, 'index.search', classifyError(cause, indexPath));
     }
   }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -17,8 +17,10 @@
  */
 import * as path from 'node:path';
 import {
+  createEmbeddingProvider,
   emptyLockfile,
   getLockfilePathForMode,
+  getSearchProfile,
   resolveUserConfigPaths,
   writeLockfile,
 } from '@ai-primitives-hub/app';
@@ -33,12 +35,16 @@ import {
 import {
   addTarget,
   addTargetToPath,
+  defaultIndexFile,
   findProjectConfigPath,
   getEnabledDefaultHubs,
+  harvestHub,
   readTargets,
   writeTargets,
 } from '@ai-primitives-hub/infra';
-import inquirer from 'inquirer';
+import {
+  loadInquirer,
+} from '../framework';
 import {
   Command,
   type CommandDefinition,
@@ -124,6 +130,10 @@ export interface InitOptions {
   yes?: boolean;
   /** Verbose output with file paths and verification commands. */
   verbose?: boolean;
+  /** Skip building the searchable index after hub import. */
+  skipIndex?: boolean;
+  /** When building an index, skip generating embeddings. */
+  noEmbed?: boolean;
   /** HTTP client seam for testing. */
   http?: HttpClient;
   /** Token provider seam for testing. */
@@ -167,6 +177,8 @@ export class InitCommand extends Command {
         ai-primitives-hub init --target-name my-copilot --target-type copilot-cli --yes
         ai-primitives-hub init --hub owner/repo --yes
         ai-primitives-hub init --hub file:./hub-config.yml --hub-type local --yes
+        ai-primitives-hub init --hub owner/repo --yes --no-embed
+        ai-primitives-hub init --hub owner/repo --yes --skip-index
     `
   });
 
@@ -176,6 +188,8 @@ export class InitCommand extends Command {
   public hub = Option.String('--hub');
   public hubType = Option.String('--hub-type');
   public yes = Option.Boolean('-y,--yes', false);
+  public skipIndex = Option.Boolean('--skip-index', false);
+  public noEmbed = Option.Boolean('--no-embed', false);
   public output = Option.String('-o,--output');
   public verbose = Option.Boolean('-v,--verbose', false);
   public commandContext!: { ctx: Context; http?: HttpClient; tokens?: TokenProvider };
@@ -190,6 +204,8 @@ export class InitCommand extends Command {
       hub: this.hub,
       hubType: this.hubType as HubType | undefined,
       yes: this.yes,
+      skipIndex: this.skipIndex,
+      noEmbed: this.noEmbed,
       verbose: this.verbose,
       http,
       tokens
@@ -232,6 +248,8 @@ async function runInteractiveWizard(ctx: Context, _opts: InitOptions): Promise<{
     { name: 'Local directory', value: 'local' },
     { name: 'Skip for now', value: 'skip' }
   ];
+
+  const inquirer = await loadInquirer();
 
   const answers = await inquirer.prompt<WizardAnswers>([
     {
@@ -548,6 +566,30 @@ async function runInit(ctx: Context, opts: InitOptions): Promise<number> {
     if (hubRef !== undefined && hubRef.length > 0) {
       hubId = await importAndSyncHub(ctx, hubRef, hubType, hubRefParam, opts);
       steps.push(`hub "${hubId}" imported and synced`);
+    }
+
+    if (hubId !== null && opts.skipIndex !== true) {
+      const hubConfigFile = path.join(userPaths.hubs, `${hubId}.yml`);
+      const outFile = defaultIndexFile(ctx.env);
+      const embeddings = opts.noEmbed === true
+        ? undefined
+        : createEmbeddingProvider(getSearchProfile('ternlight-single-v1'));
+      const indexResult = await harvestHub({
+        hubConfigFile,
+        outFile,
+        embeddings,
+        searchProfileId: embeddings ? 'ternlight-single-v1' : 'bm25-v1',
+        onLog: (msg): void => {
+          ctx.stderr.write(`[index harvest] ${msg}\n`);
+        }
+      }, ctx.env);
+      const embedSuffix = embeddings === undefined
+        ? ''
+        : ` (embeddings: ${embeddings.name} dim=${embeddings.dim})`;
+      // `totals.primitives` is a cumulative progress-log summary and can
+      // include older runs. The persisted index stats are authoritative for
+      // what was actually written by this command.
+      steps.push(`index built: ${String(indexResult.stats.primitives)} primitives → ${outFile}${embedSuffix}`);
     }
 
     const data = {

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -62,12 +62,12 @@ import {
   TargetStateStore,
   ZipBundleExtractor,
 } from '@ai-primitives-hub/infra';
-import inquirer from 'inquirer';
 import {
   Command,
   createHubManager,
   failWith,
   findProjectLockfile,
+  loadInquirer,
   loadTargets,
   lockfilePathForTarget,
   Option,
@@ -543,7 +543,7 @@ async function interactiveBundleSelection(
       return 0;
     }
 
-    await previewInstallation(selectedBundles, target.name, ctx);
+    previewInstallation(selectedBundles, target.name, ctx);
     const confirmed = await confirmInstallation(ctx);
     if (!confirmed) {
       return 0;
@@ -599,7 +599,8 @@ async function promptBundleSelection(
   bundleChoices: { name: string; value: string; short: string }[],
   bundles: { id: string }[]
 ): Promise<{ id: string; version: string; source: string }[]> {
-  const answers = await inquirer.prompt([
+  const inquirer = await loadInquirer();
+  const answers = await inquirer.prompt<{ selectedBundles: string[] }>([
     {
       type: 'checkbox',
       name: 'selectedBundles',
@@ -609,11 +610,11 @@ async function promptBundleSelection(
     }
   ]);
 
-  const selectedBundleIds = answers.selectedBundles as string[];
+  const selectedBundleIds = answers.selectedBundles;
   return bundles.filter((b) => selectedBundleIds.includes(b.id)) as { id: string; version: string; source: string }[];
 }
 
-async function previewInstallation(bundles: { id: string; version: string; source: string }[], targetName: string, ctx: Context): Promise<void> {
+function previewInstallation(bundles: { id: string; version: string; source: string }[], targetName: string, ctx: Context): void {
   ctx.stdout.write(`\nPreview: Installing ${bundles.length} bundle${bundles.length === 1 ? '' : 's'} to target "${targetName}"\n`);
   for (const b of bundles) {
     ctx.stdout.write(`  - ${b.id}@${b.version} (source: ${b.source})\n`);
@@ -621,7 +622,8 @@ async function previewInstallation(bundles: { id: string; version: string; sourc
 }
 
 async function confirmInstallation(ctx: Context): Promise<boolean> {
-  const confirm = await inquirer.prompt([
+  const inquirer = await loadInquirer();
+  const confirm = await inquirer.prompt<{ proceed: boolean }>([
     {
       type: 'confirm',
       name: 'proceed',

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -51,12 +51,12 @@ import {
   TargetStateStore,
   ZipBundleExtractor,
 } from '@ai-primitives-hub/infra';
-import inquirer from 'inquirer';
 import {
   Command,
   createHubManager,
   failWith,
   findProjectLockfile,
+  loadInquirer,
   loadTargets,
   lockfilePathForTarget,
   Option,
@@ -378,6 +378,7 @@ async function selectUpdatesInteractively(interactive: boolean, candidates: Upda
   if (!interactive || candidates.length === 0) {
     return candidates;
   }
+  const inquirer = await loadInquirer();
   const answers = await (inquirer.prompt as (q: unknown) => Promise<{ selected: UpdateCandidate[] }>)([{
     type: 'checkbox',
     name: 'selected',

--- a/packages/cli/src/framework/index.ts
+++ b/packages/cli/src/framework/index.ts
@@ -123,3 +123,6 @@ export {
 export {
   suggestCommand,
 } from './suggest';
+export {
+  loadInquirer,
+} from './inquirer';

--- a/packages/cli/src/framework/inquirer.ts
+++ b/packages/cli/src/framework/inquirer.ts
@@ -1,0 +1,27 @@
+/**
+ * Lazy loader for `inquirer` (ESM-only) when the CLI is compiled as CommonJS.
+ *
+ * Keeps the dynamic import in one place so command code can stay agnostic of
+ * the module system.
+ * @module framework/inquirer
+ */
+
+export type PromptModule = <T = Record<string, unknown>>(
+  questions: unknown,
+  initialAnswers?: Partial<T>
+) => Promise<T>;
+
+export type InquirerShape = { prompt: PromptModule };
+
+let inquirer: InquirerShape | undefined;
+
+/**
+ * Load the inquirer prompt module once and cache it.
+ * @returns An object exposing the inquirer `prompt` function.
+ */
+export async function loadInquirer(): Promise<InquirerShape> {
+  if (inquirer === undefined) {
+    inquirer = (await import('inquirer')).default as InquirerShape;
+  }
+  return inquirer;
+}

--- a/packages/cli/test/commands/doctor-status-init-update.test.ts
+++ b/packages/cli/test/commands/doctor-status-init-update.test.ts
@@ -11,6 +11,7 @@
  * approach in install.test.ts/uninstall.test.ts.
  */
 import {
+  access,
   mkdir,
   mkdtemp,
   rm,
@@ -173,6 +174,30 @@ describe('doctor/status/init/update commands', () => {
   });
 
   describe('init', () => {
+    const writeLocalHubConfig = async (hubConfigFile: string): Promise<void> => {
+      const hubSourceDir = path.join(path.dirname(hubConfigFile), 'hub-source');
+      await mkdir(hubSourceDir, { recursive: true });
+      await writeFile(
+        hubConfigFile,
+        `version: 1.0.0
+metadata:
+  name: Test Hub
+  description: Test hub
+  maintainer: test
+  updatedAt: '2026-01-01T00:00:00Z'
+sources:
+  - id: local-foo-src
+    name: Local Foo Source
+    type: local
+    url: ${hubSourceDir}
+    enabled: true
+    priority: 0
+    hubId: test-hub
+profiles: []
+`
+      );
+    };
+
     it('creates a target non-interactively', async () => {
       const result = await run(['init', '--target-name', 'copilot', '--target-type', 'copilot-cli', '--yes', '-o', 'json']);
       expect(result.exitCode).toBe(0);
@@ -195,27 +220,7 @@ describe('doctor/status/init/update commands', () => {
 
     it('imports and syncs a local hub when --hub/--hub-type local are given', async () => {
       const hubConfigFile = path.join(workspace, 'hub-config.yml');
-      const hubSourceDir = path.join(workspace, 'hub-source');
-      await mkdir(hubSourceDir, { recursive: true });
-      await writeFile(
-        hubConfigFile,
-        `version: 1.0.0
-metadata:
-  name: Test Hub
-  description: Test hub
-  maintainer: test
-  updatedAt: '2026-01-01T00:00:00Z'
-sources:
-  - id: local-foo-src
-    name: Local Foo Source
-    type: local
-    url: ${hubSourceDir}
-    enabled: true
-    priority: 0
-    hubId: test-hub
-profiles: []
-`
-      );
+      await writeLocalHubConfig(hubConfigFile);
       const result = await run([
         'init', '--target-name', 'copilot', '--target-type', 'copilot-cli',
         '--hub', hubConfigFile, '--hub-type', 'local', '--yes', '-o', 'json'
@@ -223,6 +228,45 @@ profiles: []
       expect(result.exitCode).toBe(0);
       const envelope = parseJson<{ hub: { id: string } | null }>(result.stdout);
       expect(envelope.data.hub).not.toBeNull();
+    });
+
+    it('builds an embedded index by default after importing a hub', async () => {
+      const hubConfigFile = path.join(workspace, 'hub-config.yml');
+      const outFile = path.join(workspace, 'xdg-cache', 'ai-primitives-hub', 'primitive-index.json');
+      await writeLocalHubConfig(hubConfigFile);
+      const result = await run([
+        'init', '--target-name', 'copilot', '--target-type', 'copilot-cli',
+        '--hub', hubConfigFile, '--hub-type', 'local', '--yes', '-o', 'json'
+      ]);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ steps: string[] }>(result.stdout);
+      expect(envelope.data.steps.some((s) => s.startsWith('index built:'))).toBe(true);
+      expect(envelope.data.steps.some((s) => s.includes('embeddings: ternlight-mini'))).toBe(true);
+      await access(outFile);
+    });
+
+    it('honours --skip-index and --no-embed flags', async () => {
+      const hubConfigFile = path.join(workspace, 'hub-config.yml');
+      const outFile = path.join(workspace, 'xdg-cache', 'ai-primitives-hub', 'primitive-index.json');
+      await writeLocalHubConfig(hubConfigFile);
+      const result = await run([
+        'init', '--target-name', 'copilot', '--target-type', 'copilot-cli',
+        '--hub', hubConfigFile, '--hub-type', 'local', '--yes', '--skip-index', '-o', 'json'
+      ]);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ steps: string[] }>(result.stdout);
+      expect(envelope.data.steps.some((s) => s.startsWith('index built:'))).toBe(false);
+      await expect(access(outFile)).rejects.toThrow();
+
+      const noEmbedResult = await run([
+        'init', '--target-name', 'copilot', '--target-type', 'copilot-cli',
+        '--hub', hubConfigFile, '--hub-type', 'local', '--yes', '--no-embed', '-o', 'json'
+      ]);
+      expect(noEmbedResult.exitCode).toBe(0);
+      const noEmbedEnvelope = parseJson<{ steps: string[] }>(noEmbedResult.stdout);
+      const indexStep = noEmbedEnvelope.data.steps.find((s) => s.startsWith('index built:'));
+      expect(indexStep).toBeDefined();
+      expect(indexStep).not.toContain('embeddings');
     });
   });
 

--- a/packages/cli/test/commands/index.test.ts
+++ b/packages/cli/test/commands/index.test.ts
@@ -9,6 +9,7 @@
  * already-proven bundle fixture.
  */
 import {
+  copyFile,
   mkdir,
   mkdtemp,
   readFile,
@@ -22,6 +23,7 @@ import {
 } from '@ai-primitives-hub/app';
 import {
   ActiveHubStore,
+  AppStoragePrimitiveIndexStore,
   HubStore,
   NodeFileSystem,
 } from '@ai-primitives-hub/infra';
@@ -90,6 +92,7 @@ describe('index commands', () => {
   let workspace: string;
   let bundleDir: string;
   let indexFile: string;
+  let embeddedIndexFile: string;
 
   const run = (argv: string[]): ReturnType<typeof runCommand> => runCommand(argv, {
     commandClasses: COMMAND_CLASSES,
@@ -111,6 +114,7 @@ describe('index commands', () => {
     workspace = await mkdtemp(path.join(os.tmpdir(), 'cli-index-test-'));
     bundleDir = path.join(workspace, 'bundle');
     indexFile = path.join(workspace, 'primitive-index.json');
+    embeddedIndexFile = path.join(workspace, 'embedded-index.json');
 
     const localFooDir = path.join(bundleDir, 'local-foo');
     await mkdir(path.join(localFooDir, 'prompts'), { recursive: true });
@@ -122,6 +126,10 @@ describe('index commands', () => {
 
     expect((await run([
       'index', 'build', '--root', bundleDir, '--out', indexFile, '--source-id', 'local-foo-src', '-o', 'json'
+    ])).exitCode).toBe(0);
+
+    expect((await run([
+      'index', 'build', '--root', bundleDir, '--out', embeddedIndexFile, '--source-id', 'local-foo-src', '--embed', '-o', 'json'
     ])).exitCode).toBe(0);
   });
 
@@ -135,9 +143,21 @@ describe('index commands', () => {
       expect(content).toBeTruthy();
     });
 
-    it('fails with exit 1 when --root is missing', async () => {
+    it('embeds primitive text when --embed is passed', async () => {
+      const content = JSON.parse(await readFile(embeddedIndexFile, 'utf8')) as {
+        embeddingsMeta?: { provider: string; dim: number } | null;
+      };
+      expect(content.embeddingsMeta).toBeTruthy();
+      expect(content.embeddingsMeta?.dim).toBe(384);
+    });
+
+    it('uses the current directory as the default --root and writes to the XDG cache', async () => {
       const result = await run(['index', 'build', '-o', 'json']);
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ primitives: number; bundles: number; outFile: string }>(result.stdout);
+      expect(envelope.data.primitives).toBe(0);
+      expect(envelope.data.bundles).toBe(0);
+      expect(envelope.data.outFile).toBe(path.join(workspace, 'xdg-cache', 'ai-primitives-hub', 'primitive-index.json'));
     });
   });
 
@@ -171,6 +191,54 @@ describe('index commands', () => {
       expect(envelope.data.hits).toEqual([]);
     });
 
+    it('performs hybrid search with --ranking hybrid on an embedded index', async () => {
+      const result = await run([
+        'index', 'search', '--query', 'diagnostic prompt', '--index', embeddedIndexFile, '--ranking', 'hybrid', '-o', 'json'
+      ]);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ hits: { primitive: { id: string } }[] }>(result.stdout);
+      expect(envelope.data.hits.length).toBeGreaterThan(0);
+    });
+
+    it('reads a stable index namespace for a timestamp-suffixed active hub id', async () => {
+      const store = new AppStoragePrimitiveIndexStore({
+        getPaths: () => ({
+          cache: path.join(workspace, 'xdg-cache', 'ai-primitives-hub'),
+          config: path.join(workspace, 'xdg-config', 'ai-primitives-hub'),
+          data: path.join(workspace, 'xdg-data', 'ai-primitives-hub'),
+          state: path.join(workspace, 'xdg-state', 'ai-primitives-hub')
+        })
+      });
+      const stablePath = store.getIndexPath({
+        hubId: 'amadeus-hub',
+        sourceRevision: 'contract-revision',
+        searchProfileId: 'ternlight-single-v1'
+      });
+      await mkdir(path.dirname(stablePath), { recursive: true });
+      await copyFile(embeddedIndexFile, stablePath);
+
+      const activeHubStore = new ActiveHubStore(
+        path.join(workspace, 'xdg-config', 'ai-primitives-hub', 'active-hub.json'),
+        new NodeFileSystem()
+      );
+      await mkdir(path.dirname(path.join(workspace, 'xdg-config', 'ai-primitives-hub', 'active-hub.json')), { recursive: true });
+      await activeHubStore.set('amadeus-hub-788228');
+
+      const result = await run(['index', 'search', '--query', 'hello', '-o', 'json']);
+
+      expect(result.exitCode, result.stderr).toBe(0);
+      const envelope = parseJson<{ hits: unknown[] }>(result.stdout);
+      expect(envelope.data.hits.length).toBeGreaterThan(0);
+    });
+
+    it('rejects --ranking hybrid on a non-embedded index', async () => {
+      const result = await run([
+        'index', 'search', '--query', 'hello', '--index', indexFile, '--ranking', 'hybrid'
+      ]);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('embedded index');
+    });
+
     it('uses legacy prompt-registry active hub when installing from search results', async () => {
       const userPaths = resolveUserConfigPaths({
         HOME: workspace,
@@ -197,13 +265,17 @@ describe('index commands', () => {
           {
             id: 'local-foo-src',
             name: 'Local Foo Source',
-            description: 'Source matching indexed bundle source id',
             type: 'local',
             url: 'file:///tmp/local-foo',
-            repository: 'local/foo',
-            branch: 'main',
-            path: '/',
-            hubId
+            enabled: true,
+            priority: 0,
+            hubId,
+            metadata: {
+              description: 'Source matching indexed bundle source id'
+            },
+            config: {
+              branch: 'main'
+            }
           }
         ],
         profiles: []

--- a/packages/core/src/domain/bundle/types.ts
+++ b/packages/core/src/domain/bundle/types.ts
@@ -88,6 +88,17 @@ export interface BundleRef {
 }
 
 /**
+ * Stable identity for one source-qualified bundle version.
+ *
+ * The separator is intentionally not user-facing; callers should treat the
+ * result as an opaque key shared by index records and installation snapshots.
+ * @param ref
+ */
+export function getBundleRefKey(ref: Pick<BundleRef, 'sourceId' | 'bundleId' | 'bundleVersion'>): string {
+  return `${ref.sourceId}\u0000${ref.bundleId}\u0000${ref.bundleVersion}`;
+}
+
+/**
  * The subset of a `deployment-manifest.yml` (or legacy `collection.yml`)
  * the harvester's primitive extractor reads: per-item kind/title/tags
  * hints, plus top-level tags/author as fallbacks. Permissive — unknown

--- a/packages/core/src/domain/primitive/types.ts
+++ b/packages/core/src/domain/primitive/types.ts
@@ -68,6 +68,8 @@ export interface Primitive {
   model?: string;
   /** Short excerpt of the primitive's body, for search result previews. */
   bodyPreview: string;
+  /** Optional longer extractive summary of the primitive's body (~80 words). */
+  bodySummary?: string;
   /** Content hash, for change detection between harvests. */
   contentHash: string;
   rating?: number;

--- a/packages/core/src/ports/index.ts
+++ b/packages/core/src/ports/index.ts
@@ -4,6 +4,7 @@
  */
 export * from './source-adapter';
 export * from './app-storage';
+export * from './primitive-index-store';
 export * from './clock';
 export * from './copilot-sdk';
 export * from './filesystem';

--- a/packages/core/src/ports/primitive-index-store.ts
+++ b/packages/core/src/ports/primitive-index-store.ts
@@ -1,0 +1,33 @@
+/**
+ * Compatibility key for a persisted primitive index.
+ */
+export interface PrimitiveIndexKey {
+  /** Stable identity of the hub whose sources were harvested. */
+  hubId: string;
+  /** Stable source snapshot/revision represented by the index. */
+  sourceRevision: string;
+  /** Versioned search/ranking/embedding profile. */
+  searchProfileId: string;
+}
+
+/**
+ * Resolves logical primitive-index keys to physical cache locations.
+ *
+ * The port intentionally resolves a path rather than reading or writing it;
+ * persistence remains owned by the existing index serializer and can retain
+ * its atomic-write/last-known-good policy independently of path resolution.
+ */
+export interface PrimitiveIndexStore {
+  /** Resolve a namespaced persisted index path. */
+  getIndexPath(key: PrimitiveIndexKey): string;
+  /**
+   * Find a usable index for a hub and profile when the requested snapshot is
+   * unavailable. When source IDs are supplied, compatible snapshots are
+   * preferred over newer snapshots from an incompatible source snapshot.
+   */
+  findLatestIndexPath?(
+    hubId: string,
+    searchProfileId: string,
+    sourceIds?: readonly string[]
+  ): Promise<string | undefined>;
+}

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -35,7 +35,8 @@
   },
   "dependencies": {
     "@ai-primitives-hub/core": "workspace:*",
-    "@elastic/elasticsearch": "^9.4.2",
+    "@elastic/elasticsearch": "^9.3.4",
+    "@ternlight/mini": "0.1.0",
     "adm-zip": "^0.6.0",
     "archiver": "^7.0.1",
     "js-yaml": "^4.3.1"

--- a/packages/infra/src/extractors/zip-bundle-extractor.ts
+++ b/packages/infra/src/extractors/zip-bundle-extractor.ts
@@ -26,12 +26,12 @@ export class ZipBundleExtractor implements BundleExtractor {
    * @param bytes Raw bundle bytes (zip).
    * @returns Map of relative paths to file contents.
    */
-  public extract(bytes: Uint8Array): Promise<ExtractedFiles> {
+  public async extract(bytes: Uint8Array): Promise<ExtractedFiles> {
     let zip: AdmZip;
     try {
       zip = new AdmZip(Buffer.from(bytes));
     } catch (error) {
-      return Promise.reject(new Error(`Failed to extract bundle: ${(error as Error).message}`));
+      throw new Error(`Failed to extract bundle: ${(error as Error).message}`);
     }
 
     const files = new Map<string, Uint8Array>();
@@ -39,8 +39,35 @@ export class ZipBundleExtractor implements BundleExtractor {
       if (entry.isDirectory) {
         continue;
       }
-      files.set(entry.entryName, entry.getData());
+      const path = normalizeZipPath(entry.entryName);
+      if (path === undefined) {
+        throw new Error(`Unsafe ZIP path: ${entry.entryName}`);
+      }
+      files.set(path, entry.getData());
     }
-    return Promise.resolve(files);
+    return files;
   }
+}
+
+function normalizeZipPath(entryName: string): string | undefined {
+  const path = entryName.replaceAll('\\', '/');
+  if (path.startsWith('/') || /^[A-Za-z]:\//.test(path)) {
+    return undefined;
+  }
+
+  const segments: string[] = [];
+  for (const segment of path.split('/')) {
+    if (segment === '' || segment === '.') {
+      continue;
+    }
+    if (segment === '..') {
+      if (segments.length === 0) {
+        return undefined;
+      }
+      segments.pop();
+      continue;
+    }
+    segments.push(segment);
+  }
+  return segments.length > 0 ? segments.join('/') : undefined;
 }

--- a/packages/infra/src/harvest/bundle-providers/composite-bundle-provider.ts
+++ b/packages/infra/src/harvest/bundle-providers/composite-bundle-provider.ts
@@ -1,0 +1,91 @@
+/**
+ * Composite BundleProvider for indexing multiple configured sources.
+ * @module harvest/bundle-providers/composite-bundle-provider
+ */
+import type {
+  BundleManifest,
+  BundleProvider,
+  BundleRef,
+} from '@ai-primitives-hub/core';
+
+export interface CompositeBundleProviderEntry {
+  sourceId: string;
+  provider: BundleProvider;
+}
+
+export interface CompositeBundleProviderOptions {
+  /** Called when one source cannot enumerate its bundles. */
+  onSourceError?: (sourceId: string, error: unknown) => void;
+}
+
+/** An error encountered while enumerating one configured source. */
+export interface CompositeBundleProviderSourceError {
+  sourceId: string;
+  error: unknown;
+}
+
+/**
+ * Routes each BundleRef to the provider responsible for its source.
+ */
+export class CompositeBundleProvider implements BundleProvider {
+  private readonly entries: readonly CompositeBundleProviderEntry[];
+  private readonly bySource: ReadonlyMap<string, BundleProvider>;
+  private readonly onSourceError?: CompositeBundleProviderOptions['onSourceError'];
+  private sourceErrors: CompositeBundleProviderSourceError[] = [];
+
+  public constructor(
+    entries: readonly CompositeBundleProviderEntry[],
+    options: CompositeBundleProviderOptions = {}
+  ) {
+    const bySource = new Map<string, BundleProvider>();
+    for (const entry of entries) {
+      if (bySource.has(entry.sourceId)) {
+        throw new Error(`Multiple bundle providers configured for source ${entry.sourceId}`);
+      }
+      bySource.set(entry.sourceId, entry.provider);
+    }
+    this.entries = [...entries];
+    this.bySource = bySource;
+    this.onSourceError = options.onSourceError;
+  }
+
+  private providerFor(ref: BundleRef): BundleProvider {
+    const provider = this.bySource.get(ref.sourceId);
+    if (!provider) {
+      throw new Error(`No bundle provider configured for source ${ref.sourceId}`);
+    }
+    return provider;
+  }
+
+  /** Source IDs configured for this index lifecycle operation. */
+  public getSourceIds(): readonly string[] {
+    return this.entries.map((entry) => entry.sourceId);
+  }
+
+  /** Enumeration failures observed during the latest bundle traversal. */
+  public getSourceErrors(): readonly CompositeBundleProviderSourceError[] {
+    return this.sourceErrors;
+  }
+
+  public async* listBundles(): AsyncIterable<BundleRef> {
+    this.sourceErrors = [];
+    for (const entry of this.entries) {
+      try {
+        for await (const ref of entry.provider.listBundles()) {
+          yield ref;
+        }
+      } catch (error) {
+        this.sourceErrors.push({ sourceId: entry.sourceId, error });
+        this.onSourceError?.(entry.sourceId, error);
+      }
+    }
+  }
+
+  public readManifest(ref: BundleRef): Promise<BundleManifest> {
+    return this.providerFor(ref).readManifest(ref);
+  }
+
+  public readFile(ref: BundleRef, relPath: string): Promise<string> {
+    return this.providerFor(ref).readFile(ref, relPath);
+  }
+}

--- a/packages/infra/src/harvest/bundle-providers/index.ts
+++ b/packages/infra/src/harvest/bundle-providers/index.ts
@@ -3,6 +3,9 @@
  * @module harvest/bundle-providers
  */
 export * from './awesome-copilot-bundle-provider';
+export * from './composite-bundle-provider';
 export * from './github-bundle-provider';
 export * from './local-folder';
 export * from './plugin-bundle-provider';
+export * from './registry-source-bundle-provider';
+export * from './source-adapter-bundle-provider';

--- a/packages/infra/src/harvest/bundle-providers/registry-source-bundle-provider.ts
+++ b/packages/infra/src/harvest/bundle-providers/registry-source-bundle-provider.ts
@@ -1,0 +1,87 @@
+/**
+ * Maps a configured registry source to the native primitive-harvest provider.
+ *
+ * Catalog adapters and primitive harvesters have different responsibilities:
+ * catalog adapters discover installable bundles, while these providers walk
+ * repository trees and extract primitive files. Keeping this mapping in infra
+ * lets CLI and VS Code share the same primitive discovery semantics.
+ * @module harvest/bundle-providers/registry-source-bundle-provider
+ */
+import type {
+  BundleProvider,
+  GitHubApi,
+  HubSourceSpec,
+  RegistrySource,
+} from '@ai-primitives-hub/core';
+import {
+  BlobCache,
+} from '../blob-cache';
+import {
+  AwesomeCopilotBundleProvider,
+} from './awesome-copilot-bundle-provider';
+import {
+  GitHubSingleBundleProvider,
+} from './github-bundle-provider';
+
+export interface RegistrySourceBundleProviderOptions {
+  source: RegistrySource;
+  client: GitHubApi;
+  cache: BlobCache;
+}
+
+/**
+ * Create the native provider for a GitHub-backed registry source.
+ *
+ * Local and non-GitHub sources return `undefined` and continue through the
+ * existing SourceAdapter bridge. Plugin sources are handled by the CLI's
+ * native hub-config parser; the extension's public source union does not yet
+ * expose that source type.
+ * @param options - Source and shared GitHub dependencies.
+ */
+export function createRegistrySourceBundleProvider(
+  options: RegistrySourceBundleProviderOptions
+): BundleProvider | undefined {
+  if (options.source.type !== 'github' && options.source.type !== 'awesome-copilot') {
+    return undefined;
+  }
+
+  const repo = parseGitHubRepo(options.source.url);
+  if (!repo) {
+    return undefined;
+  }
+
+  const config = options.source.config ?? {};
+  const spec: HubSourceSpec = {
+    id: options.source.id,
+    name: options.source.name,
+    type: options.source.type,
+    url: options.source.url,
+    owner: repo.owner,
+    repo: repo.repo,
+    branch: typeof config.branch === 'string' ? config.branch : 'main',
+    ...(options.source.type === 'awesome-copilot'
+      ? { collectionsPath: typeof config.collectionsPath === 'string' ? config.collectionsPath : 'collections' }
+      : {}),
+    rawConfig: config
+  };
+
+  if (options.source.type === 'awesome-copilot') {
+    return new AwesomeCopilotBundleProvider({ spec, client: options.client, cache: options.cache });
+  }
+  return new GitHubSingleBundleProvider({ spec, client: options.client, cache: options.cache });
+}
+
+function parseGitHubRepo(value: string): { owner: string; repo: string } | undefined {
+  try {
+    const url = new URL(value);
+    if (url.hostname !== 'github.com' && url.hostname !== 'www.github.com') {
+      return undefined;
+    }
+    const [owner, repoValue] = url.pathname.split('/').filter(Boolean);
+    const repo = repoValue?.replace(/\.git$/u, '');
+    return owner && repo ? { owner, repo } : undefined;
+  } catch {
+    const match = /^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?$/u.exec(value);
+    return match?.[1] && match[2] ? { owner: match[1], repo: match[2] } : undefined;
+  }
+}

--- a/packages/infra/src/harvest/bundle-providers/source-adapter-bundle-provider.ts
+++ b/packages/infra/src/harvest/bundle-providers/source-adapter-bundle-provider.ts
@@ -1,0 +1,187 @@
+/**
+ * BundleProvider bridge for catalog-style SourceAdapters.
+ *
+ * SourceAdapter exposes rich bundle metadata and downloadable archives,
+ * whereas the primitive harvester needs a BundleProvider that can enumerate
+ * refs and read manifest/files. This adapter keeps that translation in infra
+ * so CLI and VS Code can share it.
+ * @module harvest/bundle-providers/source-adapter-bundle-provider
+ */
+import type {
+  Bundle,
+  BundleExtractor,
+  BundleManifest,
+  BundleProvider,
+  BundleRef,
+  SourceAdapter,
+} from '@ai-primitives-hub/core';
+import {
+  load as parseYaml,
+} from 'js-yaml';
+import {
+  ZipBundleExtractor,
+} from '../../extractors/zip-bundle-extractor';
+
+const MANIFEST_CANDIDATES = [
+  'deployment-manifest.yml',
+  'deployment-manifest.yaml',
+  'collection.yml'
+] as const;
+
+export interface SourceAdapterBundleProviderOptions {
+  adapter: SourceAdapter;
+  /** Optional extractor; defaults to the production ZIP extractor. */
+  extractor?: BundleExtractor;
+  /** Optional policy used to project current installation state onto refs. */
+  isInstalled?: (bundle: Bundle) => boolean;
+}
+
+/**
+ * Adapts one catalog source into a primitive-harvest provider.
+ *
+ * Archives are extracted once per bundle and retained for the lifetime of the
+ * provider. A fresh provider should be created after a source sync so the
+ * catalog and archive cache represent the same source revision.
+ */
+export class SourceAdapterBundleProvider implements BundleProvider {
+  private readonly adapter: SourceAdapter;
+  private readonly extractor: BundleExtractor;
+  private readonly isInstalled: (bundle: Bundle) => boolean;
+  private bundles?: Bundle[];
+  private readonly extracted = new Map<string, ReadonlyMap<string, Uint8Array>>();
+
+  public constructor(options: SourceAdapterBundleProviderOptions) {
+    this.adapter = options.adapter;
+    this.extractor = options.extractor ?? createDefaultExtractor();
+    this.isInstalled = options.isInstalled ?? (() => false);
+  }
+
+  private async loadBundles(): Promise<Bundle[]> {
+    this.bundles ??= await this.adapter.fetchBundles();
+    return this.bundles;
+  }
+
+  private async loadFiles(ref: BundleRef): Promise<ReadonlyMap<string, Uint8Array>> {
+    const key = bundleKey(ref);
+    const cached = this.extracted.get(key);
+    if (cached) {
+      return cached;
+    }
+
+    const bundles = await this.loadBundles();
+    const bundle = bundles.find((candidate) =>
+      candidate.id === ref.bundleId && candidate.version === ref.bundleVersion
+    );
+    if (!bundle) {
+      throw new Error(`Bundle ${ref.bundleId}@${ref.bundleVersion} is not available from source ${ref.sourceId}`);
+    }
+
+    const files = await this.extractor.extract(await this.adapter.downloadBundle(bundle));
+    this.extracted.set(key, files);
+    return files;
+  }
+
+  public async* listBundles(): AsyncIterable<BundleRef> {
+    const bundles = await this.loadBundles();
+    for (const bundle of bundles) {
+      yield {
+        sourceId: this.adapter.source.id,
+        sourceType: this.adapter.source.type,
+        bundleId: bundle.id,
+        bundleVersion: bundle.version,
+        installed: this.isInstalled(bundle)
+      };
+    }
+  }
+
+  public async readManifest(ref: BundleRef): Promise<BundleManifest> {
+    const files = await this.loadFiles(ref);
+    const raw = findFile(files, MANIFEST_CANDIDATES);
+    if (!raw) {
+      throw new Error(`Bundle ${ref.bundleId}@${ref.bundleVersion} has no deployment manifest`);
+    }
+
+    try {
+      return parseManifest(raw);
+    } catch (error) {
+      throw new Error(
+        `Failed to parse manifest for ${ref.bundleId}@${ref.bundleVersion}: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  public async readFile(ref: BundleRef, relPath: string): Promise<string> {
+    const normalized = normalizeRelativePath(relPath);
+    const files = await this.loadFiles(ref);
+    const raw = findFile(files, [normalized]);
+    if (!raw) {
+      throw new Error(`Bundle ${ref.bundleId}@${ref.bundleVersion} has no file ${relPath}`);
+    }
+    return new TextDecoder().decode(raw);
+  }
+}
+
+function bundleKey(ref: BundleRef): string {
+  return `${ref.sourceId}\u0000${ref.bundleId}\u0000${ref.bundleVersion}`;
+}
+
+function normalizeRelativePath(value: string): string {
+  const normalized = value.replaceAll('\\', '/');
+  if (normalized.startsWith('/') || /^[A-Za-z]:\//.test(normalized)) {
+    throw new Error(`Refusing to read unsafe bundle path: ${value}`);
+  }
+
+  const segments: string[] = [];
+  for (const segment of normalized.split('/')) {
+    if (segment === '' || segment === '.') {
+      continue;
+    }
+    if (segment === '..') {
+      if (segments.length === 0) {
+        throw new Error(`Refusing to read unsafe bundle path: ${value}`);
+      }
+      segments.pop();
+      continue;
+    }
+    segments.push(segment);
+  }
+  if (segments.length === 0) {
+    throw new Error(`Refusing to read empty bundle path: ${value}`);
+  }
+  return segments.join('/');
+}
+
+function findFile(
+  files: ReadonlyMap<string, Uint8Array>,
+  requestedPaths: readonly string[]
+): Uint8Array | undefined {
+  const normalizedPaths = requestedPaths.map((value) => normalizeRelativePath(value));
+  for (const requested of normalizedPaths) {
+    const exact = files.get(requested);
+    if (exact) {
+      return exact;
+    }
+
+    const suffix = `/${requested}`;
+    const matches = [...files.entries()].filter(([name]) => name.endsWith(suffix));
+    if (matches.length === 1) {
+      return matches[0][1];
+    }
+    if (matches.length > 1) {
+      throw new Error(`Bundle contains multiple files matching ${requested}`);
+    }
+  }
+  return undefined;
+}
+
+function parseManifest(raw: Uint8Array): BundleManifest {
+  const parsed = parseYaml(new TextDecoder().decode(raw));
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error('manifest must contain a YAML object');
+  }
+  return parsed as BundleManifest;
+}
+
+function createDefaultExtractor(): BundleExtractor {
+  return new ZipBundleExtractor();
+}

--- a/packages/infra/src/harvest/extractor.ts
+++ b/packages/infra/src/harvest/extractor.ts
@@ -220,14 +220,12 @@ export function hashContent(body: string): string {
 }
 
 /**
- * Build a short, whitespace-normalised preview suitable for BM25 indexing.
- * @param body - Full file body.
- * @param max - Maximum character length of the preview.
- * @returns Body preview text.
+ * Strip common markdown constructs and normalise whitespace.
+ * @param body - Raw markdown body.
+ * @returns Plain-text body suitable for previews/summaries.
  */
-export function buildBodyPreview(body: string, max = 400): string {
-  // Strip markdown emphasis/links/code fences for a cleaner preview.
-  const cleaned = body
+function cleanBodyText(body: string): string {
+  return body
     .replaceAll(/```[\s\S]*?```/g, ' ')
     .replaceAll(/`[^`]+`/g, ' ')
     .replaceAll(/!\[[^\]]*\]\([^)]*\)/g, ' ')
@@ -235,7 +233,33 @@ export function buildBodyPreview(body: string, max = 400): string {
     .replaceAll(/[*_~#>]+/g, ' ')
     .replaceAll(/\s/g, ' ')
     .trim();
+}
+
+function firstWords(text: string, maxWords: number): string {
+  const words = text.split(/\s+/).filter((w) => w.length > 0);
+  return words.slice(0, maxWords).join(' ');
+}
+
+/**
+ * Build a short, whitespace-normalised preview suitable for BM25 indexing.
+ * @param body - Full file body.
+ * @param max - Maximum character length of the preview.
+ * @returns Body preview text.
+ */
+export function buildBodyPreview(body: string, max = 400): string {
+  const cleaned = cleanBodyText(body);
   return cleaned.length > max ? cleaned.slice(0, max - 1) + '…' : cleaned;
+}
+
+/**
+ * Build an extractive body summary targeting a word budget.
+ * @param body - Full file body.
+ * @param maxWords - Maximum word count of the summary.
+ * @returns Body summary text.
+ */
+export function buildBodySummary(body: string, maxWords = 80): string {
+  const cleaned = cleanBodyText(body);
+  return firstWords(cleaned, maxWords);
 }
 
 /**
@@ -319,6 +343,7 @@ export function extractFromFile(
     tools: tools.length > 0 ? tools : undefined,
     model,
     bodyPreview: buildBodyPreview(parsed.body),
+    bodySummary: buildBodySummary(parsed.body),
     contentHash: hashContent(file.content)
   };
 }
@@ -431,6 +456,7 @@ export function extractMcpPrimitives(ctx: ExtractContext): Primitive[] {
       description,
       tags: uniqueStrings([...(ctx.manifest.tags ?? []), 'mcp']),
       bodyPreview: preview,
+      bodySummary: preview,
       contentHash: hashContent(JSON.stringify(cfg))
     });
   }

--- a/packages/infra/src/harvest/hub-harvester.ts
+++ b/packages/infra/src/harvest/hub-harvester.ts
@@ -37,6 +37,8 @@ import * as path from 'node:path';
 import type {
   GitHubApi,
   HubSourceSpec,
+  PrimitiveIndexKey,
+  PrimitiveIndexStore,
   TokenProvider,
 } from '@ai-primitives-hub/core';
 import {
@@ -51,6 +53,7 @@ import {
 } from '../search/primitive-index';
 import type {
   BundleProvider,
+  EmbeddingProvider,
   IndexStats,
   Primitive,
 } from '../search/types';
@@ -93,8 +96,14 @@ import {
   type ProgressSummary,
 } from './progress-log';
 import {
+  createSourceRevision,
+  type SourceRevisionEntry,
+} from './source-revision';
+import {
+  defaultResolver,
   redactToken,
   resolveGithubToken,
+  type TokenResolver,
 } from './token-provider';
 import {
   resolveCommitSha,
@@ -129,12 +138,14 @@ interface BuildHarvestResultParams {
   progressFile: string;
   cacheDir: string;
   stats: IndexStats;
-  result: { index: PrimitiveIndex; totalMs: number; done: number; error: number; skip: number; primitives: number; wallMs: number };
+  result: HubHarvestResult;
   hubRepo: string;
   hubBranch: string;
   sourcesCount: number;
   tokenSource: string;
   client: GitHubApiClient;
+  sourceRevision: string;
+  hubId: string;
 }
 
 export interface HubHarvestPipelineOptions {
@@ -176,6 +187,19 @@ export interface HubHarvestPipelineOptions {
   onEvent?: (ev: HubHarvestEvent) => void;
   /** Observer for diagnostic messages (one per source-config decision). */
   onLog?: (msg: string) => void;
+  /**
+   * Optional embedding provider. When supplied, the harvested primitives are
+   * embedded into the index so that `ranking: 'hybrid'` searches work locally.
+   */
+  embeddings?: EmbeddingProvider;
+  /** Embedding strategy when `embeddings` is supplied. Default: `single`. */
+  embeddingStrategy?: 'single' | 'dual';
+  /** Stable app-level search profile that produced the persisted index. */
+  searchProfileId?: string;
+  /** Stable hub identity used by the shared namespaced index store. */
+  hubId?: string;
+  /** Optional shared namespaced index location resolver. */
+  indexStore?: PrimitiveIndexStore;
 }
 
 export interface HubHarvestPipelineResult {
@@ -198,6 +222,10 @@ export interface HubHarvestPipelineResult {
   };
   rateLimit: GitHubApiClient['lastRateLimit'];
   tokenSource: string;
+  sourceRevision: string;
+  hubId: string;
+  /** Per-source outcomes used by lifecycle adapters to expose index coverage. */
+  sourceCoverage: HarvestSourceCoverage[];
 }
 
 function resolveHubRepo(
@@ -290,13 +318,17 @@ export const harvestHub = async (
 ): Promise<HubHarvestPipelineResult> => {
   validateHarvestOptions(opts);
   const { hubRepo, hubBranch, cacheDir, progressFile, outFile, concurrency } = resolveHarvestPaths(opts, env);
+  const hubId = opts.hubId ?? (opts.noHubConfig === true || opts.hubConfigFile !== undefined ? 'local' : hubRepo);
+
   const requiresHubConfig = opts.noHubConfig !== true && opts.hubConfigFile === undefined;
   let client: GitHubApiClient | undefined;
   let resolvedToken: string | undefined;
   let tokenSource = 'none';
 
   if (requiresHubConfig) {
-    ({ resolvedToken, client, tokenSource } = await createGitHubClient(hubRepo, opts));
+    ({ resolvedToken, client, tokenSource } = await createGitHubClient(hubRepo, opts, env));
+  } else {
+    client = createUnauthenticatedClient();
   }
 
   const sources = await resolveHubSources({
@@ -311,8 +343,15 @@ export const harvestHub = async (
     sourcesExclude: opts.sourcesExclude
   });
 
-  if (sources.length > 0 && client === undefined) {
-    ({ resolvedToken, client, tokenSource } = await createGitHubClient(hubRepo, opts));
+  // A local hub-config still needs an authenticated client for its GitHub
+  // sources. The unauthenticated client above is only sufficient to read the
+  // local config itself; leaving it in place silently bypasses env/gh token
+  // resolution and throttles every source as an anonymous request.
+  if (!requiresHubConfig && sources.length > 0) {
+    // A local hub-config should still use env/gh credentials when available,
+    // but harvesting public sources must continue to work anonymously when
+    // no token exists. Token resolution is diagnostic here, not mandatory.
+    ({ resolvedToken, client, tokenSource } = await createGitHubClient(hubRepo, opts, env, client));
   }
 
   // An empty offline harvest must succeed without GitHub credentials.
@@ -322,7 +361,7 @@ export const harvestHub = async (
     { tokenProvider: new StaticTokenProvider('') }
   );
 
-  logHarvestStart(opts, hubRepo, hubBranch, resolvedToken, sources.length, concurrency);
+  logHarvestStart(opts, hubRepo, hubBranch, resolvedToken, tokenSource, sources.length, concurrency);
   const result = await runHarvester(
     sources,
     harvestClient,
@@ -330,14 +369,24 @@ export const harvestHub = async (
     cacheDir,
     progressFile,
     concurrency,
-    opts
+    opts,
+    hubId
   );
-  await writeIndexWithIntegrity(result.index, outFile, env);
+  const searchProfileId = opts.searchProfileId ?? 'bm25-v1';
+  const indexKey: PrimitiveIndexKey = {
+    hubId,
+    sourceRevision: result.sourceRevision,
+    searchProfileId
+  };
+  const resolvedOutFile = opts.outFile ?? opts.indexStore?.getIndexPath(indexKey) ?? outFile;
+  if (opts.dryRun !== true) {
+    await writeIndexWithIntegrity(result.index, resolvedOutFile, env);
+  }
 
   const stats = result.index.stats();
 
   return buildHarvestResult({
-    outFile,
+    outFile: resolvedOutFile,
     progressFile,
     cacheDir,
     stats,
@@ -346,7 +395,9 @@ export const harvestHub = async (
     hubBranch,
     sourcesCount: sources.length,
     tokenSource,
-    client: harvestClient
+    client: harvestClient,
+    sourceRevision: result.sourceRevision,
+    hubId
   });
 };
 
@@ -380,14 +431,26 @@ function resolveHarvestPaths(opts: HubHarvestPipelineOptions, env: NodeJS.Proces
 
 async function createGitHubClient(
   hubRepo: string,
-  opts: HubHarvestPipelineOptions
+  opts: HubHarvestPipelineOptions,
+  env: NodeJS.ProcessEnv,
+  fallbackClient?: GitHubApiClient
 ): Promise<{
-  resolvedToken: string;
+  resolvedToken: string | undefined;
   client: GitHubApiClient;
   tokenSource: string;
 }> {
-  const token = await resolveGithubToken({ explicit: opts.explicitToken });
+  const resolver: TokenResolver = {
+    readEnv: (name: string): string | undefined => {
+      const value = env[name];
+      return value && value.length > 0 ? value : undefined;
+    },
+    readGhCli: (): Promise<string | undefined> => defaultResolver.readGhCli()
+  };
+  const token = await resolveGithubToken({ explicit: opts.explicitToken }, resolver);
   if (token.token === undefined || token.token.length === 0) {
+    if (fallbackClient) {
+      return { resolvedToken: undefined, client: fallbackClient, tokenSource: 'none' };
+    }
     throw new Error('No GitHub token available (tried explicit, env, gh CLI).');
   }
   const resolvedToken: string = token.token;
@@ -399,17 +462,22 @@ async function createGitHubClient(
   return { resolvedToken, client, tokenSource: token.source };
 }
 
+function createUnauthenticatedClient(): GitHubApiClient {
+  return new GitHubApiClient(new NodeHttpClient(), { tokenProvider: new StaticTokenProvider('') });
+}
+
 function logHarvestStart(
   opts: HubHarvestPipelineOptions,
   hubRepo: string,
   hubBranch: string,
   resolvedToken: string | undefined,
+  tokenSource: string,
   sourcesCount: number,
   concurrency: number
 ): void {
   opts.onLog?.(
     `hub=${hubRepo}@${hubBranch} `
-    + `token=${resolvedToken === undefined ? 'none' : (opts.explicitToken ? 'explicit' : 'env')}:${redactToken(resolvedToken)} `
+    + `token=${tokenSource}:${redactToken(resolvedToken)} `
     + `sources=${String(sourcesCount)} concurrency=${String(concurrency)}`
   );
 }
@@ -421,8 +489,9 @@ async function runHarvester(
   cacheDir: string,
   progressFile: string,
   concurrency: number,
-  opts: HubHarvestPipelineOptions
-): Promise<{ index: PrimitiveIndex; totalMs: number; done: number; error: number; skip: number; primitives: number; wallMs: number }> {
+  opts: HubHarvestPipelineOptions,
+  hubId: string
+): Promise<HubHarvestResult> {
   const cache = new BlobCache(path.join(cacheDir, 'blobs'));
   const etagStore = await EtagStore.open(path.join(cacheDir, 'etags.json'));
   const harvester = new HubHarvester({
@@ -430,7 +499,12 @@ async function runHarvester(
     progressFile, concurrency,
     force: opts.force ?? false,
     dryRun: opts.dryRun ?? false,
-    onEvent: opts.onEvent
+    onEvent: opts.onEvent,
+    onLog: opts.onLog,
+    embeddings: opts.embeddings,
+    embeddingStrategy: opts.embeddingStrategy,
+    searchProfileId: opts.searchProfileId,
+    hubId
   });
   const result = await harvester.run();
   await etagStore.save();
@@ -459,12 +533,17 @@ function buildHarvestResult(params: BuildHarvestResultParams): HubHarvestPipelin
       done: params.result.done,
       error: params.result.error,
       skip: params.result.skip,
-      primitives: params.result.primitives,
+      // The progress log is append-only and its primitive total spans prior
+      // runs. Report the count in the index written by this invocation.
+      primitives: params.stats.primitives,
       wallMs: params.result.wallMs
     },
     hub: { repo: params.hubRepo, branch: params.hubBranch, sources: params.sourcesCount },
     rateLimit: params.client.lastRateLimit,
-    tokenSource: params.tokenSource
+    tokenSource: params.tokenSource,
+    sourceRevision: params.sourceRevision,
+    hubId: params.hubId,
+    sourceCoverage: params.result.sourceCoverage
   };
 }
 
@@ -477,6 +556,8 @@ export interface HubHarvesterOptions {
   concurrency?: number;
   /** Observer hook for CLI logging, tests, etc. */
   onEvent?: (ev: HubHarvestEvent) => void;
+  /** Optional diagnostic/progress log sink. */
+  onLog?: (msg: string) => void;
   /**
    * Optional ETag store; enables conditional /commits/:ref lookups so
    * warm runs can answer "did anything change?" with a 304 replay.
@@ -494,6 +575,26 @@ export interface HubHarvesterOptions {
    * for "how much does this hub cost to ingest" estimates.
    */
   dryRun?: boolean;
+  /**
+   * Optional embedding provider. When supplied, the harvested primitives are
+   * embedded into the index so that `ranking: 'hybrid'` searches work locally.
+   */
+  embeddings?: EmbeddingProvider;
+  /** Embedding strategy when `embeddings` is supplied. Default: `single`. */
+  embeddingStrategy?: 'single' | 'dual';
+  /** Stable app-level search profile that produced the persisted index. */
+  searchProfileId?: string;
+  /** Stable hub identity stored in index metadata. */
+  hubId?: string;
+}
+
+/** Outcome of one configured source in a harvest lifecycle operation. */
+export interface HarvestSourceCoverage {
+  sourceId: string;
+  state: 'indexed' | 'skipped' | 'unsupported' | 'failed';
+  primitives?: number;
+  revision?: string;
+  message?: string;
 }
 
 export interface HubHarvestResult extends ProgressSummary {
@@ -505,6 +606,9 @@ export interface HubHarvestResult extends ProgressSummary {
    * this holds only the primitives newly collected in this run.
    */
   index: PrimitiveIndex;
+  sourceRevision: string;
+  /** One deterministic record for every configured source. */
+  sourceCoverage: HarvestSourceCoverage[];
 }
 
 /* eslint-disable @typescript-eslint/member-ordering -- public API kept at top. */
@@ -516,6 +620,8 @@ export class HubHarvester {
     const log = await HarvestProgressLog.open(this.opts.progressFile);
     const snapshot = await loadSnapshot(this.snapshotFile());
     const primitives: Primitive[] = [];
+    const sourceRevisions = new Map<string, SourceRevisionEntry>();
+    const sourceCoverage = new Map<string, HarvestSourceCoverage>();
     const concurrency = Math.max(1, this.opts.concurrency ?? 1);
 
     const queue = [...this.opts.sources];
@@ -527,7 +633,7 @@ export class HubHarvester {
         if (!spec) {
           return;
         }
-        await this.processSource(spec, log, primitives, snapshot);
+        await this.processSource(spec, log, primitives, snapshot, sourceRevisions, sourceCoverage);
       }
     };
     for (let i = 0; i < concurrency; i += 1) {
@@ -537,22 +643,45 @@ export class HubHarvester {
 
     await log.close();
 
-    // Persist a fresh snapshot capturing the latest set of primitives per
-    // sourceId so the next warm run can reconstruct the full index.
-    const fresh = new Map<string, Primitive[]>();
+    // Reconstruct the index from the complete active source set. A source can
+    // be skipped (and restored from the snapshot) or fail transiently after a
+    // previous successful run. The old implementation only saved primitives
+    // produced by this invocation, which turned an otherwise recoverable warm
+    // run into a one-source/empty index when GitHub returned 403/404 errors.
+    const currentBySource = new Map<string, Primitive[]>();
     for (const p of primitives) {
-      const list = fresh.get(p.bundle.sourceId) ?? [];
+      const list = currentBySource.get(p.bundle.sourceId) ?? [];
       list.push(p);
-      fresh.set(p.bundle.sourceId, list);
+      currentBySource.set(p.bundle.sourceId, list);
+    }
+    const activeSourceIds = new Set(this.opts.sources.map((source) => source.id));
+    const fresh = new Map<string, Primitive[]>();
+    for (const sourceId of activeSourceIds) {
+      fresh.set(sourceId, currentBySource.get(sourceId) ?? snapshot.get(sourceId) ?? []);
     }
     await saveSnapshot(this.snapshotFile(), fresh);
 
-    const index = PrimitiveIndex.fromPrimitives(primitives);
+    const indexPrimitives = [...fresh.values()].flat();
+    const sourceRevision = createSourceRevision([...sourceRevisions.values()]);
+    const index = await PrimitiveIndex.buildFromPrimitives(indexPrimitives, {
+      hubId: this.opts.hubId,
+      sourceRevision,
+      embeddings: this.opts.embeddings,
+      embeddingStrategy: this.opts.embeddingStrategy,
+      searchProfileId: this.opts.searchProfileId,
+      onLog: this.opts.onLog
+    });
     const summary = log.summary();
     return {
       ...summary,
       totalMs: Date.now() - startedAt,
-      index
+      index,
+      sourceRevision,
+      sourceCoverage: this.opts.sources.map((source) => sourceCoverage.get(source.id) ?? {
+        sourceId: source.id,
+        state: 'failed',
+        message: 'Source did not produce a harvest outcome.'
+      })
     };
   }
 
@@ -564,27 +693,64 @@ export class HubHarvester {
     spec: HubSourceSpec,
     log: HarvestProgressLog,
     out: Primitive[],
-    snapshot: Map<string, Primitive[]>
+    snapshot: Map<string, Primitive[]>,
+    sourceRevisions: Map<string, SourceRevisionEntry>,
+    sourceCoverage: Map<string, HarvestSourceCoverage>
   ): Promise<void> {
     const bundleId = spec.id;
+    this.opts.onLog?.(`processing source ${spec.id}...`);
     this.opts.onEvent?.({ kind: 'source-start', sourceId: spec.id });
     let commitSha: string | undefined;
     try {
       commitSha = await this.resolveCommitShaForSource(spec);
-      const shouldSkip = await this.checkSkipConditions(spec, bundleId, commitSha, log, snapshot, out);
-      if (shouldSkip) {
+      sourceRevisions.set(spec.id, {
+        sourceId: spec.id,
+        url: spec.url,
+        branch: spec.branch,
+        revision: commitSha
+      });
+      const skipReason = await this.checkSkipConditions(spec, bundleId, commitSha, log, snapshot, out);
+      if (skipReason !== undefined) {
+        sourceCoverage.set(spec.id, {
+          sourceId: spec.id,
+          state: 'skipped',
+          revision: commitSha,
+          message: skipReason
+        });
+        this.opts.onLog?.(`source ${spec.id} skipped`);
         return;
       }
       const primsTotal = await this.harvestSource(spec, bundleId, commitSha, log, out);
+      sourceCoverage.set(spec.id, {
+        sourceId: spec.id,
+        state: 'indexed',
+        primitives: primsTotal,
+        revision: commitSha
+      });
+      this.opts.onLog?.(`source ${spec.id} done: ${String(primsTotal)} primitive${primsTotal === 1 ? '' : 's'}`);
       this.opts.onEvent?.({
         kind: 'source-done', sourceId: spec.id, commitSha,
         primitives: primsTotal, ms: Date.now()
       });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
+      if (!sourceRevisions.has(spec.id)) {
+        sourceRevisions.set(spec.id, {
+          sourceId: spec.id,
+          url: spec.url,
+          branch: spec.branch,
+          revision: commitSha ?? 'unknown'
+        });
+      }
       await log.recordError({
         sourceId: spec.id, bundleId,
         commitSha: commitSha ?? 'unknown', error: msg
+      });
+      sourceCoverage.set(spec.id, {
+        sourceId: spec.id,
+        state: 'failed',
+        revision: commitSha,
+        message: msg
       });
       this.opts.onEvent?.({ kind: 'source-error', sourceId: spec.id, error: msg });
     }
@@ -606,7 +772,7 @@ export class HubHarvester {
     log: HarvestProgressLog,
     snapshot: Map<string, Primitive[]>,
     out: Primitive[]
-  ): Promise<boolean> {
+  ): Promise<string | undefined> {
     if (!this.opts.force && !log.shouldResume(spec.id, bundleId, commitSha)) {
       await log.recordSkip({
         sourceId: spec.id, bundleId, commitSha,
@@ -617,7 +783,7 @@ export class HubHarvester {
       this.opts.onEvent?.({
         kind: 'source-skip', sourceId: spec.id, commitSha, reason: 'already-harvested'
       });
-      return true;
+      return 'already-harvested';
     }
     if (this.opts.dryRun) {
       await log.recordSkip({
@@ -627,9 +793,9 @@ export class HubHarvester {
       this.opts.onEvent?.({
         kind: 'source-skip', sourceId: spec.id, commitSha, reason: 'dry-run'
       });
-      return true;
+      return 'dry-run';
     }
-    return false;
+    return undefined;
   }
 
   private async harvestSource(

--- a/packages/infra/src/harvest/index.ts
+++ b/packages/infra/src/harvest/index.ts
@@ -15,5 +15,6 @@ export * from './integrity';
 export * from './plugin-manifest';
 export * from './plugin-tree-enumerator';
 export * from './progress-log';
+export * from './source-revision';
 export * from './token-provider';
 export * from './tree-enumerator';

--- a/packages/infra/src/harvest/progress-log.ts
+++ b/packages/infra/src/harvest/progress-log.ts
@@ -13,7 +13,8 @@
  *   - `shouldResume(sourceId, bundleId, commitSha)` returns false iff the
  *     log already contains a `done` event for that exact tuple. This is
  *     the hook the harvester uses to skip unchanged bundles.
- *   - `summary()` aggregates counts for a human-readable report.
+ *   - `summary()` aggregates counts for the current open invocation only;
+ *     the append-only history remains available through `projectState()`.
  *
  * Uses `node:fs`/`node:fs/promises` directly rather than `core`'s
  * `FileSystem` port: needs an open file handle held across many
@@ -78,6 +79,7 @@ export interface ProgressSummary {
 /* eslint-disable @typescript-eslint/member-ordering -- public API kept above private helpers for readability. */
 export class HarvestProgressLog {
   private readonly state = new Map<string, BundleState>();
+  private readonly runState = new Map<string, BundleState>();
   private fd: fs.promises.FileHandle | undefined;
 
   private constructor(private readonly file: string) {}
@@ -130,7 +132,7 @@ export class HarvestProgressLog {
     let skip = 0;
     let primitives = 0;
     let wallMs = 0;
-    for (const s of this.state.values()) {
+    for (const s of this.runState.values()) {
       switch (s.status) {
         case 'start': {
           start += 1;
@@ -174,11 +176,16 @@ export class HarvestProgressLog {
     const line = JSON.stringify(ev) + '\n';
     await this.fd.write(line);
     this.apply(ev);
+    this.applyTo(this.runState, ev);
   }
 
   private apply(ev: ProgressEvent): void {
+    this.applyTo(this.state, ev);
+  }
+
+  private applyTo(target: Map<string, BundleState>, ev: ProgressEvent): void {
     const k = keyOf(ev.sourceId, ev.bundleId);
-    const prev = this.state.get(k);
+    const prev = target.get(k);
     // Event precedence: done/error/skip overwrite any prior state.
     // `start` only sets state if there wasn't one already (so a replay of
     // an old start cannot undo a done).
@@ -196,7 +203,7 @@ export class HarvestProgressLog {
       error: ev.kind === 'error' ? ev.error : undefined,
       reason: ev.kind === 'skip' ? ev.reason : undefined
     };
-    this.state.set(k, next);
+    target.set(k, next);
   }
 
   private async load(): Promise<void> {

--- a/packages/infra/src/harvest/source-revision.ts
+++ b/packages/infra/src/harvest/source-revision.ts
@@ -1,0 +1,32 @@
+/**
+ * Canonical source snapshot identity shared by CLI and VS Code.
+ * @module harvest/source-revision
+ */
+import {
+  createHash,
+} from 'node:crypto';
+
+export interface SourceRevisionEntry {
+  sourceId: string;
+  url: string;
+  branch: string;
+  revision: string;
+}
+
+/**
+ * Hash the normalized source coordinates and revisions represented by an index.
+ * Keeping this representation client-neutral lets CLI and VS Code resolve the
+ * same namespaced semantic index when they harvested the same source commits.
+ * @param entries
+ */
+export function createSourceRevision(entries: readonly SourceRevisionEntry[]): string {
+  const normalized = entries
+    .map((entry) => ({
+      sourceId: entry.sourceId.trim(),
+      url: entry.url.trim(),
+      branch: entry.branch.trim(),
+      revision: entry.revision.trim()
+    }))
+    .toSorted((a, b) => a.sourceId.localeCompare(b.sourceId));
+  return createHash('sha256').update(JSON.stringify(normalized)).digest('hex');
+}

--- a/packages/infra/src/harvest/token-provider.ts
+++ b/packages/infra/src/harvest/token-provider.ts
@@ -72,6 +72,20 @@ export const defaultResolver: TokenResolver = {
 };
 
 /**
+ * Create a resolver backed by a caller-supplied environment.
+ * @param env Environment variables to inspect.
+ */
+export function createTokenResolver(env: NodeJS.ProcessEnv = process.env): TokenResolver {
+  return {
+    readEnv: (name: string): string | undefined => {
+      const value = env[name];
+      return value && value.length > 0 ? value : undefined;
+    },
+    readGhCli: (): Promise<string | undefined> => defaultResolver.readGhCli()
+  };
+}
+
+/**
  * Resolve a GitHub token via explicit -> env -> gh CLI, short-circuiting as
  * soon as a non-empty value is found.
  * @param opts - `explicit` forwards a token from the extension host; takes highest precedence.

--- a/packages/infra/src/search/embedding-text.ts
+++ b/packages/infra/src/search/embedding-text.ts
@@ -1,0 +1,86 @@
+/**
+ * Compose the text that is fed to the embedding provider for a primitive.
+ *
+ * The ternlight models truncate at 128 BERT tokens, which empirically equals
+ * about 85 English words. This module word-truncates the combined primitive
+ * text to that budget and supports both a single combined stream and a dual
+ * stream (metadata + body).
+ * @module search/embedding-text
+ */
+
+import type {
+  Primitive,
+} from '@ai-primitives-hub/core';
+
+/**
+ * Word budget for each embedding stream.
+ *
+ * The `total` budget is used for the legacy single stream. The dual streams
+ * use `metadata` for title/description/tags and `body` for the body summary.
+ */
+export const EMBEDDING_BUDGETS = {
+  metadata: 25,
+  body: 60,
+  total: 85
+} as const;
+
+function firstWords(text: string, maxWords: number): string {
+  const words = text.trim().split(/\s+/).filter(Boolean);
+  if (words.length <= maxWords) {
+    return words.join(' ');
+  }
+  return words.slice(0, maxWords).join(' ');
+}
+
+function metadataText(p: Primitive): string {
+  const parts = [p.title];
+  if (p.tags && p.tags.length > 0) {
+    parts.push(p.tags.join(' '));
+  }
+  if (p.description) {
+    parts.push(p.description);
+  }
+  return firstWords(parts.join('\n'), EMBEDDING_BUDGETS.metadata);
+}
+
+function bodyText(p: Primitive): string {
+  return firstWords(p.bodySummary ?? p.bodyPreview ?? '', EMBEDDING_BUDGETS.body);
+}
+
+/**
+ * Compose the full embedding text for a primitive.
+ *
+ * Current strategy: concatenate title, description, tags, and the bodySummary
+ * (or bodyPreview as a fallback), then truncate to the word budget. This keeps
+ * the existing hybrid-search behaviour stable while ensuring the input does not
+ * exceed the ternlight token window and can benefit from longer full-body
+ * summaries when available.
+ * @param p - Primitive to embed.
+ * @returns Text to pass to the embedding provider.
+ */
+export function buildEmbeddingText(p: Primitive): string {
+  const parts = [
+    p.title,
+    p.description,
+    p.tags.join(' '),
+    p.bodySummary ?? p.bodyPreview
+  ].filter((s): s is string => typeof s === 'string' && s.trim().length > 0);
+  return firstWords(parts.join('\n'), EMBEDDING_BUDGETS.total);
+}
+
+/**
+ * Compose one or more embedding texts for a primitive depending on strategy.
+ * @param p - Primitive to embed.
+ * @param strategy - `single` returns one combined text; `dual` returns separate
+ *   `metadata` and `body` texts.
+ * @returns A map from stream name to embedding input text.
+ */
+export function buildEmbeddingTexts(p: Primitive, strategy: 'single' | 'dual' = 'single'): Record<string, string> {
+  if (strategy === 'dual') {
+    return {
+      metadata: metadataText(p),
+      body: bodyText(p)
+    };
+  }
+  return { combined: buildEmbeddingText(p) };
+}

--- a/packages/infra/src/search/embedding/ternlight-embedding-provider.ts
+++ b/packages/infra/src/search/embedding/ternlight-embedding-provider.ts
@@ -1,0 +1,42 @@
+/**
+ * Ternlight-backed local embedding provider for the primitive index.
+ *
+ * Implements the infra `EmbeddingProvider` port using `@ternlight/mini`, a
+ * self-contained 5 MB WASM sentence encoder. No native dependencies, no GPU,
+ * no network calls after install.
+ * @module search/embedding/ternlight-embedding-provider
+ */
+import {
+  embed,
+} from '@ternlight/mini';
+import type {
+  EmbeddingProvider,
+} from '../types';
+
+/**
+ * Truncate input text to a safe byte budget before embedding.
+ * Ternlight tokenizes with BERT WordPiece and truncates at 128 tokens;
+ * 4000 characters is a generous upper bound for ~95 English words.
+ */
+const MAX_INPUT_LENGTH = 4000;
+
+function prepare(text: string): string {
+  return text.slice(0, MAX_INPUT_LENGTH);
+}
+
+/**
+ * Local embedding provider powered by `@ternlight/mini`.
+ */
+export class TernlightEmbeddingProvider implements EmbeddingProvider {
+  public readonly name = 'ternlight-mini';
+  public readonly dim = 384;
+
+  /**
+   * Embed one or more texts into 384-dimensional unit vectors.
+   * @param texts - Texts to embed.
+   * @returns Array of Float32Array embeddings, one per input.
+   */
+  public embed(texts: string[]): Promise<Float32Array[]> {
+    return Promise.resolve(texts.map((text) => embed(prepare(text))));
+  }
+}

--- a/packages/infra/src/search/index.ts
+++ b/packages/infra/src/search/index.ts
@@ -13,3 +13,4 @@ export { PrimitiveIndex } from './primitive-index';
 export * from './tokenizer';
 export * from './tuning';
 export * from './types';
+export { TernlightEmbeddingProvider } from './embedding/ternlight-embedding-provider';

--- a/packages/infra/src/search/primitive-index.ts
+++ b/packages/infra/src/search/primitive-index.ts
@@ -15,12 +15,18 @@
 
 import * as crypto from 'node:crypto';
 import {
+  getBundleRefKey,
+} from '@ai-primitives-hub/core';
+import {
   harvest,
 } from '../harvest/harvester';
 import {
   Bm25Engine,
   type FieldTokens,
 } from './bm25-engine';
+import {
+  buildEmbeddingTexts,
+} from './embedding-text';
 import {
   tokenize,
 } from './tokenizer';
@@ -47,12 +53,15 @@ import {
 
 /**
  * Internal record for indexed primitives.
- * Contains the primitive, tokenized fields, and optional embedding.
+ * Contains the primitive, tokenized fields, and optional embeddings.
  */
 interface InternalRecord {
   primitive: Primitive;
   fields: FieldTokens;
+  /** Legacy single-vector embedding, kept for backward compatibility. */
   embedding?: Float32Array;
+  /** Named embedding streams (e.g. combined, metadata, body). */
+  embeddings?: Record<string, Float32Array>;
 }
 
 /**
@@ -121,7 +130,9 @@ export class PrimitiveIndex {
     schemaVersion: number;
     builtAt: string;
     hubId?: string;
-    embeddingsMeta?: { provider: string; dim: number };
+    sourceRevision?: string;
+    searchProfileId?: string;
+    embeddingsMeta?: { provider: string; dim: number; strategy?: string; embeddingStrategy?: string };
   } = { schemaVersion: 1, builtAt: new Date().toISOString(), hubId: 'my-hub-id' };
 
   /**
@@ -185,15 +196,30 @@ export class PrimitiveIndex {
     opts: BuildOptions = {}
   ): Promise<PrimitiveIndex> {
     const idx = new PrimitiveIndex();
+    let bundleCount = 0;
     const primitives = await harvest(provider, {
-      maxFilesPerBundle: opts.maxFilesPerBundle
+      maxFilesPerBundle: opts.maxFilesPerBundle,
+      onBundle: (ref, produced): void => {
+        bundleCount += 1;
+        opts.onBundle?.(ref, produced);
+        opts.onLog?.(`harvested bundle ${ref.bundleId} (${produced} primitive${produced === 1 ? '' : 's'})`);
+      },
+      onError: (ref, err): void => {
+        opts.onHarvestError?.(ref, err);
+        opts.onLog?.(`harvest error for bundle ${ref?.bundleId ?? 'unknown'}: ${err instanceof Error ? err.message : String(err)}`);
+      }
     });
+    if (primitives.length > 0) {
+      opts.onLog?.(`harvested ${primitives.length} primitive${primitives.length === 1 ? '' : 's'} from ${bundleCount} bundle${bundleCount === 1 ? '' : 's'}`);
+    }
     await idx.reset(primitives, opts);
     return idx;
   }
 
   /**
-   * Build a new index from primitives.
+   * Build a new index from primitives synchronously.
+   * Does not support embedding providers; use {@link buildFromPrimitives}
+   * when embeddings are required.
    * @param primitives List of primitives to index.
    * @param opts Build options.
    * @returns Built PrimitiveIndex.
@@ -209,6 +235,21 @@ export class PrimitiveIndex {
   }
 
   /**
+   * Build a new index from primitives, optionally embedding them.
+   * @param primitives List of primitives to index.
+   * @param opts Build options.
+   * @returns Built PrimitiveIndex.
+   */
+  public static async buildFromPrimitives(
+    primitives: Primitive[],
+    opts: BuildOptions = {}
+  ): Promise<PrimitiveIndex> {
+    const idx = new PrimitiveIndex();
+    await idx.reset(primitives, opts);
+    return idx;
+  }
+
+  /**
    * Reset the index with new primitives.
    * @param primitives List of primitives to index.
    * @param opts Build options.
@@ -216,17 +257,60 @@ export class PrimitiveIndex {
   private async reset(primitives: Primitive[], opts: BuildOptions): Promise<void> {
     this.resetSync(primitives, opts);
     if (opts.embeddings) {
-      const texts = this.records.map((r) =>
-        `${r.primitive.title}\n${r.primitive.description}\n${r.primitive.tags.join(' ')}\n${r.primitive.bodyPreview}`
-      );
-      const vectors = await opts.embeddings.embed(texts);
-      vectors.forEach((v, i) => {
-        this.records[i].embedding = v;
+      const log = opts.onLog;
+      const count = this.records.length;
+      const provider = opts.embeddings.name ?? 'custom';
+      const strategy = opts.embeddingStrategy ?? 'single';
+      log?.(`computing ${strategy} embeddings with ${provider} (dim=${opts.embeddings.dim}) — this may take a while...`);
+
+      const textsByStream: Record<string, string[]> = {};
+      const streamNames: string[] = [];
+      for (const r of this.records) {
+        const texts = buildEmbeddingTexts(r.primitive, strategy);
+        for (const [name, text] of Object.entries(texts)) {
+          if (!textsByStream[name]) {
+            textsByStream[name] = [];
+            streamNames.push(name);
+          }
+          textsByStream[name].push(text);
+        }
+      }
+
+      const batchSize = 32;
+      const vectorsByStream: Record<string, Float32Array[]> = {};
+      const startMs = Date.now();
+      for (const name of streamNames) {
+        const texts = textsByStream[name];
+        const vectors: Float32Array[] = [];
+        for (let done = 0; done < texts.length; done += batchSize) {
+          const batch = texts.slice(done, done + batchSize);
+          const batchVectors = await opts.embeddings.embed(batch);
+          vectors.push(...batchVectors);
+        }
+        vectorsByStream[name] = vectors;
+      }
+
+      this.records.forEach((r, i) => {
+        const embeddings: Record<string, Float32Array> = {};
+        for (const name of streamNames) {
+          embeddings[name] = vectorsByStream[name][i];
+        }
+        r.embeddings = embeddings;
+        // Keep the legacy single-vector field populated for older callers.
+        if (embeddings.combined) {
+          r.embedding = embeddings.combined;
+        } else if (streamNames.length === 1) {
+          r.embedding = embeddings[streamNames[0]];
+        }
       });
+
       this.meta.embeddingsMeta = {
-        provider: (opts.embeddings as unknown as { name?: string }).name ?? 'custom',
-        dim: opts.embeddings.dim
+        provider,
+        dim: opts.embeddings.dim,
+        strategy: 'summary',
+        embeddingStrategy: strategy
       };
+      log?.(`computed ${count * streamNames.length} embeddings (${strategy}) in ${Date.now() - startMs}ms`);
     }
   }
 
@@ -237,6 +321,11 @@ export class PrimitiveIndex {
    * @param opts Build options.
    */
   private resetSync(primitives: Primitive[], opts: BuildOptions): void {
+    const startedAt = Date.now();
+    const log = opts.onLog;
+    const count = primitives.length;
+    log?.(`indexing ${count} primitive${count === 1 ? '' : 's'}...`);
+
     // Deduplicate by primitiveId; later wins.
     const byId = new Map<string, Primitive>();
     for (const p of primitives) {
@@ -247,14 +336,20 @@ export class PrimitiveIndex {
       fields: tokenizeFields(primitive)
     }));
     this.byId = new Map(this.records.map((r, i) => [r.primitive.id, i]));
+
+    log?.('building BM25 index and facet maps...');
     this.rebuildBm25();
     this.rebuildFacets();
     this.meta = {
       ...this.meta,
       schemaVersion: 1,
       builtAt: new Date().toISOString(),
-      hubId: opts.hubId ?? this.meta.hubId
+      hubId: opts.hubId ?? this.meta.hubId,
+      sourceRevision: opts.sourceRevision ?? this.meta.sourceRevision,
+      searchProfileId: opts.searchProfileId ?? (opts.embeddings ? inferSearchProfileId(opts) : 'bm25-v1'),
+      embeddingsMeta: opts.embeddings ? this.meta.embeddingsMeta : undefined
     };
+    log?.(`built BM25 index and facet maps in ${Date.now() - startedAt}ms`);
   }
 
   /**
@@ -306,7 +401,18 @@ export class PrimitiveIndex {
     candidates = intersectFacet(candidates, this.facets.bundle, query.bundles);
     candidates = intersectFacet(candidates, this.facets.tag, query.tags, true);
     if (query.installedOnly) {
-      candidates = intersectSets(candidates, this.facets.installed);
+      if (query.installedBundleKeys) {
+        const installedKeys = new Set(query.installedBundleKeys);
+        const installed = new Set<number>();
+        for (const [index, record] of this.records.entries()) {
+          if (installedKeys.has(getBundleRefKey(record.primitive.bundle))) {
+            installed.add(index);
+          }
+        }
+        candidates = intersectSets(candidates, installed);
+      } else {
+        candidates = intersectSets(candidates, this.facets.installed);
+      }
     }
     return candidates;
   }
@@ -343,27 +449,50 @@ export class PrimitiveIndex {
    * Compute final score from BM25 and optional cosine similarity.
    * @param raw Raw BM25 score.
    * @param maxScore Maximum BM25 score for normalization.
-   * @param useHybrid Whether to use hybrid scoring.
-   * @param embedding Record embedding vector.
-   * @param queryEmbedding Query embedding vector.
-   * @param alpha Weight for BM25 vs cosine similarity.
+   * @param query Search query.
+   * @param recordEmbeddings Named embedding streams for the record.
+   * @param recordEmbedding Legacy single embedding vector.
    * @returns Final score between 0 and 1.
    */
   private computeScore(
     raw: number,
     maxScore: number,
-    useHybrid: boolean,
-    embedding: Float32Array<ArrayBufferLike> | undefined,
-    queryEmbedding: Float32Array<ArrayBufferLike> | undefined,
-    alpha: number
+    query: SearchQuery,
+    recordEmbeddings: Record<string, Float32Array> | undefined,
+    recordEmbedding: Float32Array<ArrayBufferLike> | undefined
   ): number {
     const bm25Norm = maxScore > 0 ? raw / maxScore : 0;
-    let score = alpha * bm25Norm;
-    if (useHybrid && embedding && queryEmbedding) {
-      const cs = cosine(embedding, queryEmbedding);
-      score += (1 - alpha) * cs;
+    const ranking = query.ranking ?? 'bm25';
+
+    if (ranking === 'multi' && query.queryEmbeddings && recordEmbeddings) {
+      const streams = Object.keys(recordEmbeddings).filter((k) => query.queryEmbeddings?.[k]);
+      if (streams.length === 0) {
+        return bm25Norm;
+      }
+      const providedWeights = query.embeddingWeights ?? {};
+      const bm25Weight = providedWeights.bm25 ?? HYBRID_ALPHA;
+      const streamWeightTotal = streams.reduce((sum, k) => sum + (providedWeights[k] ?? 0), 0);
+      // If no per-stream weights are given, split the remaining budget evenly.
+      const defaultStreamWeight = streamWeightTotal > 0 ? 0 : (1 - bm25Weight) / streams.length;
+      let finalScore = bm25Weight * bm25Norm;
+      for (const name of streams) {
+        const weight = providedWeights[name] ?? defaultStreamWeight;
+        const qe = query.queryEmbeddings[name];
+        finalScore += weight * cosine(recordEmbeddings[name], qe);
+      }
+      return finalScore;
     }
-    return score;
+
+    const useHybrid = (ranking === 'hybrid') && !!query.queryEmbedding;
+    const alpha = HYBRID_ALPHA;
+    let hybridScore = alpha * bm25Norm;
+    if (useHybrid) {
+      const embedding = recordEmbedding ?? recordEmbeddings?.combined;
+      if (embedding && query.queryEmbedding) {
+        hybridScore += (1 - alpha) * cosine(embedding, query.queryEmbedding);
+      }
+    }
+    return hybridScore;
   }
 
   /**
@@ -427,10 +556,7 @@ export class PrimitiveIndex {
     }
 
     const maxScore = this.normalizeScores(scores);
-    const useHybrid = (query.ranking === 'hybrid') && !!query.queryEmbedding;
-    const alpha = useHybrid ? HYBRID_ALPHA : 1;
-
-    const hits = this.buildHits(scores, maxScore, useHybrid, alpha, query, explanations);
+    const hits = this.buildHits(scores, maxScore, query, explanations);
     const sortedHits = this.sortHits(hits);
 
     const limit = query.limit ?? 20;
@@ -445,8 +571,6 @@ export class PrimitiveIndex {
    * Build search hits from scores and explanations.
    * @param scores Map of record indices to scores.
    * @param maxScore Maximum score for normalization.
-   * @param useHybrid Whether to use hybrid scoring.
-   * @param alpha Weight for BM25 vs cosine similarity.
    * @param query Search query.
    * @param explanations Optional match explanations.
    * @returns List of search hits.
@@ -454,20 +578,18 @@ export class PrimitiveIndex {
   private buildHits(
     scores: Map<number, number>,
     maxScore: number,
-    useHybrid: boolean,
-    alpha: number,
     query: SearchQuery,
     explanations: Map<number, { field: SearchableField; term: string; weight: number; contribution: number }[]> | undefined
   ): SearchHit[] {
     const hits: SearchHit[] = [];
     for (const [idx, raw] of scores) {
+      const rec = this.records[idx];
       const score = this.computeScore(
         raw,
         maxScore,
-        useHybrid,
-        this.records[idx].embedding,
-        query.queryEmbedding,
-        alpha
+        query,
+        rec.embeddings,
+        rec.embedding
       );
       hits.push(this.buildSearchHit(idx, score, explanations));
     }
@@ -564,8 +686,24 @@ export class PrimitiveIndex {
     const t0 = Date.now();
     const filtered = this.filter(query);
     const result = this.rank(query, filtered);
+    const hits = query.installedBundleKeys
+      ? (() => {
+        const installedKeys = new Set(query.installedBundleKeys);
+        return result.hits.map((hit) => ({
+          ...hit,
+          primitive: {
+            ...hit.primitive,
+            bundle: {
+              ...hit.primitive.bundle,
+              installed: installedKeys.has(getBundleRefKey(hit.primitive.bundle))
+            }
+          }
+        }));
+      })()
+      : result.hits;
     return {
       ...result,
+      hits,
       facets: this.facetCounts(filtered),
       tookMs: Date.now() - t0
     };
@@ -668,6 +806,9 @@ export class PrimitiveIndex {
    * @returns Refresh report with change summary.
    */
   public async refresh(provider: BundleProvider, opts: RefreshOptions = {}): Promise<RefreshReport> {
+    if (this.meta.embeddingsMeta && !opts.embeddings) {
+      throw new Error('Refreshing an embedded index requires the embedding provider used to build it.');
+    }
     const incoming = await harvest(provider, { maxFilesPerBundle: opts.maxFilesPerBundle });
     const nextById = new Map<string, Primitive>();
     for (const p of incoming) {
@@ -692,11 +833,21 @@ export class PrimitiveIndex {
       schemaVersion: this.meta.schemaVersion,
       builtAt: this.meta.builtAt,
       hubId: this.meta.hubId,
+      sourceRevision: this.meta.sourceRevision ?? null,
+      searchProfileId: this.meta.searchProfileId ?? null,
       embeddingsMeta: this.meta.embeddingsMeta ?? null,
-      primitives: this.records.map((r) => ({
-        ...r.primitive,
-        embedding: r.embedding ? Array.from(r.embedding) : undefined
-      })),
+      primitives: this.records.map((r) => {
+        const entry: Record<string, unknown> = { ...r.primitive };
+        if (r.embeddings && Object.keys(r.embeddings).length > 0) {
+          entry.embeddings = Object.fromEntries(
+            Object.entries(r.embeddings).map(([k, v]) => [k, Array.from(v)])
+          );
+        }
+        if (r.embedding) {
+          entry.embedding = Array.from(r.embedding);
+        }
+        return entry;
+      }),
       shortlists: Array.from(this.shortlists.values())
     };
   }
@@ -712,8 +863,10 @@ export class PrimitiveIndex {
       schemaVersion: number;
       builtAt?: string;
       hubId?: string;
-      embeddingsMeta?: { provider: string; dim: number } | null;
-      primitives: (Primitive & { embedding?: number[] })[];
+      sourceRevision?: string | null;
+      searchProfileId?: string | null;
+      embeddingsMeta?: { provider: string; dim: number; strategy?: string; embeddingStrategy?: string } | null;
+      primitives: (Primitive & { embedding?: number[]; embeddings?: Record<string, number[]> })[];
       shortlists?: Shortlist[];
     };
     if (!data?.schemaVersion || data.schemaVersion !== 1) {
@@ -726,27 +879,41 @@ export class PrimitiveIndex {
       }
       return p;
     });
-    idx.records = primitives.map((p) => ({
-      primitive: {
-        id: p.id,
-        bundle: p.bundle,
-        kind: p.kind,
-        path: p.path,
-        title: p.title,
-        description: p.description,
-        tags: p.tags,
-        authors: p.authors,
-        applyTo: p.applyTo,
-        tools: p.tools,
-        model: p.model,
-        bodyPreview: p.bodyPreview,
-        contentHash: p.contentHash,
-        rating: p.rating,
-        updatedAt: p.updatedAt
-      },
-      fields: tokenizeFields(p),
-      embedding: p.embedding ? new Float32Array(p.embedding) : undefined
-    }));
+    idx.records = primitives.map((p) => {
+      const embeddings: Record<string, Float32Array> = {};
+      if (p.embeddings) {
+        for (const [k, v] of Object.entries(p.embeddings)) {
+          embeddings[k] = new Float32Array(v);
+        }
+      }
+      const embedding = p.embedding ? new Float32Array(p.embedding) : undefined;
+      if (embedding && !embeddings.combined) {
+        embeddings.combined = embedding;
+      }
+      return {
+        primitive: {
+          id: p.id,
+          bundle: p.bundle,
+          kind: p.kind,
+          path: p.path,
+          title: p.title,
+          description: p.description,
+          tags: p.tags,
+          authors: p.authors,
+          applyTo: p.applyTo,
+          tools: p.tools,
+          model: p.model,
+          bodyPreview: p.bodyPreview,
+          bodySummary: p.bodySummary,
+          contentHash: p.contentHash,
+          rating: p.rating,
+          updatedAt: p.updatedAt
+        },
+        fields: tokenizeFields(p),
+        embedding,
+        embeddings: Object.keys(embeddings).length > 0 ? embeddings : undefined
+      };
+    });
     idx.byId = new Map(idx.records.map((r, i) => [r.primitive.id, i]));
     idx.rebuildBm25();
     idx.rebuildFacets();
@@ -754,6 +921,8 @@ export class PrimitiveIndex {
       schemaVersion: 1,
       builtAt: data.builtAt ?? new Date(0).toISOString(),
       hubId: data.hubId,
+      sourceRevision: data.sourceRevision ?? undefined,
+      searchProfileId: data.searchProfileId ?? undefined,
       embeddingsMeta: data.embeddingsMeta ?? undefined
     };
     for (const sl of data.shortlists ?? []) {
@@ -761,6 +930,15 @@ export class PrimitiveIndex {
     }
     return idx;
   }
+}
+
+function inferSearchProfileId(opts: BuildOptions): string | undefined {
+  if (opts.embeddings?.name !== 'ternlight-mini') {
+    return undefined;
+  }
+  return opts.embeddingStrategy === 'dual'
+    ? 'ternlight-dual-v1'
+    : 'ternlight-single-v1';
 }
 
 function addTo(map: Map<string, Set<number>>, key: string, idx: number): void {

--- a/packages/infra/src/search/types.ts
+++ b/packages/infra/src/search/types.ts
@@ -16,6 +16,7 @@
 // Domain types — re-exported from domain layer
 // Import domain types for feature-layer type definitions
 import type {
+  BundleRef,
   Primitive,
   PrimitiveKind,
 } from '@ai-primitives-hub/core';
@@ -36,6 +37,8 @@ export {
  * Embedding provider interface for hybrid search.
  */
 export interface EmbeddingProvider {
+  /** Human-readable provider name stored in index metadata. */
+  readonly name?: string;
   readonly dim: number;
   embed(texts: string[]): Promise<Float32Array[]>;
 }
@@ -50,12 +53,18 @@ export interface SearchQuery {
   bundles?: string[];
   tags?: string[];
   installedOnly?: boolean;
+  /** Current installed bundle snapshot used by the query-time overlay. */
+  installedBundleKeys?: string[];
   limit?: number;
   offset?: number;
   explain?: boolean;
-  ranking?: 'bm25' | 'hybrid';
+  ranking?: 'bm25' | 'hybrid' | 'multi';
   /** For hybrid ranking. Must match the embedding provider dimension. */
   queryEmbedding?: Float32Array;
+  /** For multi-vector ranking: one embedding per named stream. */
+  queryEmbeddings?: Record<string, Float32Array>;
+  /** Optional per-stream weights for multi-vector ranking. */
+  embeddingWeights?: Record<string, number>;
 }
 
 /**
@@ -83,6 +92,12 @@ export interface SearchHit {
 export interface SearchResult {
   total: number;
   hits: SearchHit[];
+  /** Stable profile selected by the shared app-level search use case. */
+  searchProfileId?: string;
+  /** Effective ranking mode used for this query. */
+  ranking?: 'bm25' | 'hybrid' | 'multi';
+  /** True when the query was embedded and dense scores were combined. */
+  embeddingUsed?: boolean;
   facets: {
     kinds: Record<string, number>;
     sources: Record<string, number>;
@@ -130,9 +145,21 @@ export interface RefreshReport {
  */
 export interface BuildOptions {
   hubId?: string;
+  /** Stable source snapshot/revision represented by the index. */
+  sourceRevision?: string;
+  /** Stable app-level search profile that produced this index. */
+  searchProfileId?: string;
   embeddings?: EmbeddingProvider;
+  /** Embedding strategy: `single` keeps one combined vector per primitive; `dual` stores separate metadata and body vectors. Default: `single`. */
+  embeddingStrategy?: 'single' | 'dual';
   /** Cap per-bundle file count to bound runaway sources. Default: 500. */
   maxFilesPerBundle?: number;
+  /** Optional progress/diagnostic log sink. */
+  onLog?: (msg: string) => void;
+  /** Optional per-bundle harvest observation for lifecycle reporting. */
+  onBundle?: (ref: BundleRef, produced: number) => void;
+  /** Optional per-bundle harvest error observation for lifecycle reporting. */
+  onHarvestError?: (ref: BundleRef | null, error: unknown) => void;
 }
 
 /**

--- a/packages/infra/src/storage/index.ts
+++ b/packages/infra/src/storage/index.ts
@@ -4,3 +4,4 @@
  */
 export * from './xdg-app-storage';
 export * from './xdg-base-dirs';
+export * from './primitive-index-store';

--- a/packages/infra/src/storage/primitive-index-store.ts
+++ b/packages/infra/src/storage/primitive-index-store.ts
@@ -1,0 +1,123 @@
+/**
+ * AppStorage-backed primitive-index location resolver.
+ * @module storage/primitive-index-store
+ */
+import type {
+  Dirent,
+} from 'node:fs';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import type {
+  AppStorage,
+  PrimitiveIndexKey,
+  PrimitiveIndexStore,
+} from '@ai-primitives-hub/core';
+
+const INDEX_FILENAME = 'primitive-index.v2.json';
+
+/**
+ * Convert an external identity into one safe, deterministic path segment.
+ * @param value
+ */
+function safeSegment(value: string): string {
+  const segment = value.trim()
+    .replaceAll(/[^a-zA-Z0-9._-]/gu, '_')
+    .replaceAll(/\.{2,}/gu, '_');
+  return segment.length > 0 ? segment : '_';
+}
+
+function indexHubNamespaces(hubId: string, entries: Dirent[]): string[] {
+  const normalized = hubId.trim();
+  const base = normalized.replace(/-\d{6}$/u, '');
+  const prefix = `${safeSegment(base)}-`;
+  return entries
+    .filter((entry) => entry.isDirectory() && (
+      entry.name === safeSegment(base)
+      || (entry.name.startsWith(prefix) && /^\d{6}$/u.test(entry.name.slice(prefix.length)))
+    ))
+    .map((entry) => entry.name);
+}
+
+/**
+ * Resolves shared semantic index paths below an injected application cache.
+ */
+export class AppStoragePrimitiveIndexStore implements PrimitiveIndexStore {
+  private readonly cacheRoot: string;
+
+  public constructor(storage: Pick<AppStorage, 'getPaths'>) {
+    this.cacheRoot = storage.getPaths().cache;
+  }
+
+  public getIndexPath(key: PrimitiveIndexKey): string {
+    return path.join(
+      this.cacheRoot,
+      'indexes',
+      safeSegment(key.hubId),
+      safeSegment(key.sourceRevision),
+      safeSegment(key.searchProfileId),
+      INDEX_FILENAME
+    );
+  }
+
+  /**
+   * Find the best persisted revision for a hub/profile pair.
+   * @param hubId Stable hub identity.
+   * @param searchProfileId Search profile to load.
+   * @param sourceIds Locally known source IDs used to reject incompatible snapshots.
+   * @returns The best compatible index path, or undefined when none exists.
+   */
+  public async findLatestIndexPath(
+    hubId: string,
+    searchProfileId: string,
+    sourceIds?: readonly string[]
+  ): Promise<string | undefined> {
+    const indexesRoot = path.join(this.cacheRoot, 'indexes');
+    let hubNamespaces: Dirent[];
+    try {
+      hubNamespaces = await fs.readdir(indexesRoot, { withFileTypes: true });
+    } catch {
+      return undefined;
+    }
+
+    const expectedSourceIds = sourceIds && new Set(sourceIds);
+    const candidates: { file: string; mtimeMs: number; sourceOverlap: number }[] = [];
+    for (const hubNamespace of indexHubNamespaces(hubId, hubNamespaces)) {
+      const profileRoot = path.join(indexesRoot, safeSegment(hubNamespace));
+      let revisions: Dirent[];
+      try {
+        revisions = await fs.readdir(profileRoot, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      for (const revision of revisions.filter((entry) => entry.isDirectory())) {
+        const file = path.join(profileRoot, revision.name, safeSegment(searchProfileId), INDEX_FILENAME);
+        try {
+          const raw = await fs.readFile(file, 'utf8');
+          const index = JSON.parse(raw) as {
+            primitives?: { bundle?: { sourceId?: unknown } }[];
+          };
+          if (!Array.isArray(index.primitives) || index.primitives.length === 0) {
+            continue;
+          }
+          const indexedSourceIds = expectedSourceIds
+            ? new Set(index.primitives.flatMap((primitive) =>
+              typeof primitive.bundle?.sourceId === 'string' ? [primitive.bundle.sourceId] : []
+            ))
+            : undefined;
+          const sourceOverlap = expectedSourceIds && indexedSourceIds
+            ? [...indexedSourceIds].filter((sourceId) => expectedSourceIds.has(sourceId)).length
+            : 0;
+          if (expectedSourceIds && sourceOverlap === 0) {
+            continue;
+          }
+          const stat = await fs.stat(file);
+          candidates.push({ file, mtimeMs: stat.mtimeMs, sourceOverlap });
+        } catch {
+          // Ignore malformed or concurrently removed snapshots.
+        }
+      }
+    }
+    return candidates
+      .toSorted((a, b) => b.sourceOverlap - a.sourceOverlap || b.mtimeMs - a.mtimeMs)[0]?.file;
+  }
+}

--- a/packages/infra/src/stores/active-hub-store.ts
+++ b/packages/infra/src/stores/active-hub-store.ts
@@ -15,6 +15,8 @@ import type {
 
 interface ActiveHubFile {
   hubId: string | null;
+  /** Compatibility field used by the shared index pointer format. */
+  hub?: string;
   setAt: string;
 }
 
@@ -42,7 +44,7 @@ export class ActiveHubStore {
     }
     try {
       const data = await this.fs.readJson<ActiveHubFile>(this.activeHubPath);
-      return data.hubId ?? null;
+      return data.hubId ?? data.hub ?? null;
     } catch {
       return null;
     }

--- a/packages/infra/src/stores/json-index-store.ts
+++ b/packages/infra/src/stores/json-index-store.ts
@@ -12,6 +12,9 @@
  * @module stores/json-index-store
  */
 
+import {
+  randomUUID,
+} from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {
@@ -25,10 +28,17 @@ import {
  */
 export function saveIndex(idx: PrimitiveIndex, filePath: string): void {
   const dir = path.dirname(filePath);
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
+  fs.mkdirSync(dir, { recursive: true });
+  const temporaryPath = path.join(
+    dir,
+    `.${path.basename(filePath)}.${process.pid}.${randomUUID()}.tmp`
+  );
+  try {
+    fs.writeFileSync(temporaryPath, JSON.stringify(idx.toJSON(), null, 2), 'utf8');
+    fs.renameSync(temporaryPath, filePath);
+  } finally {
+    fs.rmSync(temporaryPath, { force: true });
   }
-  fs.writeFileSync(filePath, JSON.stringify(idx.toJSON(), null, 2), 'utf8');
 }
 
 /**

--- a/packages/infra/test/extractors/zip-bundle-extractor.test.ts
+++ b/packages/infra/test/extractors/zip-bundle-extractor.test.ts
@@ -51,4 +51,10 @@ describe('ZipBundleExtractor', () => {
 
     await expect(new ZipBundleExtractor().extract(garbage)).rejects.toThrow(/Failed to extract bundle/);
   });
+
+  it('rejects archive entries that escape the bundle root', async () => {
+    const zipBytes = buildZip([{ path: '../outside.txt', bytes: new TextEncoder().encode('unsafe') }]);
+
+    await expect(new ZipBundleExtractor().extract(zipBytes)).rejects.toThrow(/Unsafe ZIP path/);
+  });
 });

--- a/packages/infra/test/harvest/bundle-providers/composite-bundle-provider.test.ts
+++ b/packages/infra/test/harvest/bundle-providers/composite-bundle-provider.test.ts
@@ -1,0 +1,67 @@
+import type {
+  BundleManifest,
+  BundleProvider,
+  BundleRef,
+} from '@ai-primitives-hub/core';
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  CompositeBundleProvider,
+} from '../../../src/harvest/bundle-providers/composite-bundle-provider';
+
+function providerThatLists(...refs: BundleRef[]): BundleProvider {
+  return {
+    async* listBundles(): AsyncIterable<BundleRef> {
+      yield* refs;
+    },
+    readManifest: async (): Promise<BundleManifest> => ({ id: 'test', version: '1.0.0', name: 'Test', items: [] }),
+    readFile: async (): Promise<string> => ''
+  };
+}
+
+describe('CompositeBundleProvider', () => {
+  it('continues enumerating healthy sources when one source fails', async () => {
+    const errors: { sourceId: string; error: unknown }[] = [];
+    const provider = new CompositeBundleProvider([
+      {
+        sourceId: 'broken',
+        provider: {
+          async* listBundles(): AsyncIterable<BundleRef> {
+            yield* [];
+            throw new Error('branch not found');
+          },
+          readManifest: async (): Promise<BundleManifest> => ({ id: 'broken', version: '1.0.0', name: 'Broken', items: [] }),
+          readFile: async (): Promise<string> => ''
+        }
+      },
+      {
+        sourceId: 'healthy',
+        provider: providerThatLists({
+          sourceId: 'healthy',
+          sourceType: 'github',
+          bundleId: 'healthy-bundle',
+          bundleVersion: 'main',
+          installed: false
+        })
+      }
+    ], {
+      onSourceError: (sourceId, error) => errors.push({ sourceId, error })
+    });
+
+    const refs: BundleRef[] = [];
+    for await (const ref of provider.listBundles()) {
+      refs.push(ref);
+    }
+
+    expect(refs).toHaveLength(1);
+    expect(refs[0]?.bundleId).toBe('healthy-bundle');
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.sourceId).toBe('broken');
+    expect(provider.getSourceIds()).toEqual(['broken', 'healthy']);
+    expect(provider.getSourceErrors()).toHaveLength(1);
+    expect(provider.getSourceErrors()[0]?.sourceId).toBe('broken');
+  });
+});

--- a/packages/infra/test/harvest/extractor.test.ts
+++ b/packages/infra/test/harvest/extractor.test.ts
@@ -16,6 +16,7 @@ import {
 } from 'vitest';
 import {
   buildBodyPreview,
+  buildBodySummary,
   computePrimitiveId,
   detectKindFromPath,
   type ExtractContext,
@@ -185,6 +186,27 @@ describe('buildBodyPreview', () => {
   });
 });
 
+describe('buildBodySummary', () => {
+  it('returns the first maxWords words of the cleaned body', () => {
+    const body = 'One two three four five six seven eight nine ten.';
+    const summary = buildBodySummary(body, 5);
+    expect(summary).toBe('One two three four five');
+  });
+
+  it('strips markdown before counting words', () => {
+    const body = '# Heading\n\n```js\nconst x = 1;\n```\n\nThis is a sample body with enough words to count beyond the default summary budget so the cleaner is exercised.';
+    const summary = buildBodySummary(body, 10);
+    expect(summary).not.toContain('```');
+    expect(summary.split(/\s+/).filter(Boolean).length).toBeLessThanOrEqual(10);
+  });
+
+  it('returns fewer words when the body is short', () => {
+    const body = 'Short body.';
+    const summary = buildBodySummary(body, 80);
+    expect(summary).toBe('Short body.');
+  });
+});
+
 describe('extractFromFile', () => {
   const ref: BundleRef = {
     sourceId: 'source123',
@@ -212,6 +234,8 @@ describe('extractFromFile', () => {
       expect(result.title).toBe('Test');
       expect(result.description).toBe('A test');
       expect(result.tags).toEqual(['test', 'example']);
+      expect(result.bodySummary).toBeDefined();
+      expect(result.bodySummary).toContain('Body content');
     }
   });
 

--- a/packages/infra/test/harvest/hub-harvester.test.ts
+++ b/packages/infra/test/harvest/hub-harvester.test.ts
@@ -105,6 +105,10 @@ describe('hub-harvester', () => {
     expect(result.primitives).toBe(2);
     expect(result.totalMs).toBeGreaterThanOrEqual(0);
     expect(result.index.stats().primitives).toBe(2);
+    expect(result.sourceCoverage).toEqual([
+      { sourceId: 'src-1', state: 'indexed', primitives: 1, revision: 'sha-o1r1' },
+      { sourceId: 'src-2', state: 'indexed', primitives: 1, revision: 'sha-o2r2' }
+    ]);
   });
 
   it('skips unchanged sources on a second run (smart rebuild)', async () => {
@@ -135,6 +139,41 @@ describe('hub-harvester', () => {
     expect(second.skip).toBe(1);
     expect(commitCallCount()).toBe(commitCallsAfterFirst + 1);
     expect(second.index.stats().primitives).toBe(1);
+    expect(second.sourceCoverage).toEqual([
+      { sourceId: 'src-1', state: 'skipped', message: 'already-harvested', revision: 'fixed-sha' }
+    ]);
+  });
+
+  it('retains the last successful source snapshot when a warm run fails', async () => {
+    const promptBytes = Buffer.from('---\ntitle: Hello\n---\n# Hello\n', 'utf8');
+    const promptSha = computeGitBlobSha(promptBytes);
+    const fake = new FakeGitHubApi();
+    seedRepo(fake, 'o', 'r', 'first-sha', [{ path: 'prompts/a.prompt.md', sha: promptSha, size: promptBytes.length }], new Map([[promptSha, promptBytes]]));
+    const cache = new BlobCache(path.join(tmp, 'blobs'));
+    const options = {
+      sources: [spec('src-1', 'o', 'r')],
+      client: fake,
+      cache,
+      progressFile: path.join(tmp, 'progress.jsonl'),
+      concurrency: 1
+    } as const;
+
+    const first = await new HubHarvester(options).run();
+    expect(first.index.stats().primitives).toBe(1);
+
+    // The commit moved, but the subsequent tree request is unavailable. The
+    // warm run must keep the last known-good primitive rather than replacing
+    // the persisted source snapshot with an empty array.
+    fake.seedJson('/repos/o/r/commits/main', { sha: 'second-sha' });
+    const second = await new HubHarvester(options).run();
+    expect(second.error).toBe(1);
+    expect(second.index.stats().primitives).toBe(1);
+    expect(second.sourceCoverage).toHaveLength(1);
+    expect(second.sourceCoverage[0]).toMatchObject({
+      sourceId: 'src-1',
+      state: 'failed',
+      revision: 'second-sha'
+    });
   });
 
   it('harvests an awesome-copilot-plugin source (one bundle per plugin)', async () => {
@@ -414,6 +453,55 @@ items:
         progressFile: path.join(tmp, 'progress.jsonl'),
         cacheDir: path.join(tmp, 'cache')
       })).rejects.toThrow('Invalid hubRepo');
+    });
+
+    it('does not write an index during a dry run', async () => {
+      const outFile = path.join(tmp, 'dry-run-index.json');
+      await harvestHub({
+        noHubConfig: true,
+        dryRun: true,
+        outFile,
+        progressFile: path.join(tmp, 'dry-run-progress.jsonl'),
+        cacheDir: path.join(tmp, 'dry-run-cache')
+      });
+      expect(fs.existsSync(outFile)).toBe(false);
+    });
+
+    it('allows public extra-source harvests to continue anonymously when no token exists', async () => {
+      const envKeys = ['GITHUB_TOKEN', 'GH_TOKEN'];
+      const saved = new Map<string, string | undefined>();
+      const savedPath = process.env.PATH;
+      for (const key of envKeys) {
+        saved.set(key, process.env[key]);
+        delete process.env[key];
+      }
+      process.env.PATH = path.join(tmp, 'no-gh-path');
+
+      try {
+        const result = await harvestHub({
+          noHubConfig: true,
+          dryRun: true,
+          extraSources: ['id=hello,type=github,url=https://github.com/octocat/hello-world'],
+          outFile: path.join(tmp, 'anonymous-index.json'),
+          progressFile: path.join(tmp, 'anonymous-progress.jsonl'),
+          cacheDir: path.join(tmp, 'anonymous-cache')
+        });
+        expect(result.tokenSource).toBe('none');
+      } finally {
+        if (savedPath === undefined) {
+          delete process.env.PATH;
+        } else {
+          process.env.PATH = savedPath;
+        }
+        for (const key of envKeys) {
+          const value = saved.get(key);
+          if (value === undefined) {
+            delete process.env[key];
+          } else {
+            process.env[key] = value;
+          }
+        }
+      }
     });
   });
 });

--- a/packages/infra/test/harvest/token-provider.test.ts
+++ b/packages/infra/test/harvest/token-provider.test.ts
@@ -4,6 +4,7 @@ import {
   it,
 } from 'vitest';
 import {
+  createTokenResolver,
   redactToken,
   resolveGithubToken,
   type TokenResolver,
@@ -65,5 +66,14 @@ describe('token-provider', () => {
     expect(redactToken('ghp_abcdefghij')).toBe('***<len=14,tail=ghij>');
     expect(redactToken('')).toBe('***<empty>');
     expect(redactToken(undefined)).toBe('***<missing>');
+  });
+
+  it('reads the environment supplied by the harvest caller', async () => {
+    const r = await resolveGithubToken(
+      {},
+      createTokenResolver({ GITHUB_TOKEN: 'caller-token' })
+    );
+    expect(r.token).toBe('caller-token');
+    expect(r.source).toBe('env:GITHUB_TOKEN');
   });
 });

--- a/packages/infra/test/search/embedding-text.test.ts
+++ b/packages/infra/test/search/embedding-text.test.ts
@@ -1,0 +1,97 @@
+import type {
+  Primitive,
+} from '@ai-primitives-hub/core';
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  buildEmbeddingText,
+  buildEmbeddingTexts,
+  EMBEDDING_BUDGETS,
+} from '../../src/search/embedding-text';
+
+function primitive(overrides: Partial<Primitive> = {}): Primitive {
+  return {
+    id: 'test-1',
+    bundle: {
+      sourceId: 'src',
+      sourceType: 'github',
+      bundleId: 'bundle',
+      bundleVersion: '1.0.0',
+      installed: false
+    },
+    kind: 'skill',
+    title: 'Terraform Module Generator',
+    description: 'Generate Terraform modules from natural language.',
+    path: 'skills/terraform.skill.md',
+    tags: ['terraform', 'infrastructure', 'cloud'],
+    bodyPreview: 'This skill helps you generate Terraform modules from natural language descriptions.',
+    contentHash: 'abc',
+    ...overrides
+  };
+}
+
+function wordCount(text: string): number {
+  return text.trim().split(/\s+/).filter(Boolean).length;
+}
+
+describe('buildEmbeddingText', () => {
+  it('concatenates title, description, tags, and bodySummary or bodyPreview', () => {
+    const text = buildEmbeddingText(primitive());
+    expect(text).toContain('Terraform Module Generator');
+    expect(text).toContain('Generate Terraform modules from natural language.');
+    expect(text).toContain('terraform infrastructure cloud');
+    expect(text).toContain('This skill helps you generate');
+  });
+
+  it('prefers bodySummary over bodyPreview when present', () => {
+    const text = buildEmbeddingText(primitive({
+      bodySummary: 'summary text from the full body',
+      bodyPreview: 'preview text'
+    }));
+    expect(text).toContain('summary text from the full body');
+    expect(text).not.toContain('preview text');
+  });
+
+  it('does not exceed the total word budget', () => {
+    const longDescription = 'word '.repeat(200);
+    const longBody = 'body '.repeat(200);
+    const text = buildEmbeddingText(primitive({
+      description: longDescription,
+      bodyPreview: longBody
+    }));
+    expect(wordCount(text)).toBeLessThanOrEqual(EMBEDDING_BUDGETS.total);
+  });
+
+  it('preserves priority order (title before description before body)', () => {
+    const text = buildEmbeddingText(primitive({
+      description: 'word '.repeat(200),
+      bodyPreview: 'body '.repeat(200)
+    }));
+    const words = text.trim().split(/\s+/).filter(Boolean);
+    expect(words[0]).toBe('Terraform');
+    expect(words[1]).toBe('Module');
+    expect(words[2]).toBe('Generator');
+  });
+});
+
+describe('buildEmbeddingTexts', () => {
+  it('returns a single combined stream by default', () => {
+    const texts = buildEmbeddingTexts(primitive());
+    expect(Object.keys(texts)).toEqual(['combined']);
+    expect(texts.combined).toContain('Terraform Module Generator');
+  });
+
+  it('returns separate metadata and body streams for dual strategy', () => {
+    const texts = buildEmbeddingTexts(primitive({
+      bodySummary: 'summary text from the full body'
+    }), 'dual');
+    expect(Object.keys(texts).toSorted()).toEqual(['body', 'metadata']);
+    expect(texts.metadata).toContain('Terraform Module Generator');
+    expect(texts.body).toContain('summary text from the full body');
+    expect(wordCount(texts.metadata)).toBeLessThanOrEqual(EMBEDDING_BUDGETS.metadata);
+    expect(wordCount(texts.body)).toBeLessThanOrEqual(EMBEDDING_BUDGETS.body);
+  });
+});

--- a/packages/infra/test/search/index.test.ts
+++ b/packages/infra/test/search/index.test.ts
@@ -10,6 +10,9 @@ import {
   harvest,
 } from '../../src/harvest/harvester';
 import {
+  TernlightEmbeddingProvider,
+} from '../../src/search/embedding/ternlight-embedding-provider';
+import {
   PrimitiveIndex,
 } from '../../src/search/primitive-index';
 import {
@@ -53,6 +56,20 @@ describe('PrimitiveIndex', () => {
     const idx = await buildIndex();
     const res = idx.search({ installedOnly: true });
     expect(res.hits.every((h) => h.primitive.bundle.installed)).toBe(true);
+  });
+
+  it('applies the current installed bundle snapshot at query time', async () => {
+    const idx = await buildIndex();
+    const target = idx.all().find((primitive) => !primitive.bundle.installed);
+    expect(target).toBeDefined();
+
+    const res = idx.search({
+      installedOnly: true,
+      installedBundleKeys: [`${target!.bundle.sourceId}\u0000${target!.bundle.bundleId}\u0000${target!.bundle.bundleVersion}`]
+    });
+
+    expect(res.hits.length).toBeGreaterThan(0);
+    expect(res.hits.every((hit) => hit.primitive.bundle.bundleId === target!.bundle.bundleId)).toBe(true);
   });
 
   it('explain mode attaches matches', async () => {
@@ -105,6 +122,21 @@ describe('PrimitiveIndex', () => {
     }
   });
 
+  it('replaces an existing index atomically without leaving temporary files', async () => {
+    const idx = await buildIndex();
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'primitive-index-atomic-'));
+    const file = path.join(dir, 'nested', 'primitive-index.json');
+    try {
+      saveIndex(idx, file);
+      saveIndex(idx, file);
+
+      expect(loadIndex(file).stats().primitives).toBe(idx.stats().primitives);
+      expect(fs.readdirSync(path.dirname(file))).toStrictEqual(['primitive-index.json']);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('refresh reports adds/updates/removes and prunes shortlists', async () => {
     const bundles = createFixtureBundles();
     const provider = new FakeBundleProvider(bundles);
@@ -121,5 +153,15 @@ describe('PrimitiveIndex', () => {
     expect(report.updated.length).toBe(0);
     // Shortlist should still contain the primitive since nothing was removed
     expect(idx.getShortlist(sl.id)?.primitiveIds.length).toBe(1);
+  });
+
+  it('requires embeddings when refreshing an embedded index', async () => {
+    const idx = await PrimitiveIndex.buildFrom(
+      new FakeBundleProvider(createFixtureBundles()),
+      { embeddings: new TernlightEmbeddingProvider() }
+    );
+
+    await expect(idx.refresh(new FakeBundleProvider(createFixtureBundles())))
+      .rejects.toThrow(/requires the embedding provider/);
   });
 });

--- a/packages/infra/test/search/primitive-index-embeddings.test.ts
+++ b/packages/infra/test/search/primitive-index-embeddings.test.ts
@@ -1,0 +1,122 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  harvest,
+} from '../../src/harvest/harvester';
+import {
+  TernlightEmbeddingProvider,
+} from '../../src/search/embedding/ternlight-embedding-provider';
+import {
+  PrimitiveIndex,
+} from '../../src/search/primitive-index';
+import {
+  loadIndex,
+  saveIndex,
+} from '../../src/stores/json-index-store';
+import {
+  createFixtureBundles,
+  FakeBundleProvider,
+} from '../fixtures/primitive-index';
+
+async function buildEmbeddedIndex(): Promise<PrimitiveIndex> {
+  const provider = new FakeBundleProvider(createFixtureBundles());
+  return PrimitiveIndex.buildFrom(provider, {
+    embeddings: new TernlightEmbeddingProvider()
+  });
+}
+
+describe('PrimitiveIndex embeddings', () => {
+  it('builds an index with embeddings when a provider is supplied', async () => {
+    const idx = await buildEmbeddedIndex();
+    const json = idx.toJSON() as {
+      searchProfileId?: string | null;
+      embeddingsMeta?: { provider: string; dim: number } | null;
+      primitives: { embedding?: number[] }[];
+    };
+    expect(json.searchProfileId).toBe('ternlight-single-v1');
+    expect(json.embeddingsMeta).toBeTruthy();
+    expect(json.embeddingsMeta?.dim).toBe(384);
+    expect(json.embeddingsMeta?.strategy).toBe('summary');
+
+    const withEmbedding = json.primitives.filter((p) => p.embedding && p.embedding.length > 0);
+    expect(withEmbedding.length).toBe(json.primitives.length);
+  });
+
+  it('buildFromPrimitives without embeddings does not store embeddings', async () => {
+    const provider = new FakeBundleProvider(createFixtureBundles());
+    const prims = await harvest(provider);
+    const idx = PrimitiveIndex.fromPrimitives(prims);
+    const json = idx.toJSON() as {
+      embeddingsMeta?: { provider: string; dim: number } | null;
+    };
+    expect(json.embeddingsMeta ?? null).toBeNull();
+  });
+
+  it('supports hybrid search with a query embedding', async () => {
+    const idx = await buildEmbeddedIndex();
+    const embedder = new TernlightEmbeddingProvider();
+    const [queryEmbedding] = await embedder.embed(['rust setup']);
+    const res = idx.search({ q: 'rust setup', ranking: 'hybrid', queryEmbedding, limit: 5 });
+    expect(res.hits.length).toBeGreaterThan(0);
+    expect(res.hits[0].score).toBeGreaterThan(0);
+  });
+
+  it('round-trips embeddings through saveIndex/loadIndex', async () => {
+    const idx = await buildEmbeddedIndex();
+    const file = path.join(os.tmpdir(), `pi-embed-${Date.now()}.json`);
+    try {
+      saveIndex(idx, file);
+      const loaded = loadIndex(file);
+      const json = loaded.toJSON() as {
+        embeddingsMeta?: { provider: string; dim: number } | null;
+        primitives: { embedding?: number[] }[];
+      };
+      expect(json.embeddingsMeta).toBeTruthy();
+      expect(json.embeddingsMeta?.strategy).toBe('summary');
+      expect(json.primitives.some((p) => p.embedding && p.embedding.length === 384)).toBe(true);
+
+      const embedder = new TernlightEmbeddingProvider();
+      const [queryEmbedding] = await embedder.embed(['terraform']);
+      const res = loaded.search({ q: 'terraform', ranking: 'hybrid', queryEmbedding, limit: 5 });
+      expect(res.hits.length).toBeGreaterThan(0);
+    } finally {
+      fs.rmSync(file, { force: true });
+    }
+  });
+
+  it('builds a dual-embedding index and supports multi-vector search', async () => {
+    const provider = new FakeBundleProvider(createFixtureBundles());
+    const idx = await PrimitiveIndex.buildFrom(provider, {
+      embeddings: new TernlightEmbeddingProvider(),
+      embeddingStrategy: 'dual'
+    });
+    const json = idx.toJSON() as {
+      searchProfileId?: string | null;
+      embeddingsMeta?: { provider: string; dim: number; embeddingStrategy?: string } | null;
+      primitives: { embeddings?: Record<string, number[]> }[];
+    };
+    expect(json.searchProfileId).toBe('ternlight-dual-v1');
+    expect(json.embeddingsMeta?.embeddingStrategy).toBe('dual');
+    expect(json.primitives[0]?.embeddings?.metadata).toHaveLength(384);
+    expect(json.primitives[0]?.embeddings?.body).toHaveLength(384);
+
+    const embedder = new TernlightEmbeddingProvider();
+    const [metadataQuery] = await embedder.embed(['terraform']);
+    const [bodyQuery] = await embedder.embed(['infrastructure provisioning']);
+    const res = idx.search({
+      q: 'terraform infrastructure',
+      ranking: 'multi',
+      queryEmbeddings: { metadata: metadataQuery, body: bodyQuery },
+      embeddingWeights: { bm25: 0.6, metadata: 0.15, body: 0.25 },
+      limit: 5
+    });
+    expect(res.hits.length).toBeGreaterThan(0);
+    expect(res.hits[0].score).toBeGreaterThan(0);
+  });
+});

--- a/packages/infra/test/search/source-adapter-bundle-provider.test.ts
+++ b/packages/infra/test/search/source-adapter-bundle-provider.test.ts
@@ -1,0 +1,134 @@
+import type {
+  Bundle,
+  BundleExtractor,
+  ExtractedFiles,
+  SourceAdapter,
+} from '@ai-primitives-hub/core';
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  SourceAdapterBundleProvider,
+} from '../../src/harvest/bundle-providers/source-adapter-bundle-provider';
+
+const source = {
+  id: 'source-1',
+  name: 'Source 1',
+  type: 'local',
+  url: 'file:///source-1',
+  enabled: true,
+  priority: 1
+} as const;
+
+const bundle: Bundle = {
+  id: 'bundle-1',
+  name: 'Bundle 1',
+  version: '1.0.0',
+  description: '',
+  author: 'test',
+  sourceId: source.id,
+  environments: [],
+  tags: [],
+  lastUpdated: '2026-01-01T00:00:00Z',
+  size: '1 KB',
+  dependencies: [],
+  license: 'MIT',
+  manifestUrl: '',
+  downloadUrl: ''
+};
+
+function createAdapter(): SourceAdapter {
+  return {
+    source,
+    type: source.type,
+    fetchBundles: async () => [bundle],
+    downloadBundle: async () => Buffer.from('bundle-archive'),
+    fetchMetadata: async () => ({ name: source.name, description: '', bundleCount: 1, lastUpdated: '', version: '1' }),
+    validate: async () => ({ valid: true, errors: [], warnings: [] }),
+    requiresAuthentication: () => false,
+    getManifestUrl: () => '',
+    getDownloadUrl: () => '',
+    downloadReadme: async () => null
+  };
+}
+
+function createExtractor(): BundleExtractor {
+  const files: ExtractedFiles = new Map([
+    ['deployment-manifest.yml', new TextEncoder().encode('id: bundle-1\nversion: 1.0.0\nname: Bundle 1\n')],
+    ['prompts/hello.prompt.md', new TextEncoder().encode('# Hello')]
+  ]);
+  return {
+    extract: async () => files
+  };
+}
+
+describe('SourceAdapterBundleProvider', () => {
+  it('translates source bundles into refs and reads archive files', async () => {
+    const provider = new SourceAdapterBundleProvider({
+      adapter: createAdapter(),
+      extractor: createExtractor()
+    });
+
+    const refs = [];
+    for await (const ref of provider.listBundles()) {
+      refs.push(ref);
+    }
+
+    expect(refs).toEqual([{
+      sourceId: 'source-1',
+      sourceType: 'local',
+      bundleId: 'bundle-1',
+      bundleVersion: '1.0.0',
+      installed: false
+    }]);
+    await expect(provider.readManifest(refs[0])).resolves.toMatchObject({ id: 'bundle-1', version: '1.0.0' });
+    await expect(provider.readFile(refs[0], 'prompts/hello.prompt.md')).resolves.toBe('# Hello');
+  });
+
+  it('supports archives with a single wrapper directory', async () => {
+    const files: ExtractedFiles = new Map([
+      ['bundle-1/deployment-manifest.yml', new TextEncoder().encode('id: bundle-1\nversion: 1.0.0\n')],
+      ['bundle-1/prompt.md', new TextEncoder().encode('content')]
+    ]);
+    const provider = new SourceAdapterBundleProvider({
+      adapter: createAdapter(),
+      extractor: { extract: async () => files }
+    });
+    const refs = [];
+    for await (const item of provider.listBundles()) {
+      refs.push(item);
+    }
+
+    await expect(provider.readFile(refs[0], 'prompt.md')).resolves.toBe('content');
+  });
+
+  it('projects installation state onto bundle refs', async () => {
+    const provider = new SourceAdapterBundleProvider({
+      adapter: createAdapter(),
+      extractor: createExtractor(),
+      isInstalled: (candidate) => candidate.id === 'bundle-1'
+    });
+
+    await expect(collect(provider.listBundles())).resolves.toEqual([expect.objectContaining({ installed: true })]);
+  });
+
+  it('rejects unsafe requested paths', async () => {
+    const provider = new SourceAdapterBundleProvider({
+      adapter: createAdapter(),
+      extractor: createExtractor()
+    });
+    const [ref] = await collect(provider.listBundles());
+
+    await expect(provider.readFile(ref, '../secrets')).rejects.toThrow(/unsafe bundle path/);
+  });
+});
+
+async function collect<T>(items: AsyncIterable<T>): Promise<T[]> {
+  const result: T[] = [];
+  for await (const item of items) {
+    result.push(item);
+  }
+  return result;
+}

--- a/packages/infra/test/search/ternlight-embedding-provider.test.ts
+++ b/packages/infra/test/search/ternlight-embedding-provider.test.ts
@@ -1,0 +1,56 @@
+import {
+  cosineSim,
+} from '@ternlight/mini';
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  TernlightEmbeddingProvider,
+} from '../../src/search/embedding/ternlight-embedding-provider';
+
+function l2Norm(v: Float32Array): number {
+  let sum = 0;
+  for (const x of v) {
+    sum += x * x;
+  }
+  return Math.sqrt(sum);
+}
+
+describe('TernlightEmbeddingProvider', () => {
+  it('exposes a 384-dimensional embedding model', () => {
+    const provider = new TernlightEmbeddingProvider();
+    expect(provider.dim).toBe(384);
+  });
+
+  it('embeds a batch of texts into unit L2-normalised vectors', async () => {
+    const provider = new TernlightEmbeddingProvider();
+    const vectors = await provider.embed(['hello world', 'unit test example']);
+    expect(vectors).toHaveLength(2);
+    for (const v of vectors) {
+      expect(v).toBeInstanceOf(Float32Array);
+      expect(v.length).toBe(384);
+      expect(l2Norm(v)).toBeCloseTo(1, 5);
+    }
+  });
+
+  it('returns an empty array for an empty batch', async () => {
+    const provider = new TernlightEmbeddingProvider();
+    const vectors = await provider.embed([]);
+    expect(vectors).toStrictEqual([]);
+  });
+
+  it('produces higher cosine similarity for related texts than unrelated ones', async () => {
+    const provider = new TernlightEmbeddingProvider();
+    const [a, b, c] = await provider.embed([
+      'write unit tests for an Angular component',
+      'generate Jasmine unit tests',
+      'deploy a Docker container to Kubernetes'
+    ]);
+    const related = cosineSim(a, b);
+    const unrelated = cosineSim(a, c);
+    expect(related).toBeGreaterThan(unrelated);
+    expect(related).toBeGreaterThan(0);
+  });
+});

--- a/packages/infra/test/storage/primitive-index-store.test.ts
+++ b/packages/infra/test/storage/primitive-index-store.test.ts
@@ -1,0 +1,96 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  AppStoragePrimitiveIndexStore,
+  XdgAppStorage,
+} from '../../src/storage';
+
+describe('AppStoragePrimitiveIndexStore', () => {
+  it('resolves a hub, source revision, and profile namespaced index path', () => {
+    const storage = new XdgAppStorage({ XDG_CACHE_HOME: '/tmp/shared-cache' });
+    const store = new AppStoragePrimitiveIndexStore(storage);
+
+    expect(store.getIndexPath({
+      hubId: 'owner/repository',
+      sourceRevision: 'refs/heads/main@abc123',
+      searchProfileId: 'ternlight-dual-v1'
+    })).toBe(path.join(
+      '/tmp/shared-cache',
+      'ai-primitives-hub',
+      'indexes',
+      'owner_repository',
+      'refs_heads_main_abc123',
+      'ternlight-dual-v1',
+      'primitive-index.v2.json'
+    ));
+  });
+
+  it('does not allow key values to escape the cache root', () => {
+    const storage = new XdgAppStorage({ XDG_CACHE_HOME: '/tmp/shared-cache' });
+    const store = new AppStoragePrimitiveIndexStore(storage);
+    const indexPath = store.getIndexPath({
+      hubId: '../../outside',
+      sourceRevision: '../revision',
+      searchProfileId: 'profile/with/slashes'
+    });
+
+    expect(indexPath.startsWith(path.join('/tmp/shared-cache', 'ai-primitives-hub', 'indexes'))).toBe(true);
+    expect(indexPath).not.toContain('..');
+  });
+
+  it('finds existing timestamp-suffixed snapshots through the stable hub namespace', async () => {
+    const cacheRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'shared-index-store-test-'));
+    const storage = new XdgAppStorage({ XDG_CACHE_HOME: cacheRoot });
+    const store = new AppStoragePrimitiveIndexStore(storage);
+    const legacyPath = store.getIndexPath({
+      hubId: 'amadeus-hub-788228',
+      sourceRevision: 'legacy-revision',
+      searchProfileId: 'ternlight-dual-v1'
+    });
+    await fs.mkdir(path.dirname(legacyPath), { recursive: true });
+    await fs.writeFile(legacyPath, JSON.stringify({ primitives: [{ id: 'primitive-1' }] }));
+
+    await expect(store.findLatestIndexPath('amadeus-hub', 'ternlight-dual-v1')).resolves.toBe(legacyPath);
+    await fs.rm(cacheRoot, { recursive: true, force: true });
+  });
+
+  it('prefers a source-compatible snapshot over a newer incompatible snapshot', async () => {
+    const cacheRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'shared-index-store-compatibility-test-'));
+    const storage = new XdgAppStorage({ XDG_CACHE_HOME: cacheRoot });
+    const store = new AppStoragePrimitiveIndexStore(storage);
+    const compatiblePath = store.getIndexPath({
+      hubId: 'amadeus-hub',
+      sourceRevision: 'older-compatible-revision',
+      searchProfileId: 'ternlight-dual-v1'
+    });
+    const incompatiblePath = store.getIndexPath({
+      hubId: 'amadeus-hub',
+      sourceRevision: 'newer-incompatible-revision',
+      searchProfileId: 'ternlight-dual-v1'
+    });
+    await fs.mkdir(path.dirname(compatiblePath), { recursive: true });
+    await fs.mkdir(path.dirname(incompatiblePath), { recursive: true });
+    await fs.writeFile(compatiblePath, JSON.stringify({
+      primitives: [{ bundle: { sourceId: 'current-source' } }]
+    }));
+    await fs.writeFile(incompatiblePath, JSON.stringify({
+      primitives: [{ bundle: { sourceId: 'legacy-source' } }]
+    }));
+    const now = Date.now() / 1000;
+    await fs.utimes(compatiblePath, now - 10, now - 10);
+    await fs.utimes(incompatiblePath, now, now);
+
+    await expect(store.findLatestIndexPath(
+      'amadeus-hub',
+      'ternlight-dual-v1',
+      ['current-source']
+    )).resolves.toBe(compatiblePath);
+    await fs.rm(cacheRoot, { recursive: true, force: true });
+  });
+});

--- a/packages/infra/test/stores/active-hub-store.test.ts
+++ b/packages/infra/test/stores/active-hub-store.test.ts
@@ -32,6 +32,11 @@ describe('ActiveHubStore', () => {
     expect(await store.get()).toBe('my-hub');
   });
 
+  it('reads the shared index pointer hub field', async () => {
+    fs.seed('/hubs/active-hub.json', JSON.stringify({ hub: 'shared-hub', profile: 'bm25-v1' }));
+    expect(await store.get()).toBe('shared-hub');
+  });
+
   it('updates the active hub id when set again', async () => {
     await store.set('hub-1');
     await store.set('hub-2');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -412,8 +412,11 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@elastic/elasticsearch':
-        specifier: ^9.4.2
+        specifier: ^9.3.4
         version: 9.4.2
+      '@ternlight/mini':
+        specifier: 0.1.0
+        version: 0.1.0
       adm-zip:
         specifier: ^0.6.0
         version: 0.6.0
@@ -3227,6 +3230,10 @@ packages:
   '@szmarczak/http-timer@5.0.1':
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
+
+  '@ternlight/mini@0.1.0':
+    resolution: {integrity: sha512-YuBODYpRoXWuH3fTw2pSvlm39VkbVuKybXJwgybzMSZQjck92ZWD1MEQj5K/ANdlW3EvsqrH/NZxbKE5rwSOzA==}
+    engines: {node: '>=18'}
 
   '@textlint/ast-node-types@15.7.1':
     resolution: {integrity: sha512-Wii5UgUKFEh9Uv6wbq1zr4/Kf+dtjiUuzPrrXzKp8H+ifkvKNzi23V4Nz+6wVyHQn5T28AFuc8VH8OtzvGYecA==}
@@ -13678,6 +13685,8 @@ snapshots:
   '@szmarczak/http-timer@5.0.1':
     dependencies:
       defer-to-connect: 2.0.1
+
+  '@ternlight/mini@0.1.0': {}
 
   '@textlint/ast-node-types@15.7.1': {}
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "lib": ["ES2024"],
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Description

This PR adds local, on-device semantic (embedding) search to the primitive index. Users can now build indexes with dense vector embeddings and search with a hybrid BM25 + cosine-similarity ranking mode. `init` is updated to produce a searchable embedded index by default, while remaining fully backward compatible and offline-capable.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test coverage improvement
- [x] 🔧 Configuration/build changes

## Related Issues

Relates to #372

## Changes Made

- Add `TernlightEmbeddingProvider` (384-dim, WASM, no native dependencies) behind an `EmbeddingProvider` port in `packages/infra`.
- Extend `PrimitiveIndex` to batch-compute and persist embeddings, and to rank results with a hybrid BM25 + cosine-similarity score (60/40 split).
- Add `buildIndex` and `searchIndex` use cases in `packages/app`.
- Add `--embed` to `index build` and `index harvest`, and `--ranking hybrid` to `index search`.
- Make `init` build an embedded index by default after importing a hub; add `--skip-index` and `--no-embed` escape hatches.
- Update `index build` defaults: root falls back to the current directory and output falls back to the XDG cache directory.
- Inline the `ternlight-mini` WASM into the SEA bundle so the single executable remains self-contained.
- Lazily create the GitHub client in `harvestHub`, allowing local/URL hub configs to be harvested offline without a token.
- Stream progress logging with live ETAs during source harvesting, BM25 indexing, and embedding computation.
- Add and extend unit/integration tests across `core`, `infra`, `app`, and `cli`.
- Update `.vscode/settings.json` to pin the editor TypeScript SDK to the workspace version.

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

### Manual Testing Steps

1. `pnpm -C packages/infra run build && pnpm -C packages/infra run test`
2. `pnpm -C packages/app run build && pnpm -C packages/app run test`
3. `pnpm -C packages/cli run build && pnpm -C packages/cli run test`
4. `pnpm -C packages/cli run build:sea:local`
5. Run `./packages/cli/dist/ai-primitives-hub-linux-x64 init` with a hub and verify the embedded index is built with progress output.
6. Run `./packages/cli/dist/ai-primitives-hub-linux-x64 index search --query "..." --ranking hybrid` and verify results are ranked.

### Tested On

- [ ] macOS
- [ ] Windows
- [x] Linux

- [ ] VS Code Stable
- [ ] VS Code Insiders

## Screenshots

<!-- N/A -->

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Documentation

- [ ] README.md updated
- [ ] JSDoc comments added/updated
- [x] No documentation changes needed

## Additional Notes

- The embedding model (`ternlight-mini`) is ~5 MB and runs entirely on CPU via WASM. No GPU, network, or API key is required after installation.
- Embeddings are computed from `title`, `description`, `tags`, and `bodyPreview` — the same fields used for BM25. `kind` and `path` remain facet/filter and tie-breaker fields and are not embedded.
- Indexes remain backward compatible: `index search` defaults to BM25, and hybrid mode returns a clear error if the index has no embeddings.
- For a representative 749-primitive hub, embedding adds ~1.1 MB to the index file and completes in the low tens of seconds on CPU.

## Reviewer Guidelines

Please pay special attention to:

- The `EmbeddingProvider` port and `TernlightEmbeddingProvider` implementation in `packages/infra/src/search`.
- The hybrid scoring logic and batch-embedding implementation in `PrimitiveIndex`.
- The `init`/`index build`/`index harvest` CLI UX and default behavior.
- The esbuild SEA WASM inlining in `packages/cli/scripts/build-sea.mjs`.
- Test coverage for the new `app` search use cases and CLI command flows.

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
