### PR TITLE
feat(install): extend install routing for new primitive kinds and target types

### DIFF
--- a/lib/bin/build-collection-bundle.js
+++ b/lib/bin/build-collection-bundle.js
@@ -1,12 +1,17 @@
 #!/usr/bin/env node
 const fs = require('node:fs');
 const path = require('node:path');
-const { spawnSync } = require('node:child_process');
 
 const archiver = require('archiver');
 
-const { readCollection, resolveCollectionItemPaths, generateBundleId } = require('../dist');
-const { resolveCollectionReadmePath } = require('../dist/collections');
+const {
+  createReleaseManifestPlan,
+  createLegacyReleaseManifestPlan,
+  generateBundleId,
+  isMissingSourceLicenseError,
+  LEGACY_RELEASE_WARNING,
+  serializeReleaseManifest,
+} = require('../dist');
 
 function parseArgs(argv) {
   const out = {
@@ -34,19 +39,7 @@ function parseArgs(argv) {
   return out;
 }
 
-function normalizeRepoRel(p) {
-  return String(p).replace(/\\/g, '/').replace(/^\//, '');
-}
-
-function runNodeScript(scriptPath, args, cwd) {
-  const res = spawnSync('node', [scriptPath, ...args], { cwd, encoding: 'utf8' });
-  if (res.status !== 0) {
-    throw new Error(res.stderr || res.stdout || `Command failed: node ${scriptPath}`);
-  }
-  return res;
-}
-
-async function createZip({ repoRoot, zipPath, manifestPath, itemPaths }) {
+async function createZip({ zipPath, manifest, entries }) {
   await fs.promises.mkdir(path.dirname(zipPath), { recursive: true });
 
   const output = fs.createWriteStream(zipPath);
@@ -62,17 +55,16 @@ async function createZip({ repoRoot, zipPath, manifestPath, itemPaths }) {
 
     archive.pipe(output);
 
-    archive.file(manifestPath, {
+    archive.append(manifest, {
       name: 'deployment-manifest.yml',
       date: fixedDate,
     });
 
-    itemPaths
-      .map(normalizeRepoRel)
-      .sort()
-      .forEach((rel) => {
-        const abs = path.join(repoRoot, rel);
-        archive.file(abs, { name: rel, date: fixedDate });
+    entries
+      .slice()
+      .sort((left, right) => (left.path < right.path ? -1 : left.path > right.path ? 1 : 0))
+      .forEach((entry) => {
+        archive.append(entry.bytes, { name: entry.path, date: fixedDate });
       });
 
     archive.finalize();
@@ -89,26 +81,35 @@ async function main() {
   if (!repoSlug) throw new Error('Missing --repo-slug (or set GITHUB_REPOSITORY)');
 
   const outDir = args.outDir || path.join('dist');
-  const collection = readCollection(repoRoot, args.collectionFile);
-  const collectionId = collection.id;
-  if (!collectionId) throw new Error('collection.id is required');
+  let releasePlan;
+  try {
+    releasePlan = createReleaseManifestPlan({
+      repoRoot,
+      collectionFile: args.collectionFile,
+      version: args.version,
+    });
+  } catch (error) {
+    if (!isMissingSourceLicenseError(error)) throw error;
+    releasePlan = createLegacyReleaseManifestPlan({
+      repoRoot,
+      collectionFile: args.collectionFile,
+      version: args.version,
+    });
+    console.error(`warning: ${LEGACY_RELEASE_WARNING}`);
+  }
+  const collectionId = releasePlan.manifest.id;
+  if (typeof collectionId !== 'string' || collectionId.length === 0) throw new Error('collection.id is required');
 
   const bundleId = generateBundleId(repoSlug, collectionId, args.version);
   const collectionOutDir = path.join(outDir, collectionId);
   await fs.promises.mkdir(collectionOutDir, { recursive: true });
 
   const standaloneManifestPath = path.join(collectionOutDir, 'deployment-manifest.yml');
-  const generateManifestScript = path.join(__dirname, 'generate-manifest.js');
-  runNodeScript(
-    generateManifestScript,
-    [args.version, '--collection-file', args.collectionFile, '--out', standaloneManifestPath],
-    repoRoot
-  );
+  const manifest = serializeReleaseManifest(releasePlan.manifest);
+  await fs.promises.writeFile(standaloneManifestPath, manifest);
 
-  const itemPaths = resolveCollectionItemPaths(repoRoot, collection);
-  const readmePath = resolveCollectionReadmePath(collection);
   const zipPath = path.join(collectionOutDir, `${collectionId}.bundle.zip`);
-  await createZip({ repoRoot, zipPath, manifestPath: standaloneManifestPath, itemPaths });
+  await createZip({ zipPath, manifest, entries: releasePlan.entries });
 
   process.stdout.write(
     JSON.stringify(
@@ -118,7 +119,7 @@ async function main() {
         outDir: collectionOutDir.replace(/\\/g, '/'),
         manifestAsset: standaloneManifestPath.replace(/\\/g, '/'),
         zipAsset: zipPath.replace(/\\/g, '/'),
-        readmeAsset: readmePath ? readmePath.replace(/\\/g, '/') : undefined,
+        readmeAsset: releasePlan.readmeSourcePath ? releasePlan.readmeSourcePath.replace(/\\/g, '/') : undefined,
         bundleId,
       },
       null,

--- a/lib/bin/generate-manifest.js
+++ b/lib/bin/generate-manifest.js
@@ -79,8 +79,9 @@ try {
     const descMatch =
       itemContent.match(/^##?\s*Description[:\s]+(.+)$/im) || itemContent.match(/^>\s*(.+)$/m);
 
-    // Clone tags array to avoid YAML anchors
-    const tags = collection.tags ? [...collection.tags] : [];
+    // Keep collection tags on the root manifest only. Item tags are
+    // optional extras declared on the collection item, not a clone.
+    const tags = Array.isArray(item.tags) && item.tags.length > 0 ? [...item.tags] : undefined;
 
     // Determine file extension
     const extension = path.extname(itemPath);
@@ -104,7 +105,7 @@ try {
       description: descMatch ? descMatch[1] : '',
       file: itemPath,
       type: type,
-      tags: tags,
+      ...(tags ? { tags } : {}),
     };
   });
 

--- a/lib/bin/publish-collections.js
+++ b/lib/bin/publish-collections.js
@@ -3,6 +3,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const childProcess = require('node:child_process');
 const crypto = require('node:crypto');
+const yaml = require('js-yaml');
 
 let yauzl;
 try {
@@ -13,6 +14,8 @@ try {
 }
 
 const { listCollectionFiles, readCollection } = require('../dist');
+
+const SHA256_PATTERN = /^sha256:[a-f0-9]{64}$/;
 
 class PublishError extends Error {
   constructor(message, code, context = {}) {
@@ -168,6 +171,78 @@ function buildBundle({ repoRoot, repoSlug, collectionFile, version, spawnSync = 
 function ghReleaseExists({ repoRoot, tag, spawnSync = childProcess.spawnSync }) {
   const res = spawnSync('gh', ['release', 'view', tag], { cwd: repoRoot, stdio: 'ignore' });
   return res.status === 0;
+}
+
+async function validateGovernedReleaseAssets({ manifestAsset, zipAsset, readArchive = readZipFiles }) {
+  const standaloneManifest = fs.readFileSync(manifestAsset, 'utf8');
+  const manifest = yaml.load(standaloneManifest);
+  if (!manifest || manifest.formatVersion !== 1 || !Array.isArray(manifest.files) || !manifest.provenance) {
+    throw new PublishError('Release manifest is not a governed formatVersion: 1 manifest', 'INVALID_RELEASE_MANIFEST');
+  }
+  const files = await readArchive(zipAsset);
+  const archiveManifest = files.get('deployment-manifest.yml');
+  if (!archiveManifest || archiveManifest.toString('utf8') !== standaloneManifest) {
+    throw new PublishError('Standalone deployment manifest does not exactly match the ZIP manifest', 'MANIFEST_ARCHIVE_MISMATCH');
+  }
+  const declaredPaths = new Set(manifest.files.map((entry) => entry.path));
+  const archivePaths = [...files.keys()].filter((entryPath) => entryPath !== 'deployment-manifest.yml');
+  if (manifest.files.length !== archivePaths.length
+    || archivePaths.some((entryPath) => !declaredPaths.has(entryPath))) {
+    throw new PublishError('Release manifest inventory does not cover every ZIP entry', 'INCOMPLETE_ARCHIVE_INVENTORY');
+  }
+  for (const entry of manifest.files) {
+    const bytes = files.get(entry.path);
+    const actualHash = bytes ? `sha256:${crypto.createHash('sha256').update(bytes).digest('hex')}` : undefined;
+    if (!bytes || entry.size !== bytes.byteLength || !SHA256_PATTERN.test(entry.sha256) || entry.sha256 !== actualHash) {
+      throw new PublishError(`Release manifest integrity validation failed for ${entry.path}`, 'ARCHIVE_INTEGRITY_MISMATCH', { path: entry.path });
+    }
+  }
+}
+
+async function readZipFiles(absZip) {
+  if (!yauzl) {
+    throw new PublishError('Cannot validate governed archive: yauzl is unavailable', 'ARCHIVE_VALIDATION_UNAVAILABLE');
+  }
+  return new Promise((resolve, reject) => {
+    yauzl.open(absZip, { lazyEntries: true }, (openError, zipfile) => {
+      if (openError) return reject(openError);
+      const files = new Map();
+      const fail = (error) => {
+        try {
+          zipfile.close();
+        } catch {
+          // Best-effort cleanup only.
+        }
+        reject(error);
+      };
+      zipfile.readEntry();
+      zipfile.on('entry', (entry) => {
+        if (/\/$/.test(entry.fileName)) {
+          zipfile.readEntry();
+          return;
+        }
+        zipfile.openReadStream(entry, (streamError, stream) => {
+          if (streamError) return fail(streamError);
+          const chunks = [];
+          stream.on('data', (chunk) => chunks.push(chunk));
+          stream.on('error', fail);
+          stream.on('end', () => {
+            files.set(entry.fileName, Buffer.concat(chunks));
+            zipfile.readEntry();
+          });
+        });
+      });
+      zipfile.on('end', () => {
+        try {
+          zipfile.close();
+        } catch {
+          // Best-effort cleanup only.
+        }
+        resolve(files);
+      });
+      zipfile.on('error', fail);
+    });
+  });
 }
 
 function publishRelease({ repoRoot, tag, manifestAsset, zipAsset, readmeAsset, spawnSync = childProcess.spawnSync }) {
@@ -327,6 +402,14 @@ async function processAffectedCollection({ repoRoot, repoSlug, args, logger, aff
 
   logger.log(`Collection ${affectedCollection.id}: tag ${versionInfo.tag}`);
 
+  const manifestAsset = path.isAbsolute(bundle.manifestAsset)
+    ? bundle.manifestAsset
+    : path.join(repoRoot, bundle.manifestAsset);
+  const zipAsset = path.isAbsolute(bundle.zipAsset)
+    ? bundle.zipAsset
+    : path.join(repoRoot, bundle.zipAsset);
+  await validateGovernedReleaseAssets({ manifestAsset, zipAsset });
+
   publishRelease({
     repoRoot,
     tag: versionInfo.tag,
@@ -383,6 +466,7 @@ module.exports = {
   getAllCollectionFiles,
   listZipEntries,
   logDryRunSummary,
+  validateGovernedReleaseAssets,
   PublishError,
 };
 

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -41,6 +41,23 @@ export {
   resolveCollectionReadmePath,
 } from './collections';
 
+export {
+  createReleaseManifestPlan,
+  createLegacyReleaseManifestPlan,
+  isMissingSourceLicenseError,
+  LEGACY_RELEASE_WARNING,
+  NO_SOURCE_LICENSE_MESSAGE,
+  resolveGitRevision,
+  resolveSourceRepository,
+  serializeReleaseManifest,
+} from './release-manifest';
+export type {
+  CreateReleaseManifestPlanOptions,
+  ReleaseArchiveEntry,
+  ReleaseManifestFileRole,
+  ReleaseManifestPlan,
+} from './release-manifest';
+
 // Bundle ID exports
 export { generateBundleId } from './bundle-id';
 

--- a/lib/src/release-manifest.ts
+++ b/lib/src/release-manifest.ts
@@ -1,0 +1,629 @@
+/**
+ * Self-contained release manifest planning.
+ *
+ * This module deliberately has no dependency on the newer workspace packages:
+ * `@prompt-registry/collection-scripts` remains a Node 18-compatible published
+ * package and is used by both its own publisher and the migrated CLI.
+ * @module release-manifest
+ */
+import {
+  spawnSync,
+} from 'node:child_process';
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as yaml from 'js-yaml';
+import type {
+  Collection,
+  CollectionItem,
+} from './types';
+import {
+  normalizeRepoRelativePath,
+} from './validate';
+
+/** Canonical primitive values accepted by governed release manifests. */
+const PRIMITIVE_KINDS = new Set([
+  'prompt', 'instruction', 'chat-mode', 'agent', 'skill', 'plugin', 'hook',
+  'mcp-server', 'steering', 'spec', 'command', 'rule', 'output-style', 'tool',
+  'power', 'knowledge', 'playbook'
+]);
+
+/** Error message used when governed release evidence is incomplete. */
+export const NO_SOURCE_LICENSE_MESSAGE = 'No source license or notice file was found for the governed release';
+
+/** Warning shown when a legacy compatibility archive is produced. */
+export const LEGACY_RELEASE_WARNING = 'No committed LICENSE, COPYING, or NOTICE file was found; '
+  + 'building a legacy bundle without governed release evidence. '
+  + 'Add license text to enable governed self-contained releases.';
+
+/** File roles understood by the governed release contract. */
+export type ReleaseManifestFileRole = 'installable' | 'metadata' | 'ignored';
+
+/** Exact data written to one archive entry. */
+export interface ReleaseArchiveEntry {
+  path: string;
+  role: ReleaseManifestFileRole;
+  bytes: Buffer;
+}
+
+/** A planned governed manifest paired with the exact files it inventories. */
+export interface ReleaseManifestPlan {
+  manifest: Record<string, unknown>;
+  entries: ReleaseArchiveEntry[];
+  collectionPath: string;
+  readmeSourcePath?: string;
+}
+
+/** Inputs resolved by a command or publisher before planning a release. */
+export interface CreateReleaseManifestPlanOptions {
+  repoRoot: string;
+  collectionFile: string;
+  version: string;
+  source?: string;
+  revision?: string;
+  packageMetadata?: Record<string, unknown>;
+}
+
+interface GitSourceTree {
+  revision: string;
+  readFile: (repositoryPath: string) => Buffer;
+  listFiles: (repositoryDirectory: string) => string[];
+}
+
+interface PackageMetadata {
+  name?: string;
+  description?: string;
+  author?: string;
+  keywords?: string[];
+  license?: string;
+  repository?: string | { url?: string };
+}
+
+interface CollectionWithMcp extends Collection {
+  mcpServers?: Record<string, unknown>;
+  mcp?: { items?: Record<string, unknown>; inputs?: unknown[] };
+}
+
+interface LegacyCollection extends CollectionWithMcp {
+  license?: string;
+}
+
+/**
+ * Plan the canonical manifest and all non-manifest ZIP entries for one source
+ * collection. The returned inventory is based on exact bytes, so callers must
+ * write these bytes unchanged into the final archive.
+ * @param options
+ */
+export function createReleaseManifestPlan(
+  options: CreateReleaseManifestPlanOptions
+): ReleaseManifestPlan {
+  const collectionPath = resolveRepoRelativePath(options.repoRoot, options.collectionFile);
+  const sourceTree = createGitSourceTree(options.repoRoot, options.revision);
+  const collection = yaml.load(sourceTree.readFile(collectionPath).toString('utf8')) as CollectionWithMcp;
+  if (!collection || typeof collection !== 'object') {
+    throw new Error(`Invalid collection YAML: ${collectionPath}`);
+  }
+  if (typeof collection.id !== 'string' || collection.id.length === 0) {
+    throw new Error(`Collection id is required: ${collectionPath}`);
+  }
+  if (typeof collection.name !== 'string' || collection.name.length === 0) {
+    throw new Error(`Collection name is required: ${collectionPath}`);
+  }
+
+  const packageMetadata = (options.packageMetadata ?? readPackageMetadata(sourceTree)) as PackageMetadata;
+  const source = resolveSourceRepository(options.repoRoot, options.source ?? repositoryUrl(packageMetadata.repository));
+  const revision = sourceTree.revision;
+  const license = collectionLicense(collection, packageMetadata);
+  const items = Array.isArray(collection.items) ? collection.items : [];
+  const itemEntries = collectItemEntries(sourceTree, items);
+  const canonicalItems = items.map((item) => createCanonicalItem(sourceTree, item));
+  const legacyItems = canonicalItems.map((item) => createLegacyItem(item));
+
+  const sourceSnapshotPath = `metadata/source/${collectionPath}`;
+  const entries: ReleaseArchiveEntry[] = [
+    ...itemEntries,
+    {
+      path: sourceSnapshotPath,
+      role: 'metadata',
+      bytes: sourceTree.readFile(collectionPath)
+    }
+  ];
+
+  const readmeSourcePath = resolveCollectionReadmePath(collection);
+  let readmePath: string | undefined;
+  if (readmeSourcePath !== null) {
+    readmePath = 'README.md';
+    entries.push({ path: readmePath, role: 'metadata', bytes: sourceTree.readFile(readmeSourcePath) });
+  }
+
+  const licenseSourcePath = findLicensePath(sourceTree);
+  if (licenseSourcePath === null) {
+    throw new Error(NO_SOURCE_LICENSE_MESSAGE);
+  }
+  const licensePath = 'LICENSE';
+  entries.push({
+    path: licensePath,
+    role: 'metadata',
+    bytes: sourceTree.readFile(licenseSourcePath)
+  });
+
+  assertUniqueArchivePaths(entries);
+  assertUniqueCanonicalItems(canonicalItems);
+
+  const mcpServers = collection.mcpServers ?? collection.mcp?.items;
+  const mcpInputs = collection.mcp?.inputs;
+  const manifest = {
+    formatVersion: 1,
+    id: collection.id,
+    version: options.version,
+    name: collection.name || packageMetadata.description || '',
+    description: collection.description || packageMetadata.description || '',
+    author: collection.author || packageMetadata.author || 'Prompt Registry',
+    tags: collection.tags || packageMetadata.keywords || [],
+    environments: ['vscode', 'windsurf', 'cursor'],
+    ...(readmePath === undefined ? {} : { readme: readmePath }),
+    license,
+    repository: source,
+    items: canonicalItems,
+    files: sortByPath(entries.map((entry) => ({
+      path: entry.path,
+      role: entry.role,
+      size: entry.bytes.byteLength,
+      sha256: sha256(entry.bytes)
+    }))),
+    provenance: {
+      source,
+      revision,
+      collectionPath,
+      sourceSnapshotPath,
+      license,
+      licensePath
+    },
+    prompts: legacyItems,
+    dependencies: [],
+    ...(mcpServers && Object.keys(mcpServers).length > 0 ? { mcpServers } : {}),
+    ...(mcpInputs && mcpInputs.length > 0 ? { mcpInputs } : {})
+  };
+
+  return {
+    manifest,
+    entries: sortByPath(entries),
+    collectionPath,
+    ...(readmeSourcePath === null ? {} : { readmeSourcePath })
+  };
+}
+
+/**
+ * Plan the pre-formatVersion archive used for legacy compatibility builds.
+ *
+ * This deliberately reads the working tree and emits the historical manifest
+ * shape. It must only be used after governed planning reports missing license
+ * evidence; it is not a relaxed governed-release planner.
+ * @param options
+ */
+export function createLegacyReleaseManifestPlan(
+  options: CreateReleaseManifestPlanOptions
+): ReleaseManifestPlan {
+  const collectionPath = resolveRepoRelativePath(options.repoRoot, options.collectionFile);
+  const collectionBytes = readWorkingTreeFile(options.repoRoot, collectionPath);
+  const collection = yaml.load(collectionBytes.toString('utf8')) as LegacyCollection;
+  if (!collection || typeof collection !== 'object') {
+    throw new Error(`Invalid collection YAML: ${collectionPath}`);
+  }
+  if (typeof collection.id !== 'string' || collection.id.length === 0) {
+    throw new Error(`Collection id is required: ${collectionPath}`);
+  }
+  if (typeof collection.name !== 'string' || collection.name.length === 0) {
+    throw new Error(`Collection name is required: ${collectionPath}`);
+  }
+
+  const packageMetadata = (options.packageMetadata ?? readWorkingTreePackageMetadata(options.repoRoot)) as PackageMetadata;
+  const items = Array.isArray(collection.items) ? collection.items : [];
+  const prompts: Record<string, unknown>[] = [];
+  const entriesByPath = new Map<string, ReleaseArchiveEntry>();
+
+  for (const item of items) {
+    const itemPath = normalizeRepoRelativePath(item.path);
+    const itemBytes = readWorkingTreeFile(options.repoRoot, itemPath);
+    prompts.push(createLegacyManifestItem(item, itemPath, itemBytes.toString('utf8')));
+
+    for (const entryPath of resolveLegacyItemPaths(options.repoRoot, itemPath, item.kind)) {
+      if (!entriesByPath.has(entryPath)) {
+        entriesByPath.set(entryPath, {
+          path: entryPath,
+          role: 'installable',
+          bytes: readWorkingTreeFile(options.repoRoot, entryPath)
+        });
+      }
+    }
+  }
+
+  const entries = sortByPath([...entriesByPath.values()]);
+  assertUniqueArchivePaths(entries);
+
+  const readmeSourcePath = resolveCollectionReadmePath(collection);
+  const mcpServers = collection.mcpServers ?? collection.mcp?.items;
+  const mcpInputs = collection.mcp?.inputs;
+  const repository = normalizeRepositoryUrl(repositoryUrl(packageMetadata.repository));
+  const manifest = {
+    id: collection.id,
+    version: options.version,
+    name: collection.name || packageMetadata.description || '',
+    description: collection.description || packageMetadata.description || '',
+    author: collection.author || packageMetadata.author || 'Prompt Registry',
+    tags: collection.tags || packageMetadata.keywords || [],
+    environments: ['vscode', 'windsurf', 'cursor'],
+    license: collection.license || packageMetadata.license || 'MIT',
+    repository,
+    prompts,
+    dependencies: [],
+    ...(readmeSourcePath === null ? {} : { readme: path.basename(readmeSourcePath) }),
+    ...(mcpServers && Object.keys(mcpServers).length > 0 ? { mcpServers } : {}),
+    ...(mcpInputs && mcpInputs.length > 0 ? { mcpInputs } : {})
+  };
+
+  return {
+    manifest,
+    entries,
+    collectionPath,
+    ...(readmeSourcePath === null ? {} : { readmeSourcePath })
+  };
+}
+
+/**
+ * Identify the one governed-planning failure that permits legacy fallback.
+ * All other planning failures remain blocking.
+ * @param error
+ */
+export const isMissingSourceLicenseError = (error: unknown): boolean =>
+  error instanceof Error && error.message === NO_SOURCE_LICENSE_MESSAGE;
+
+/**
+ * Serialize a planned manifest with the repository's stable YAML settings.
+ * @param manifest
+ */
+export function serializeReleaseManifest(manifest: Record<string, unknown>): string {
+  return yaml.dump(manifest, { lineWidth: -1 });
+}
+
+/**
+ * Resolve an immutable source revision, requiring Git rather than a mutable ref.
+ * @param repoRoot
+ */
+export function resolveGitRevision(repoRoot: string): string {
+  return createGitSourceTree(repoRoot).revision;
+}
+
+/**
+ * Resolve a stable source URL from explicit metadata or Git remote origin.
+ * @param repoRoot
+ * @param preferredSource
+ */
+export function resolveSourceRepository(repoRoot: string, preferredSource?: string): string {
+  const candidate = preferredSource || readGitRemoteUrl(repoRoot);
+  const source = normalizeRepositoryUrl(candidate);
+  if (!source) {
+    throw new Error('Unable to resolve a source repository URL from package metadata or git remote origin');
+  }
+  return source;
+}
+
+const createGitSourceTree = (repoRoot: string, requestedRevision?: string): GitSourceTree => {
+  const revision = resolveGitCommit(repoRoot, requestedRevision ?? 'HEAD');
+  return {
+    revision,
+    readFile: (repositoryPath) => readGitBlob(repoRoot, revision, repositoryPath),
+    listFiles: (repositoryDirectory) => listGitTreeFiles(repoRoot, revision, repositoryDirectory)
+  };
+};
+
+const resolveGitCommit = (repoRoot: string, revision: string): string => {
+  const result = runGit(repoRoot, ['rev-parse', '--verify', `${revision}^{commit}`]);
+  return assertImmutableRevision(result.trim());
+};
+
+const runGit = (repoRoot: string, args: string[]): string => {
+  const result = spawnSync('git', args, { cwd: repoRoot, encoding: 'buffer' });
+  if (result.status !== 0) {
+    const stderr = Buffer.isBuffer(result.stderr) ? result.stderr.toString('utf8').trim() : '';
+    throw new Error(`Git command failed: git ${args.join(' ')}${stderr ? `: ${stderr}` : ''}`);
+  }
+  return Buffer.isBuffer(result.stdout) ? result.stdout.toString('utf8') : '';
+};
+
+const readGitBlob = (repoRoot: string, revision: string, repositoryPath: string): Buffer => {
+  const normalizedPath = normalizeRepoRelativePath(repositoryPath);
+  const result = spawnSync('git', ['show', `${revision}:${normalizedPath}`], {
+    cwd: repoRoot,
+    encoding: 'buffer'
+  });
+  if (result.status !== 0 || !Buffer.isBuffer(result.stdout)) {
+    const stderr = Buffer.isBuffer(result.stderr) ? result.stderr.toString('utf8').trim() : '';
+    throw new Error(`Source file is not present at revision ${revision}: ${normalizedPath}${stderr ? ` (${stderr})` : ''}`);
+  }
+  return result.stdout;
+};
+
+const listGitTreeFiles = (repoRoot: string, revision: string, repositoryDirectory: string): string[] => {
+  const normalizedDirectory = normalizeRepoRelativePath(repositoryDirectory);
+  const output = normalizedDirectory === '.'
+    ? runGit(repoRoot, ['ls-tree', '-r', '--name-only', revision])
+    : runGit(repoRoot, ['ls-tree', '-r', '--name-only', revision, '--', normalizedDirectory]);
+  return output
+    .split('\n')
+    .filter((entry): entry is string => entry.length > 0)
+    .map((entry) => normalizeRepoRelativePath(entry))
+    .filter((entry) => normalizedDirectory === '.' || entry === normalizedDirectory || entry.startsWith(`${normalizedDirectory}/`));
+};
+
+const collectItemEntries = (sourceTree: GitSourceTree, items: CollectionItem[]): ReleaseArchiveEntry[] => {
+  const entries = new Map<string, ReleaseArchiveEntry>();
+  for (const item of items) {
+    const itemPath = normalizeRepoRelativePath(item.path);
+    const paths = item.kind === 'skill' || item.kind === 'plugin'
+      ? listInstallableSkillFiles(sourceTree, path.posix.dirname(itemPath))
+      : [itemPath];
+    for (const entryPath of paths) {
+      if (!entries.has(entryPath)) {
+        entries.set(entryPath, {
+          path: entryPath,
+          role: 'installable',
+          bytes: sourceTree.readFile(entryPath)
+        });
+      }
+    }
+  }
+  return [...entries.values()];
+};
+
+const listInstallableSkillFiles = (sourceTree: GitSourceTree, directory: string): string[] =>
+  sortStrings(sourceTree.listFiles(directory).filter((entry) => !isIgnoredPath(entry)));
+
+const isIgnoredPath = (entry: string): boolean => {
+  const segments = entry.split('/');
+  const fileName = segments.at(-1) ?? '';
+  return segments.includes('__pycache__')
+    || segments.includes('.git')
+    || segments.includes('node_modules')
+    || fileName === '.DS_Store'
+    || fileName.endsWith('.pyc')
+    || fileName.endsWith('.pyo');
+};
+
+const itemTags = (item: CollectionItem): string[] | undefined =>
+  Array.isArray(item.tags) && item.tags.length > 0 ? [...item.tags] : undefined;
+
+const createCanonicalItem = (
+  sourceTree: GitSourceTree,
+  item: CollectionItem
+): Record<string, unknown> => {
+  const itemPath = normalizeRepoRelativePath(item.path);
+  const kind = normalizeKind(item.kind);
+  const content = sourceTree.readFile(itemPath).toString('utf8');
+  const metadata = extractItemMetadata(content, itemPath);
+  const id = generateItemId(itemPath, kind);
+  const tags = itemTags(item);
+  return {
+    id,
+    path: itemPath,
+    kind,
+    name: metadata.name || id,
+    description: metadata.description,
+    ...(tags === undefined ? {} : { tags })
+  };
+};
+
+const createLegacyItem = (canonical: Record<string, unknown>): Record<string, unknown> => {
+  return {
+    id: canonical.id,
+    name: canonical.name,
+    description: canonical.description,
+    file: canonical.path,
+    type: legacyType(String(canonical.kind)),
+    ...(canonical.tags === undefined ? {} : { tags: canonical.tags })
+  };
+};
+
+const extractItemMetadata = (content: string, itemPath: string): { name: string; description: string } => {
+  if (itemPath.endsWith('.json')) {
+    try {
+      const parsed = JSON.parse(content) as Record<string, unknown>;
+      return {
+        name: typeof parsed.name === 'string' ? parsed.name : '',
+        description: typeof parsed.description === 'string' ? parsed.description : ''
+      };
+    } catch {
+      return { name: '', description: '' };
+    }
+  }
+  const nameMatch = /^#\s+(.+)$/m.exec(content);
+  const descriptionMatch = /^##?\s*Description[:\s]+(.+)$/im.exec(content)
+    ?? /^>\s*(.+)$/m.exec(content);
+  return {
+    name: nameMatch?.[1] ?? '',
+    description: descriptionMatch?.[1] ?? ''
+  };
+};
+
+const normalizeKind = (value: string): string => {
+  const aliases: Record<string, string> = {
+    prompts: 'prompt',
+    instructions: 'instruction',
+    chatmode: 'chat-mode',
+    'chat-modes': 'chat-mode',
+    agents: 'agent',
+    skills: 'skill',
+    plugins: 'plugin',
+    hooks: 'hook',
+    mcp: 'mcp-server',
+    specs: 'spec',
+    commands: 'command',
+    rules: 'rule',
+    'output-styles': 'output-style',
+    tools: 'tool',
+    powers: 'power',
+    playbooks: 'playbook'
+  };
+  const kind = aliases[value.trim().toLowerCase()] ?? value.trim().toLowerCase();
+  if (!PRIMITIVE_KINDS.has(kind)) {
+    throw new Error(`Collection item kind is not a canonical primitive kind: ${value}`);
+  }
+  return kind;
+};
+
+const legacyType = (kind: string): string => ({
+  instruction: 'instructions',
+  'chat-mode': 'chatmode'
+})[kind] ?? kind;
+
+const generateItemId = (itemPath: string, kind: string): string => {
+  const extension = path.extname(itemPath);
+  if (kind === 'skill' || kind === 'plugin') {
+    const parts = itemPath.split('/');
+    return parts.length >= 2 ? (parts.at(-2) ?? path.basename(itemPath, extension)) : path.basename(itemPath, extension);
+  }
+  return path.basename(itemPath, extension);
+};
+
+const resolveCollectionReadmePath = (collection: Collection): string | null =>
+  collection.readme?.path ? normalizeRepoRelativePath(collection.readme.path) : null;
+
+const resolveRepoRelativePath = (repoRoot: string, candidate: string): string => {
+  const relative = path.isAbsolute(candidate) ? path.relative(repoRoot, candidate) : candidate;
+  return normalizeRepoRelativePath(relative);
+};
+
+const readPackageMetadata = (sourceTree: GitSourceTree): Record<string, unknown> => {
+  try {
+    return JSON.parse(sourceTree.readFile('package.json').toString('utf8')) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+};
+
+const readWorkingTreePackageMetadata = (repoRoot: string): Record<string, unknown> => {
+  try {
+    return JSON.parse(readWorkingTreeFile(repoRoot, 'package.json').toString('utf8')) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+};
+
+const readWorkingTreeFile = (repoRoot: string, repositoryPath: string): Buffer => {
+  const normalizedPath = normalizeRepoRelativePath(repositoryPath);
+  return fs.readFileSync(path.join(repoRoot, normalizedPath));
+};
+
+const resolveLegacyItemPaths = (repoRoot: string, itemPath: string, kind: string): string[] => {
+  if (kind !== 'skill' && kind !== 'plugin') {
+    return [itemPath];
+  }
+
+  const itemDirectory = path.dirname(path.join(repoRoot, itemPath));
+  if (!fs.existsSync(itemDirectory) || !fs.statSync(itemDirectory).isDirectory()) {
+    return [itemPath];
+  }
+
+  return sortStrings(listWorkingTreeFiles(itemDirectory, repoRoot).filter((entry) => !isIgnoredPath(entry)));
+};
+
+const listWorkingTreeFiles = (directory: string, repoRoot: string): string[] => {
+  const files: string[] = [];
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...listWorkingTreeFiles(fullPath, repoRoot));
+    } else if (entry.isFile()) {
+      files.push(normalizeRepoRelativePath(path.relative(repoRoot, fullPath)));
+    }
+  }
+  return files;
+};
+
+const createLegacyManifestItem = (
+  item: CollectionItem,
+  itemPath: string,
+  content: string
+): Record<string, unknown> => {
+  const metadata = extractItemMetadata(content, itemPath);
+  const kind = item.kind.trim().toLowerCase();
+  const id = generateItemId(itemPath, kind);
+  const tags = itemTags(item);
+  return {
+    id,
+    name: metadata.name || id,
+    description: metadata.description,
+    file: itemPath,
+    type: legacyType(kind),
+    ...(tags === undefined ? {} : { tags })
+  };
+};
+
+const repositoryUrl = (repository: PackageMetadata['repository']): string =>
+  typeof repository === 'string' ? repository : repository?.url ?? '';
+
+const normalizeRepositoryUrl = (value: string): string =>
+  value.replace(/^git\+/, '').replace(/\.git$/, '');
+
+const readGitRemoteUrl = (repoRoot: string): string => {
+  const result = spawnSync('git', ['remote', 'get-url', 'origin'], { cwd: repoRoot, encoding: 'utf8' });
+  return result.status === 0 ? result.stdout.trim() : '';
+};
+
+const assertImmutableRevision = (revision: string): string => {
+  if (!/^[a-f0-9]{40,64}$/i.test(revision)) {
+    throw new Error(`Source revision must be a full immutable Git object ID, got "${revision}"`);
+  }
+  return revision.toLowerCase();
+};
+
+const collectionLicense = (collection: Collection, packageMetadata: PackageMetadata): string =>
+  packageMetadata.license || 'SEE LICENSE IN LICENSE';
+
+const findLicensePath = (sourceTree: GitSourceTree): string | null => {
+  const candidate = sourceTree.listFiles('.')
+    .filter((entry) => !entry.includes('/'))
+    .find((name) => /^(license|copying|notice)(\.[^.]*)?$/i.test(name));
+  return candidate ?? null;
+};
+
+const sha256 = (content: Buffer): string =>
+  `sha256:${crypto.createHash('sha256').update(content).digest('hex')}`;
+
+const sortByPath = <T extends { path: string }>(values: readonly T[]): T[] =>
+  // eslint-disable-next-line unicorn/no-array-sort -- Node 18 does not provide Array.prototype.toSorted.
+  [...values].sort((left, right) => comparePaths(left.path, right.path));
+
+const sortStrings = (values: readonly string[]): string[] =>
+  // eslint-disable-next-line unicorn/no-array-sort -- Node 18 does not provide Array.prototype.toSorted.
+  [...values].sort(comparePaths);
+
+const comparePaths = (left: string, right: string): number =>
+  left < right ? -1 : (left > right ? 1 : 0);
+
+const assertUniqueArchivePaths = (entries: ReleaseArchiveEntry[]): void => {
+  const seen = new Set<string>();
+  for (const entry of entries) {
+    if (seen.has(entry.path)) {
+      throw new Error(`Release archive contains duplicate path: ${entry.path}`);
+    }
+    seen.add(entry.path);
+  }
+};
+
+const assertUniqueCanonicalItems = (items: Record<string, unknown>[]): void => {
+  const ids = new Set<string>();
+  const paths = new Set<string>();
+  for (const item of items) {
+    const id = String(item.id);
+    const itemPath = String(item.path);
+    if (ids.has(id)) {
+      throw new Error(`Release manifest contains duplicate item id: ${id}`);
+    }
+    if (paths.has(itemPath)) {
+      throw new Error(`Release manifest contains duplicate item path: ${itemPath}`);
+    }
+    ids.add(id);
+    paths.add(itemPath);
+  }
+};

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -31,6 +31,7 @@ export interface CollectionItem {
   kind: string;
   name?: string;
   description?: string;
+  tags?: string[];
 }
 
 export interface Collection {

--- a/lib/src/validate.ts
+++ b/lib/src/validate.ts
@@ -25,19 +25,44 @@ import type {
  * @returns Array of valid item kinds
  */
 export function loadItemKindsFromSchema(schemaDir?: string): string[] {
-  try {
-    const schemaPath = schemaDir
-      ? path.join(schemaDir, 'collection.schema.json')
-      : path.join(__dirname, '..', '..', 'schemas', 'collection.schema.json');
-    const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
-    const kinds = schema?.properties?.items?.items?.properties?.kind?.enum;
-    if (Array.isArray(kinds) && kinds.length > 0) {
-      return kinds;
+  const schemaPaths = schemaDir === undefined
+    ? [
+      path.join(__dirname, '..', '..', 'schemas', 'collection.schema.json'),
+      path.join(__dirname, '..', '..', '..', 'schemas', 'collection.schema.json')
+    ]
+    : [path.join(schemaDir, 'collection.schema.json')];
+  for (const schemaPath of schemaPaths) {
+    try {
+      const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+      const kinds = schema?.properties?.items?.items?.properties?.kind?.enum;
+      if (Array.isArray(kinds) && kinds.length > 0) {
+        return kinds;
+      }
+    } catch {
+      // Try the next candidate path before using the resilience fallback.
     }
-  } catch {
-    // Schema unavailable or malformed, use fallback
   }
-  return ['prompt', 'instruction', 'agent', 'skill'];
+
+  // Schema unavailable or malformed, use fallback.
+  return [
+    'prompt',
+    'instruction',
+    'chat-mode',
+    'agent',
+    'skill',
+    'plugin',
+    'hook',
+    'mcp-server',
+    'steering',
+    'spec',
+    'command',
+    'rule',
+    'output-style',
+    'tool',
+    'power',
+    'knowledge',
+    'playbook'
+  ];
 }
 
 /**
@@ -58,8 +83,7 @@ export const VALIDATION_RULES: ValidationRules = {
   },
   itemKinds: loadItemKindsFromSchema(),
   deprecatedKinds: {
-    chatmode: 'agent',
-    'chat-mode': 'agent'
+    chatmode: 'agent'
   }
 };
 

--- a/lib/test/publish-collections.test.ts
+++ b/lib/test/publish-collections.test.ts
@@ -5,9 +5,11 @@
  * These tests cover the critical CI/CD workflow functionality.
  */
 import * as assert from 'node:assert';
+import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import * as yaml from 'js-yaml';
 
 // Import the publish-collections module - use require for CommonJS
 // When compiled to dist-test/test/, need to resolve back to lib/bin/
@@ -174,6 +176,128 @@ describe('Publish Collections CLI', () => {
     });
   });
 
+  describe('validateGovernedReleaseAssets()', () => {
+    const { validateGovernedReleaseAssets, PublishError } = publishModule;
+    let tempDir: string;
+
+    beforeEach(() => {
+      tempDir = createTempDir('governed-release-validation-');
+    });
+
+    afterEach(() => {
+      cleanup(tempDir);
+    });
+
+    it('accepts an exact standalone manifest and complete archive inventory', async () => {
+      const prompt = Buffer.from('# Hello\n');
+      const manifest = {
+        formatVersion: 1,
+        files: [{
+          path: 'prompts/hello.md',
+          role: 'installable',
+          size: prompt.byteLength,
+          sha256: `sha256:${crypto.createHash('sha256').update(prompt).digest('hex')}`
+        }],
+        provenance: { source: 'https://example.test/repo', revision: 'a'.repeat(40) }
+      };
+      const manifestPath = path.join(tempDir, 'deployment-manifest.yml');
+      const manifestText = yaml.dump(manifest, { lineWidth: -1 });
+      fs.writeFileSync(manifestPath, manifestText);
+
+      await assert.doesNotReject(validateGovernedReleaseAssets({
+        manifestAsset: manifestPath,
+        zipAsset: path.join(tempDir, 'bundle.zip'),
+        readArchive: async () => new Map([
+          ['deployment-manifest.yml', Buffer.from(manifestText)],
+          ['prompts/hello.md', prompt]
+        ])
+      }));
+    });
+
+    it('rejects an archive integrity mismatch before publication', async () => {
+      const manifest = {
+        formatVersion: 1,
+        files: [{ path: 'prompts/hello.md', role: 'installable', size: 1, sha256: `sha256:${'0'.repeat(64)}` }],
+        provenance: { source: 'https://example.test/repo', revision: 'a'.repeat(40) }
+      };
+      const manifestPath = path.join(tempDir, 'deployment-manifest.yml');
+      const manifestText = yaml.dump(manifest, { lineWidth: -1 });
+      fs.writeFileSync(manifestPath, manifestText);
+
+      await assert.rejects(
+        validateGovernedReleaseAssets({
+          manifestAsset: manifestPath,
+          zipAsset: path.join(tempDir, 'bundle.zip'),
+          readArchive: async () => new Map([
+            ['deployment-manifest.yml', Buffer.from(manifestText)],
+            ['prompts/hello.md', Buffer.from('bad')]
+          ])
+        }),
+        (error: unknown) => {
+          if (!(error instanceof PublishError)) {
+            return false;
+          }
+          return (error as { code?: string }).code === 'ARCHIVE_INTEGRITY_MISMATCH';
+        }
+      );
+    });
+
+    it('rejects archive content that is not declared by the inventory', async () => {
+      const prompt = Buffer.from('# Hello\n');
+      const manifest = {
+        formatVersion: 1,
+        files: [{
+          path: 'prompts/hello.md',
+          role: 'installable',
+          size: prompt.byteLength,
+          sha256: `sha256:${crypto.createHash('sha256').update(prompt).digest('hex')}`
+        }],
+        provenance: { source: 'https://example.test/repo', revision: 'a'.repeat(40) }
+      };
+      const manifestPath = path.join(tempDir, 'deployment-manifest.yml');
+      const manifestText = yaml.dump(manifest, { lineWidth: -1 });
+      fs.writeFileSync(manifestPath, manifestText);
+
+      await assert.rejects(
+        validateGovernedReleaseAssets({
+          manifestAsset: manifestPath,
+          zipAsset: path.join(tempDir, 'bundle.zip'),
+          readArchive: async () => new Map([
+            ['deployment-manifest.yml', Buffer.from(manifestText)],
+            ['prompts/hello.md', prompt],
+            ['metadata/untracked.txt', Buffer.from('not declared')]
+          ])
+        }),
+        (error: unknown) => error instanceof PublishError
+          && (error as { code?: string }).code === 'INCOMPLETE_ARCHIVE_INVENTORY'
+      );
+    });
+
+    it('rejects a historical legacy manifest at the governed publication gate', async () => {
+      const manifestText = yaml.dump({
+        id: 'legacy-bundle',
+        version: '1.0.0',
+        name: 'Legacy Bundle',
+        prompts: [{ id: 'hello', file: 'prompts/hello.md', type: 'prompt' }]
+      });
+      const manifestPath = path.join(tempDir, 'deployment-manifest.yml');
+      fs.writeFileSync(manifestPath, manifestText);
+
+      await assert.rejects(
+        validateGovernedReleaseAssets({
+          manifestAsset: manifestPath,
+          zipAsset: path.join(tempDir, 'bundle.zip'),
+          readArchive: async () => new Map([
+            ['deployment-manifest.yml', Buffer.from(manifestText)],
+            ['prompts/hello.md', Buffer.from('# Hello\n')]
+          ])
+        }),
+        (error: unknown) => error instanceof PublishError
+          && (error as { code?: string }).code === 'INVALID_RELEASE_MANIFEST'
+      );
+    });
+  });
+
   describe('getAllCollectionFiles()', () => {
     const { getAllCollectionFiles } = publishModule;
     let tempDir: string;
@@ -244,6 +368,7 @@ items:
     kind: prompt
 `);
       writeFile(tempDir, 'prompts/test.md', '# Test Prompt');
+      writeFile(tempDir, 'LICENSE', 'Test fixture license\n');
 
       const { spawnSync } = require('node:child_process');
       spawnSync('git', ['init'], { cwd: tempDir });

--- a/lib/test/release-manifest.test.ts
+++ b/lib/test/release-manifest.test.ts
@@ -1,0 +1,204 @@
+import * as assert from 'node:assert';
+import {
+  spawnSync,
+} from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  createLegacyReleaseManifestPlan,
+  createReleaseManifestPlan,
+} from '../src/release-manifest';
+
+const createTempDir = (prefix: string): string => fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+
+const writeFile = (root: string, relativePath: string, content: string): void => {
+  const fullPath = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, content);
+};
+
+const runGit = (root: string, args: string[]): string => {
+  const result = spawnSync('git', args, { cwd: root, encoding: 'utf8' });
+  assert.strictEqual(result.status, 0, result.stderr);
+  return result.stdout.trim();
+};
+
+const commitFixture = (root: string): string => {
+  runGit(root, ['init']);
+  runGit(root, ['config', 'user.email', 'test@example.com']);
+  runGit(root, ['config', 'user.name', 'Release Manifest Test']);
+  runGit(root, ['remote', 'add', 'origin', 'https://github.com/example/example.git']);
+  runGit(root, ['add', '.']);
+  runGit(root, ['commit', '-m', 'Fixture']);
+  return runGit(root, ['rev-parse', 'HEAD']);
+};
+
+describe('createReleaseManifestPlan()', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir('release-manifest-test-');
+    writeFile(tempDir, 'LICENSE', 'Example license\n');
+    writeFile(tempDir, 'README.md', '# Collection overview\n');
+    writeFile(tempDir, 'prompts/hello.prompt.md', '# Hello\n');
+    writeFile(tempDir, 'skills/example/SKILL.md', '# Example skill\n');
+    writeFile(tempDir, 'skills/example/references/reference.md', '# Reference\n');
+    writeFile(tempDir, 'skills/example/__pycache__/ignored.pyc', 'cache');
+    writeFile(tempDir, 'collections/example.collection.yml', `id: example
+name: Example
+readme:
+  path: README.md
+items:
+  - path: prompts/hello.prompt.md
+    kind: prompt
+  - path: skills/example/SKILL.md
+    kind: skill
+`);
+    commitFixture(tempDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('creates a canonical manifest with an integrity inventory over archive bytes', () => {
+    const revision = runGit(tempDir, ['rev-parse', 'HEAD']);
+    const plan = createReleaseManifestPlan({
+      repoRoot: tempDir,
+      collectionFile: 'collections/example.collection.yml',
+      version: '1.2.3',
+      source: 'https://github.com/example/example.git',
+      revision,
+      packageMetadata: { license: 'Example-License' }
+    });
+
+    const manifest = plan.manifest as {
+      formatVersion: number;
+      items: { path: string; kind: string }[];
+      files: { path: string; role: string; size: number; sha256: string }[];
+      provenance: { source: string; revision: string; sourceSnapshotPath: string; licensePath: string };
+    };
+
+    assert.strictEqual(manifest.formatVersion, 1);
+    assert.deepStrictEqual(manifest.items.map((item) => item.kind), ['prompt', 'skill']);
+    assert.deepStrictEqual(plan.entries.map((entry) => entry.path), [
+      'LICENSE',
+      'README.md',
+      'metadata/source/collections/example.collection.yml',
+      'prompts/hello.prompt.md',
+      'skills/example/SKILL.md',
+      'skills/example/references/reference.md'
+    ]);
+    assert.ok(!plan.entries.some((entry) => entry.path.includes('__pycache__')));
+    assert.strictEqual(manifest.provenance.source, 'https://github.com/example/example');
+    assert.strictEqual(manifest.provenance.revision, revision);
+    assert.strictEqual(manifest.provenance.sourceSnapshotPath, 'metadata/source/collections/example.collection.yml');
+    assert.strictEqual(manifest.provenance.licensePath, 'LICENSE');
+    assert.ok(manifest.files.every((file) => /^sha256:[a-f0-9]{64}$/.test(file.sha256)));
+    assert.ok(manifest.files.some((file) => file.path === 'README.md' && file.role === 'metadata'));
+    assert.ok(manifest.files.some((file) => file.path === 'skills/example/references/reference.md' && file.role === 'installable'));
+  });
+
+  it('keeps collection tags at the root and does not clone them onto items', () => {
+    writeFile(tempDir, 'collections/example.collection.yml', `id: example
+name: Example
+tags: [argos, splunk]
+readme:
+  path: README.md
+items:
+  - path: prompts/hello.prompt.md
+    kind: prompt
+  - path: skills/example/SKILL.md
+    kind: skill
+    tags: [orchestration]
+`);
+    runGit(tempDir, ['add', 'collections/example.collection.yml']);
+    runGit(tempDir, ['commit', '-m', 'Add collection tags']);
+
+    const revision = runGit(tempDir, ['rev-parse', 'HEAD']);
+    const plan = createReleaseManifestPlan({
+      repoRoot: tempDir,
+      collectionFile: 'collections/example.collection.yml',
+      version: '1.2.3',
+      source: 'https://github.com/example/example.git',
+      revision,
+      packageMetadata: { license: 'Example-License' }
+    });
+    const manifest = plan.manifest as {
+      tags?: string[];
+      items: { path: string; tags?: string[] }[];
+    };
+
+    assert.deepStrictEqual(manifest.tags, ['argos', 'splunk']);
+    const prompt = manifest.items.find((item) => item.path === 'prompts/hello.prompt.md');
+    const skill = manifest.items.find((item) => item.path === 'skills/example/SKILL.md');
+    assert.strictEqual(prompt?.tags, undefined);
+    assert.deepStrictEqual(skill?.tags, ['orchestration']);
+
+    const legacy = createLegacyReleaseManifestPlan({
+      repoRoot: tempDir,
+      collectionFile: 'collections/example.collection.yml',
+      version: '1.2.3'
+    }).manifest as {
+      tags?: string[];
+      prompts: { file: string; tags?: string[] }[];
+    };
+    assert.deepStrictEqual(legacy.tags, ['argos', 'splunk']);
+    assert.strictEqual(legacy.prompts.find((item) => item.file === 'prompts/hello.prompt.md')?.tags, undefined);
+    assert.deepStrictEqual(legacy.prompts.find((item) => item.file === 'skills/example/SKILL.md')?.tags, ['orchestration']);
+  });
+
+  it('uses exact committed source bytes instead of later working-tree changes', () => {
+    const revision = runGit(tempDir, ['rev-parse', 'HEAD']);
+    writeFile(tempDir, 'prompts/hello.prompt.md', '# Changed only in the worktree\n');
+    writeFile(tempDir, 'collections/example.collection.yml', 'id: changed\nname: Changed\nitems: []\n');
+
+    const plan = createReleaseManifestPlan({
+      repoRoot: tempDir,
+      collectionFile: 'collections/example.collection.yml',
+      version: '1.2.3',
+      source: 'https://github.com/example/example.git',
+      revision,
+      packageMetadata: { license: 'Example-License' }
+    });
+    const manifest = plan.manifest as {
+      id: string;
+      provenance: { revision: string };
+    };
+    const prompt = plan.entries.find((entry) => entry.path === 'prompts/hello.prompt.md');
+    const snapshot = plan.entries.find((entry) => entry.path === 'metadata/source/collections/example.collection.yml');
+
+    assert.strictEqual(manifest.id, 'example');
+    assert.strictEqual(manifest.provenance.revision, revision);
+    assert.strictEqual(prompt?.bytes.toString('utf8'), '# Hello\n');
+    assert.ok(snapshot?.bytes.toString('utf8').includes('id: example'));
+  });
+
+  it('plans a legacy archive without fabricating governed license evidence', () => {
+    fs.rmSync(path.join(tempDir, 'LICENSE'));
+
+    const plan = createLegacyReleaseManifestPlan({
+      repoRoot: tempDir,
+      collectionFile: 'collections/example.collection.yml',
+      version: '1.2.3'
+    });
+    const manifest = plan.manifest as Record<string, unknown> & {
+      prompts: { file: string }[];
+    };
+
+    assert.strictEqual(manifest.formatVersion, undefined);
+    assert.strictEqual(manifest.files, undefined);
+    assert.strictEqual(manifest.provenance, undefined);
+    assert.strictEqual(manifest.license, 'MIT');
+    assert.deepStrictEqual(plan.entries.map((entry) => entry.path), [
+      'prompts/hello.prompt.md',
+      'skills/example/SKILL.md',
+      'skills/example/references/reference.md'
+    ]);
+    assert.deepStrictEqual(manifest.prompts.map((item) => item.file), [
+      'prompts/hello.prompt.md',
+      'skills/example/SKILL.md'
+    ]);
+  });
+});

--- a/lib/test/validate.test.ts
+++ b/lib/test/validate.test.ts
@@ -137,10 +137,9 @@ describe('Validation Module', () => {
       assert.strictEqual(result.replacement, 'agent');
     });
 
-    it('should reject deprecated chat-mode', () => {
+    it('should accept canonical chat-mode', () => {
       const result = validateItemKind('chat-mode');
-      assert.strictEqual(result.valid, false);
-      assert.strictEqual(result.deprecated, true);
+      assert.strictEqual(result.valid, true);
     });
 
     it('should reject invalid kind', () => {

--- a/packages/app/src/install/index.ts
+++ b/packages/app/src/install/index.ts
@@ -26,6 +26,11 @@ export {
   InstallPipelineError,
 } from './pipeline';
 
+export {
+  TargetWriteRejectedError,
+  writeTargetSafely,
+} from './target-write';
+
 export type {
   InstallOutcome,
   InstallPipelineOptions,

--- a/packages/app/src/install/pipeline.ts
+++ b/packages/app/src/install/pipeline.ts
@@ -21,6 +21,7 @@ import {
   type BundleExtractor,
   type BundleResolver,
   type BundleSpec,
+  getInstallableBundleFiles,
   type Installable,
   type Target,
   type ValidatedManifest,
@@ -30,6 +31,10 @@ import type {
   TargetWriter,
   TargetWriteResult,
 } from '../writers/file-tree-writer';
+import {
+  TargetWriteRejectedError,
+  writeTargetSafely,
+} from './target-write';
 
 /**
  * Pipeline events emitted during install.
@@ -176,11 +181,15 @@ export class InstallPipeline {
     let writeResult;
     try {
       const writer = this.opts.writerFactory(target);
-      writeResult = await writer.write(target, files);
+      const targetFiles = getInstallableBundleFiles(files, manifest);
+      writeResult = await writeTargetSafely(writer, target, targetFiles);
     } catch (writeError) {
+      const code = writeError instanceof TargetWriteRejectedError
+        ? writeError.code
+        : 'FS.WRITE_FAILED';
       throw new InstallPipelineError(
         `write failed: ${(writeError as Error).message}`,
-        'FS.WRITE_FAILED',
+        code,
         'write'
       );
     }

--- a/packages/app/src/install/target-write.ts
+++ b/packages/app/src/install/target-write.ts
@@ -1,0 +1,61 @@
+/**
+ * Safe target-write orchestration.
+ *
+ * A writer may know that a target cannot accept part of a bundle. Keep that
+ * decision before the first filesystem mutation whenever the writer exposes
+ * `preflight`; retain the result check as a compatibility guard for older or
+ * external writers that only implement `write`.
+ * @module install/target-write
+ */
+import type {
+  ExtractedFiles,
+  Target,
+  TargetWriter,
+  TargetWriteResult,
+} from '@ai-primitives-hub/core';
+
+/**
+ * Raised when a target cannot install every routed bundle file.
+ */
+export class TargetWriteRejectedError extends Error {
+  public readonly code = 'BUNDLE.UNSUPPORTED_CONTENT';
+
+  public constructor(public readonly skipped: readonly string[]) {
+    super(`target cannot install bundle content: ${[...skipped].toSorted().join(', ')}`);
+    this.name = 'TargetWriteRejectedError';
+  }
+}
+
+/**
+ * Preflight and execute a target write without accepting partial content.
+ * @param writer Target writer.
+ * @param target Target configuration.
+ * @param files Extracted bundle files.
+ * @returns The successful writer result.
+ * @throws {TargetWriteRejectedError} When content is skipped.
+ */
+export async function writeTargetSafely(
+  writer: TargetWriter,
+  target: Target,
+  files: ExtractedFiles
+): Promise<TargetWriteResult> {
+  if (writer.preflight !== undefined) {
+    const plan = await writer.preflight(target, files);
+    if (plan.skipped.length > 0) {
+      throw new TargetWriteRejectedError(plan.skipped);
+    }
+  }
+
+  const result = await writer.write(target, files);
+  if (result.skipped.length > 0) {
+    if (writer.rollback !== undefined && result.written.length > 0) {
+      try {
+        await writer.rollback(target, result.written);
+      } catch {
+        // Preserve the policy failure; rollback is explicitly best effort.
+      }
+    }
+    throw new TargetWriteRejectedError(result.skipped);
+  }
+  return result;
+}

--- a/packages/app/src/stores/json-lockfile-store.ts
+++ b/packages/app/src/stores/json-lockfile-store.ts
@@ -311,12 +311,20 @@ export const cleanupOrphanedSource = (lock: Lockfile, sourceId: string): Lockfil
  * expects. Excludes `deployment-manifest.yml` — it is bundle metadata,
  * not an installed file — matching every writer's own exclusion of it.
  * @param files - Extracted bundle files (path -> raw bytes).
+ * @param includedPaths
  * @returns Per-file checksum entries, manifest excluded.
  */
-export const checksumFiles = (files: ExtractedFiles): LockfileFileEntry[] => {
+export const checksumFiles = (
+  files: ExtractedFiles,
+  includedPaths?: Iterable<string>
+): LockfileFileEntry[] => {
   const entries: LockfileFileEntry[] = [];
+  const included = includedPaths === undefined ? null : new Set(includedPaths);
   for (const [filePath, bytes] of files) {
     if (filePath === 'deployment-manifest.yml') {
+      continue;
+    }
+    if (included !== null && !included.has(filePath)) {
       continue;
     }
     entries.push({

--- a/packages/app/src/writers/file-tree-writer.ts
+++ b/packages/app/src/writers/file-tree-writer.ts
@@ -27,9 +27,11 @@ import type {
   ExtractedFiles,
   KindRoutes,
   LayoutConfigLoader,
+  PrimitiveKind,
   ResourceTransformer,
   Target,
   TargetLayout,
+  TargetWritePlan,
   TargetWriter,
   TargetWriteResult,
 } from '@ai-primitives-hub/core';
@@ -39,6 +41,7 @@ import {
   expandPath,
   getSkillName,
   getTargetFileName,
+  normalizePrimitiveKind,
   normalizePromptId,
   verifyWrittenBytes,
 } from '@ai-primitives-hub/core';
@@ -194,6 +197,42 @@ export class FileTreeTargetWriter implements TargetWriter {
   public constructor(private readonly opts: FileTreeTargetWriterOptions) {}
 
   /**
+   * Determine which extracted bundle files this writer can place without
+   * changing the target filesystem.
+   * @param target - Target chosen via `--target <name>`.
+   * @param files - Extracted bundle files.
+   * @returns Deterministic writable/skipped bundle-relative paths.
+   */
+  public async preflight(target: Target, files: ExtractedFiles): Promise<TargetWritePlan> {
+    const layout = await this.resolveLayout(target);
+    const skip = new Set(layout.skipPaths);
+    const allowed = target.allowedKinds === undefined
+      ? null
+      : new Set(target.allowedKinds.map((kind) => normalizePrimitiveKind(kind) ?? kind));
+    const writable: string[] = [];
+    const skipped: string[] = [];
+
+    for (const bundlePath of files.keys()) {
+      if (skip.has(bundlePath)) {
+        continue;
+      }
+      const route = pickRoute(bundlePath, layout.kindRoutes);
+      if (route === null) {
+        skipped.push(bundlePath);
+        continue;
+      }
+      const routeKind = routeToKind(route.prefix);
+      if (allowed !== null && (routeKind === null || !allowed.has(routeKind))) {
+        skipped.push(bundlePath);
+        continue;
+      }
+      writable.push(bundlePath);
+    }
+
+    return { writable, skipped };
+  }
+
+  /**
    * Write the bundle into the target.
    * @param target - Target chosen via `--target <name>`.
    * @param files - Extracted bundle files.
@@ -203,38 +242,71 @@ export class FileTreeTargetWriter implements TargetWriter {
     const layout = await this.resolveLayout(target);
     const baseDir = expandPath(layout.baseDir, this.opts.env);
     const skip = new Set(layout.skipPaths);
-    const allowed = target.allowedKinds === undefined ? null : new Set(target.allowedKinds);
+    const allowed = target.allowedKinds === undefined
+      ? null
+      : new Set(target.allowedKinds.map((kind) => normalizePrimitiveKind(kind) ?? kind));
     const written: string[] = [];
+    const writtenBundlePaths: string[] = [];
     const skipped: string[] = [];
+    let pendingWritePath: string | null = null;
 
-    // Eager mkdir of the routed-kind directories; reduces churn over
-    // calling mkdir per file. Per-kind subdir creation is recursive
-    // so root + nested dirs are covered.
-    for (const sub of Object.values(layout.kindRoutes)) {
-      await this.opts.fs.mkdir(path.join(baseDir, sub), { recursive: true });
+    try {
+      // Eager mkdir of the routed-kind directories; reduces churn over
+      // calling mkdir per file. Per-kind subdir creation is recursive
+      // so root + nested dirs are covered.
+      for (const sub of Object.values(layout.kindRoutes)) {
+        await this.opts.fs.mkdir(path.join(baseDir, sub), { recursive: true });
+      }
+
+      for (const [bundlePath, bytes] of files) {
+        if (skip.has(bundlePath)) {
+          continue;
+        }
+        const route = pickRoute(bundlePath, layout.kindRoutes);
+        if (route === null) {
+          // Unrouted file; not an error (bundles may carry extras).
+          skipped.push(bundlePath);
+          continue;
+        }
+        // Skip when allowedKinds explicitly excludes this kind.
+        const routeKind = routeToKind(route.prefix);
+        if (allowed !== null && (routeKind === null || !allowed.has(routeKind))) {
+          skipped.push(bundlePath);
+          continue;
+        }
+
+        const outPath = path.join(baseDir, route.outPrefix, route.tail);
+        // Keep the path visible to the catch block before write starts:
+        // a filesystem can persist the file and then throw.
+        pendingWritePath = outPath;
+        await this.writeContent(target, bundlePath, bytes, outPath);
+        pendingWritePath = null;
+        written.push(outPath);
+        writtenBundlePaths.push(bundlePath);
+      }
+    } catch (cause) {
+      const rollbackPaths = pendingWritePath === null
+        ? written
+        : [...written, pendingWritePath];
+      await this.rollback(target, rollbackPaths);
+      throw cause;
     }
+    return { written, skipped, writtenBundlePaths };
+  }
 
-    for (const [bundlePath, bytes] of files) {
-      if (skip.has(bundlePath)) {
-        continue;
+  /**
+   * Remove files written by a failed or rejected installation.
+   * @param _target - Target chosen via `--target <name>`.
+   * @param written - Absolute paths returned by `write`.
+   */
+  public async rollback(_target: Target, written: readonly string[]): Promise<void> {
+    for (const filePath of written) {
+      try {
+        await this.opts.fs.remove(filePath);
+      } catch {
+        // Rollback is best effort; preserve the original install failure.
       }
-      const route = pickRoute(bundlePath, layout.kindRoutes);
-      if (route === null) {
-        // Unrouted file; not an error (bundles may carry extras).
-        skipped.push(bundlePath);
-        continue;
-      }
-      // Skip when allowedKinds explicitly excludes this kind.
-      if (allowed !== null && !allowed.has(routeToKind(route.prefix))) {
-        skipped.push(bundlePath);
-        continue;
-      }
-
-      const outPath = path.join(baseDir, route.outPrefix, route.tail);
-      await this.writeContent(target, bundlePath, bytes, outPath);
-      written.push(outPath);
     }
-    return { written, skipped };
   }
 
   /**
@@ -310,17 +382,17 @@ export class FileTreeTargetWriter implements TargetWriter {
   ): Promise<TargetWriteResult> {
     const layout = await this.resolveLayout(target);
     const baseDir = expandPath(layout.baseDir, this.opts.env);
-    const allowed = target.allowedKinds === undefined ? null : new Set(target.allowedKinds);
+    const allowed = target.allowedKinds === undefined
+      ? null
+      : new Set(target.allowedKinds.map((kind) => normalizePrimitiveKind(kind) ?? kind));
     const written: string[] = [];
+    const writtenBundlePaths: string[] = [];
     const skipped: string[] = [];
 
     for (const item of items) {
       const type = item.type ?? determineFileType(item.file, item.tags);
       const routeKey = KIND_TO_ROUTE_KEY[type];
-      // `allowedKinds` is keyed on the same vocabulary as `write()`'s
-      // `routeToKind` (plural route-key names, e.g. "skills"/"prompts"),
-      // not on the singular `CopilotFileType` domain vocabulary.
-      if (allowed !== null && !allowed.has(routeToKind(routeKey))) {
+      if (allowed !== null && !allowed.has(copilotTypeToPrimitiveKind(type))) {
         skipped.push(item.file);
         continue;
       }
@@ -333,7 +405,14 @@ export class FileTreeTargetWriter implements TargetWriter {
 
       if (type === 'skill') {
         const wroteAny = await this.writeSkillItem(baseDir, outPrefix, item, files, written);
-        if (!wroteAny) {
+        if (wroteAny) {
+          for (const bundlePath of files.keys()) {
+            const sourcePrefix = `${path.posix.dirname(item.file)}/`;
+            if (bundlePath.startsWith(sourcePrefix)) {
+              writtenBundlePaths.push(bundlePath);
+            }
+          }
+        } else {
           skipped.push(item.file);
         }
         continue;
@@ -347,9 +426,10 @@ export class FileTreeTargetWriter implements TargetWriter {
       const outPath = path.join(baseDir, outPrefix, getTargetFileName(item.id, type));
       await this.writeContent(target, item.file, bytes, outPath);
       written.push(outPath);
+      writtenBundlePaths.push(item.file);
     }
 
-    return { written, skipped };
+    return { written, skipped, writtenBundlePaths };
   }
 
   private async resolveLayout(target: Target): Promise<TargetLayout> {
@@ -427,13 +507,29 @@ interface PickedRoute {
 }
 
 const pickRoute = (bundlePath: string, routes: KindRoutes): PickedRoute | null => {
-  for (const [prefix, outPrefix] of Object.entries(routes)) {
-    if (bundlePath.startsWith(prefix)) {
-      return { prefix, outPrefix, tail: bundlePath.slice(prefix.length) };
+  const normalizedBundlePath = normalizeBundlePath(bundlePath);
+  const sorted = Object.entries(routes).toSorted((a, b) => b[0].length - a[0].length);
+  for (const [prefix, outPrefix] of sorted) {
+    if (normalizedBundlePath.startsWith(prefix)) {
+      return { prefix, outPrefix, tail: normalizedBundlePath.slice(prefix.length) };
     }
   }
   return null;
 };
+
+/**
+ * Normalize legacy bundle directory aliases before route matching.
+ *
+ * `chatmodes/` was the historical authoring path while the canonical
+ * vocabulary uses `chat-modes/`. Keep accepting both on disk without
+ * duplicating aliases in every target layout. The original path remains in
+ * lockfile/checksum data; only the routing view is normalized.
+ * @param bundlePath
+ */
+const normalizeBundlePath = (bundlePath: string): string =>
+  bundlePath.startsWith('chatmodes/')
+    ? `chat-modes/${bundlePath.slice('chatmodes/'.length)}`
+    : bundlePath;
 
 /**
  * Map a layout prefix back to the primitive kind it represents.
@@ -441,4 +537,39 @@ const pickRoute = (bundlePath: string, routes: KindRoutes): PickedRoute | null =
  * @param prefix - Layout prefix (e.g., "prompts/").
  * @returns Kind name without trailing slash.
  */
-const routeToKind = (prefix: string): string => prefix.replace(/\/$/, '');
+const ROUTE_PREFIX_KINDS: Record<string, PrimitiveKind> = {
+  '.kiro/steering/': 'steering',
+  '.kiro/specs/': 'spec',
+  '.claude/commands/': 'command',
+  '.claude/output-styles/': 'output-style',
+  '.cursor/rules/': 'rule',
+  '.cursor/agents/': 'agent',
+  '.cursor/skills/': 'skill',
+  '.cursor/commands/': 'command',
+  '.opencode/tools/': 'tool',
+  '.opencode/commands/': 'command',
+  '.opencode/agents/': 'agent',
+  '.opencode/skills/': 'skill',
+  '.opencode/rules/': 'rule',
+  '.opencode/hooks/': 'hook',
+  '.opencode/plugins/': 'plugin',
+  '.devin/knowledge/': 'knowledge',
+  '.devin/playbooks/': 'playbook',
+  '.devin/powers/': 'power',
+  '.devin/prompts/': 'prompt',
+  '.devin/instructions/': 'instruction',
+  '.devin/agents/': 'agent',
+  '.devin/skills/': 'skill',
+  '.devin/hooks/': 'hook',
+  '.devin/plugins/': 'plugin'
+};
+
+const routeToKind = (prefix: string): PrimitiveKind | null => {
+  const normalizedPrefix = prefix.endsWith('/') ? prefix : `${prefix}/`;
+  return normalizePrimitiveKind(prefix.replace(/\/$/, ''))
+    ?? ROUTE_PREFIX_KINDS[normalizedPrefix]
+    ?? null;
+};
+
+const copilotTypeToPrimitiveKind = (type: CopilotFileType): PrimitiveKind =>
+  type === 'instructions' ? 'instruction' : (type === 'chatmode' ? 'chat-mode' : type);

--- a/packages/app/test/install/pipeline.test.ts
+++ b/packages/app/test/install/pipeline.test.ts
@@ -22,6 +22,10 @@ import {
   it,
 } from 'vitest';
 import {
+  createGovernedReleaseArchive,
+  createLegacyReleaseArchive,
+} from '../../../core/test/fixtures/release-archives';
+import {
   InstallPipeline,
   InstallPipelineError,
   type PipelineEvent,
@@ -196,5 +200,77 @@ describe('InstallPipeline', () => {
 
     await pipeline.run({ bundleId: 'my-bundle' }, TARGET);
     expect(calledWith).toBe(TARGET);
+  });
+
+  it('passes only declared installable content to the target writer for a governed release', async () => {
+    let writerFiles: string[] = [];
+    const pipeline = new InstallPipeline({
+      resolver: okResolver,
+      downloader: okDownloader,
+      extractor: { extract: async () => createGovernedReleaseArchive({ id: 'my-bundle' }) },
+      writerFactory: () => ({
+        preflight: async (_target, files) => ({ writable: [...files.keys()], skipped: [] }),
+        write: async (_target, files) => {
+          writerFiles = [...files.keys()];
+          return {
+            written: ['/out/prompts/hello.prompt.md'],
+            skipped: [],
+            writtenBundlePaths: ['prompts/hello.prompt.md']
+          };
+        },
+        remove: async () => {}
+      })
+    });
+
+    await pipeline.run({ bundleId: 'my-bundle' }, TARGET);
+
+    expect(writerFiles).toEqual([
+      'deployment-manifest.yml',
+      'prompts/hello.prompt.md'
+    ]);
+  });
+
+  it('passes the complete extracted map to legacy writers unchanged', async () => {
+    const legacyFiles = createLegacyReleaseArchive({ id: 'my-bundle' });
+    let writerInput: ExtractedFiles | undefined;
+    const pipeline = new InstallPipeline({
+      resolver: okResolver,
+      downloader: okDownloader,
+      extractor: { extract: async () => legacyFiles },
+      writerFactory: () => ({
+        preflight: async () => ({ writable: [...legacyFiles.keys()], skipped: [] }),
+        write: async (_target, files) => {
+          writerInput = files;
+          return { written: [...files.keys()], skipped: [] };
+        },
+        remove: async () => {}
+      })
+    });
+
+    await pipeline.run({ bundleId: 'my-bundle' }, TARGET);
+
+    expect(writerInput).toBe(legacyFiles);
+    expect([...writerInput!.keys()]).toEqual([...legacyFiles.keys()]);
+  });
+
+  it('does not construct or invoke a writer when governed validation fails', async () => {
+    const malformedFiles = createGovernedReleaseArchive({ id: 'my-bundle' });
+    malformedFiles.set('unexpected.txt', new TextEncoder().encode('not declared'));
+    let writerFactoryCalls = 0;
+    const pipeline = new InstallPipeline({
+      resolver: okResolver,
+      downloader: okDownloader,
+      extractor: { extract: async () => malformedFiles },
+      writerFactory: () => {
+        writerFactoryCalls += 1;
+        return okWriter;
+      }
+    });
+
+    await expect(pipeline.run({ bundleId: 'my-bundle' }, TARGET)).rejects.toMatchObject({
+      code: 'BUNDLE.MANIFEST_INVALID',
+      stage: 'validate'
+    });
+    expect(writerFactoryCalls).toBe(0);
   });
 });

--- a/packages/app/test/writers/file-tree-writer.test.ts
+++ b/packages/app/test/writers/file-tree-writer.test.ts
@@ -37,6 +37,18 @@ import {
 
 const localPath = (...segments: string[]): string => path.join(...segments);
 
+class FailAfterFirstWriteFileSystem extends InMemoryFileSystem {
+  private writeCount = 0;
+
+  public override async writeFile(filePath: string, contents: string): Promise<void> {
+    this.writeCount += 1;
+    await super.writeFile(filePath, contents);
+    if (this.writeCount === 2) {
+      throw new Error('disk full after write');
+    }
+  }
+}
+
 describe('resolveLayout', () => {
   it('resolves vscode user scope layout from built-in defaults', () => {
     const target: Target = { name: 'test', type: 'vscode', scope: 'user', path: '/custom/path' };
@@ -66,6 +78,29 @@ describe('resolveLayout', () => {
   it('throws for an unknown target type', () => {
     const target = { name: 'test', type: 'nonexistent', scope: 'user' } as unknown as Target;
     expect(() => resolveLayout(target)).toThrow('No layout defined for target type "nonexistent"');
+  });
+
+  it('resolves cursor repository scope to ${workspaceRoot}', () => {
+    const target: Target = { name: 'test', type: 'cursor', scope: 'repository', rootPath: '/ws' };
+    const layout = resolveLayout(target);
+    expect(layout.baseDir).toBe('/ws');
+    expect(layout.kindRoutes).toHaveProperty('.cursor/rules/');
+  });
+
+  it('resolves kiro repository scope with .kiro/steering and .kiro/specs routes', () => {
+    const target: Target = { name: 'test', type: 'kiro', scope: 'repository', rootPath: '/ws' };
+    const layout = resolveLayout(target);
+    expect(layout.baseDir).toBe('/ws/.kiro');
+    expect(layout.kindRoutes['.kiro/steering/']).toBe('steering/');
+    expect(layout.kindRoutes['.kiro/specs/']).toBe('specs/');
+  });
+
+  it('resolves claude-code repository scope with claude commands and output-styles', () => {
+    const target: Target = { name: 'test', type: 'claude-code', scope: 'repository', rootPath: '/ws' };
+    const layout = resolveLayout(target);
+    expect(layout.baseDir).toBe('/ws/.claude');
+    expect(layout.kindRoutes['.claude/commands/']).toBe('commands/');
+    expect(layout.kindRoutes['.claude/output-styles/']).toBe('output-styles/');
   });
 });
 
@@ -137,6 +172,33 @@ describe('FileTreeTargetWriter', () => {
     expect(await fs.readFile(localPath('/out', 'prompts', 'test.md'))).toBe('# Test');
   });
 
+  it('rolls back files when a filesystem write throws after persisting', async () => {
+    const fs = new FailAfterFirstWriteFileSystem();
+    const writer = new FileTreeTargetWriter({ fs, env: {} });
+    const files = new Map<string, Uint8Array>([
+      ['prompts/first.md', new TextEncoder().encode('# First')],
+      ['prompts/second.md', new TextEncoder().encode('# Second')]
+    ]);
+
+    await expect(writer.write(target, files)).rejects.toThrow('disk full after write');
+
+    expect(await fs.exists(localPath('/out', 'prompts', 'first.md'))).toBe(false);
+    expect(await fs.exists(localPath('/out', 'prompts', 'second.md'))).toBe(false);
+  });
+
+  it('routes the legacy chatmodes path alias to the canonical chat-modes route', async () => {
+    const fs = new InMemoryFileSystem();
+    const writer = new FileTreeTargetWriter({ fs, env: {} });
+    const files = new Map<string, Uint8Array>([
+      ['chatmodes/review.chatmode.md', new TextEncoder().encode('# Review')]
+    ]);
+
+    const result = await writer.write(target, files);
+
+    expect(result.written).toContain(localPath('/out', 'agents', 'review.chatmode.md'));
+    expect(result.skipped).toEqual([]);
+  });
+
   it('skips files in the layout skipPaths list', async () => {
     const fs = new InMemoryFileSystem();
     const writer = new FileTreeTargetWriter({ fs, env: {} });
@@ -165,7 +227,7 @@ describe('FileTreeTargetWriter', () => {
   it('honors target.allowedKinds by skipping excluded kinds', async () => {
     const fs = new InMemoryFileSystem();
     const writer = new FileTreeTargetWriter({ fs, env: {} });
-    const restrictedTarget: Target = { ...target, allowedKinds: ['skills'] };
+    const restrictedTarget: Target = { ...target, allowedKinds: ['skill'] };
     const files = new Map<string, Uint8Array>([
       ['prompts/test.md', new TextEncoder().encode('# Test')],
       ['skills/my-skill/SKILL.md', new TextEncoder().encode('# Skill')]
@@ -262,6 +324,48 @@ describe('FileTreeTargetWriter', () => {
 
     await expect(writer.remove(target, 'unrouted/thing.bin')).resolves.not.toThrow();
   });
+
+  it('prefers the most specific route for .kiro/steering/', async () => {
+    const fs = new InMemoryFileSystem();
+    const kiroTarget: Target = { name: 'test', type: 'kiro', scope: 'repository', rootPath: '/ws' };
+    const writer = new FileTreeTargetWriter({ fs, env: {} });
+    const files = new Map<string, Uint8Array>([
+      ['.kiro/steering/api.md', new TextEncoder().encode('# API')]
+    ]);
+
+    const result = await writer.write(kiroTarget, files);
+
+    expect(result.written).toContain(localPath('/ws', '.kiro', 'steering', 'api.md'));
+    expect(result.skipped).toEqual([]);
+  });
+
+  it('routes .cursor/rules/ for cursor repository scope', async () => {
+    const fs = new InMemoryFileSystem();
+    const cursorTarget: Target = { name: 'test', type: 'cursor', scope: 'repository', rootPath: '/ws' };
+    const writer = new FileTreeTargetWriter({ fs, env: {} });
+    const files = new Map<string, Uint8Array>([
+      ['.cursor/rules/backend.mdc', new TextEncoder().encode('# Rules')]
+    ]);
+
+    const result = await writer.write(cursorTarget, files);
+
+    expect(result.written).toContain(localPath('/ws', '.cursor', 'rules', 'backend.mdc'));
+  });
+
+  it('routes knowledge/ and playbooks/ for devin repository scope', async () => {
+    const fs = new InMemoryFileSystem();
+    const devinTarget: Target = { name: 'test', type: 'devin', scope: 'repository', rootPath: '/ws' };
+    const writer = new FileTreeTargetWriter({ fs, env: {} });
+    const files = new Map<string, Uint8Array>([
+      ['knowledge/onboarding.md', new TextEncoder().encode('# Onboarding')],
+      ['playbooks/bug-fix.md', new TextEncoder().encode('# Bug fix')]
+    ]);
+
+    const result = await writer.write(devinTarget, files);
+
+    expect(result.written).toContain(localPath('/ws', '.devin', 'knowledge', 'onboarding.md'));
+    expect(result.written).toContain(localPath('/ws', '.devin', 'playbooks', 'bug-fix.md'));
+  });
 });
 
 describe('FileTreeTargetWriter.writeManifestItems', () => {
@@ -332,7 +436,7 @@ describe('FileTreeTargetWriter.writeManifestItems', () => {
   it('skips items whose kind is excluded by target.allowedKinds', async () => {
     const fs = new InMemoryFileSystem();
     const writer = new FileTreeTargetWriter({ fs, env: {} });
-    const restrictedTarget: Target = { ...repoTarget, allowedKinds: ['skills'] };
+    const restrictedTarget: Target = { ...repoTarget, allowedKinds: ['skill'] };
     const files = new Map<string, Uint8Array>([
       ['some-source-name.md', new TextEncoder().encode('# Hello')]
     ]);

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,6 +41,7 @@
     "@ai-primitives-hub/app": "workspace:*",
     "@ai-primitives-hub/core": "workspace:*",
     "@ai-primitives-hub/infra": "workspace:*",
+    "@prompt-registry/collection-scripts": "workspace:^",
     "archiver": "^7.0.1",
     "clipanion": "4.0.0-rc.4",
     "inquirer": "^9.3.8",

--- a/packages/cli/src/commands/bundle-build.ts
+++ b/packages/cli/src/commands/bundle-build.ts
@@ -23,16 +23,23 @@ import {
   existsSync,
   unlinkSync,
 } from 'node:fs';
+import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import {
-  readCollection,
-  resolveCollectionItemPaths,
-  resolveCollectionReadmePath,
-} from '@ai-primitives-hub/app';
-import {
-  generateBundleId,
   normalizeRepoRelativePath,
+  validateManifest,
 } from '@ai-primitives-hub/core';
+import {
+  ZipBundleExtractor,
+} from '@ai-primitives-hub/infra';
+import {
+  createLegacyReleaseManifestPlan,
+  createReleaseManifestPlan,
+  generateBundleId,
+  isMissingSourceLicenseError,
+  LEGACY_RELEASE_WARNING,
+  serializeReleaseManifest,
+} from '@prompt-registry/collection-scripts';
 import archiver from 'archiver';
 import {
   Command,
@@ -44,7 +51,6 @@ import {
   renderError,
 } from '../framework';
 import {
-  generateBundleManifest,
   resolveCollectionFile,
 } from './bundle-manifest';
 
@@ -67,17 +73,15 @@ const FIXED_DATE = new Date('1980-01-01T00:00:00.000Z');
 /**
  * Create a deterministic ZIP archive with fixed timestamps and sorted entries.
  * @param input - Zip creation parameters.
- * @param input.repoRoot
  * @param input.zipPath
- * @param input.manifestPath
- * @param input.itemPaths
+ * @param input.manifest
+ * @param input.entries
  * @returns Promise that resolves when the ZIP is created.
  */
 const createDeterministicZip = (input: {
-  repoRoot: string;
   zipPath: string;
-  manifestPath: string;
-  itemPaths: string[];
+  manifest: string;
+  entries: { path: string; bytes: Uint8Array }[];
 }): Promise<void> => {
   // The single archiver/streams use site in this command file.
   // Reproducible timestamps, sorted entry order, max zlib compression.
@@ -116,13 +120,15 @@ const createDeterministicZip = (input: {
       reject(err);
     });
     archive.pipe(output);
-    archive.file(input.manifestPath, { name: 'deployment-manifest.yml', date: FIXED_DATE });
-    const sorted = input.itemPaths
-      .map((p) => normalizeRepoRelativePath(p))
-      .toSorted((a, b) => a.localeCompare(b));
-    for (const rel of sorted) {
-      const abs = path.join(input.repoRoot, rel);
-      archive.file(abs, { name: rel, date: FIXED_DATE });
+    archive.append(input.manifest, { name: 'deployment-manifest.yml', date: FIXED_DATE });
+    const sorted = input.entries
+      .map((entry) => ({
+        path: normalizeRepoRelativePath(entry.path),
+        bytes: entry.bytes
+      }))
+      .toSorted((a, b) => (a.path < b.path ? -1 : (a.path > b.path ? 1 : 0)));
+    for (const entry of sorted) {
+      archive.append(Buffer.from(entry.bytes), { name: entry.path, date: FIXED_DATE });
     }
     archive.finalize().catch(() => { /* handled by archive.on('error') above */ });
   });
@@ -180,7 +186,7 @@ export class BundleBuildCommand extends Command {
   public async execute(): Promise<number> {
     const { ctx } = this.commandContext;
     const fmt = (this.output ?? 'text');
-    const version = this.version ?? '';
+    const version = this.version ?? '0.0.0-dev';
 
     try {
       const cwd = ctx.cwd();
@@ -192,8 +198,26 @@ export class BundleBuildCommand extends Command {
       // injected working directories (Context invariant).
       const outDirRel = this.outDir ?? 'dist';
       const outDir = path.isAbsolute(outDirRel) ? outDirRel : path.join(cwd, outDirRel);
-      const collection = readCollection(cwd, collectionFile);
-      const collectionId = collection.id;
+      const warnings: string[] = [];
+      let releasePlan;
+      try {
+        releasePlan = createReleaseManifestPlan({
+          repoRoot: cwd,
+          collectionFile,
+          version
+        });
+      } catch (err) {
+        if (!isMissingSourceLicenseError(err)) {
+          throw err;
+        }
+        releasePlan = createLegacyReleaseManifestPlan({
+          repoRoot: cwd,
+          collectionFile,
+          version
+        });
+        warnings.push(LEGACY_RELEASE_WARNING);
+      }
+      const collectionId = String(releasePlan.manifest.id);
       if (typeof collectionId !== 'string' || collectionId.length === 0) {
         throw new RegistryError({
           code: 'BUNDLE.INVALID_MANIFEST',
@@ -205,33 +229,16 @@ export class BundleBuildCommand extends Command {
       const collectionOutDir = path.join(outDir, collectionId);
       await ctx.fs.mkdir(collectionOutDir, { recursive: true });
 
-      // Generate the deployment-manifest.yml in the bundle output
-      // directory by calling `bundle manifest`'s exported helper
-      // in-process (its own errors propagate via the same try/catch).
       const standaloneManifestPath = path.join(collectionOutDir, 'deployment-manifest.yml');
-      // Suppress the manifest sub-step's own stdout envelope so it
-      // doesn't pollute this command's output. The OutputStream
-      // contract is just `{ write(chunk: string): void }`.
-      const subCtx: Context = {
-        ...ctx,
-        stdout: { write: () => undefined }
-      };
-      await generateBundleManifest(
-        subCtx,
-        cwd,
-        { output: 'json', version, collectionFile },
-        standaloneManifestPath
-      );
-
-      const itemPaths = resolveCollectionItemPaths(cwd, collection);
-      const readmeAsset = resolveCollectionReadmePath(collection);
+      const manifestYaml = serializeReleaseManifest(releasePlan.manifest);
+      await ctx.fs.writeFile(standaloneManifestPath, manifestYaml);
       const zipPath = path.join(collectionOutDir, `${collectionId}.bundle.zip`);
       await createDeterministicZip({
-        repoRoot: cwd,
         zipPath,
-        manifestPath: standaloneManifestPath,
-        itemPaths
+        manifest: manifestYaml,
+        entries: releasePlan.entries
       });
+      await validateBuiltArchive(zipPath, collectionId, version);
 
       const data: BundleBuildData = {
         collectionId,
@@ -239,15 +246,16 @@ export class BundleBuildCommand extends Command {
         outDir: collectionOutDir.replaceAll('\\', '/'),
         manifestAsset: standaloneManifestPath.replaceAll('\\', '/'),
         zipAsset: zipPath.replaceAll('\\', '/'),
-        ...(readmeAsset ? { readmeAsset: readmeAsset.replaceAll('\\', '/') } : {}),
+        ...(releasePlan.readmeSourcePath ? { readmeAsset: releasePlan.readmeSourcePath.replaceAll('\\', '/') } : {}),
         bundleId
       };
       formatOutput({
         ctx,
         command: 'bundle.build',
         output: fmt,
-        status: 'ok',
+        status: warnings.length > 0 ? 'warning' : 'ok',
         data,
+        warnings,
         textRenderer: (d) =>
           `Built ${d.zipAsset} (bundle id: ${d.bundleId}, version: ${d.version})\n`
       });
@@ -265,3 +273,18 @@ export class BundleBuildCommand extends Command {
     }
   }
 }
+
+/**
+ * Verify the exact bytes written to the ZIP satisfy the release contract.
+ * @param zipPath
+ * @param collectionId
+ * @param version
+ */
+const validateBuiltArchive = async (
+  zipPath: string,
+  collectionId: string,
+  version: string
+): Promise<void> => {
+  const files = await new ZipBundleExtractor().extract(await fs.readFile(zipPath));
+  validateManifest(files, { expectedId: collectionId, expectedVersion: version });
+};

--- a/packages/cli/src/commands/bundle-manifest.ts
+++ b/packages/cli/src/commands/bundle-manifest.ts
@@ -70,7 +70,7 @@ interface RawCollection {
   author?: string;
   tags?: string[];
   readme?: { path?: string };
-  items?: { path?: string; kind?: string }[];
+  items?: { path?: string; kind?: string; tags?: string[] }[];
   mcpServers?: Record<string, unknown>;
   mcp?: { items?: Record<string, unknown>; inputs?: unknown[] };
 }
@@ -81,7 +81,7 @@ interface PromptEntry {
   description: string;
   file: string;
   type: string;
-  tags: string[];
+  tags?: string[];
 }
 
 /**
@@ -149,33 +149,36 @@ function generateItemId(itemPath: string, kind: string): string {
   return path.basename(itemPath, extension);
 }
 
+function itemTags(item: { tags?: string[] }): string[] | undefined {
+  return Array.isArray(item.tags) && item.tags.length > 0 ? [...item.tags] : undefined;
+}
+
 /**
  * Build a prompt entry for the deployment manifest.
  * @param item Collection item.
  * @param item.path
  * @param item.kind
+ * @param item.tags
  * @param itemPath Item path.
- * @param collection Raw collection.
  * @param itemContent Item markdown content.
  * @returns Prompt entry.
  */
 function buildPromptEntry(
-  item: { path?: string; kind?: string },
+  item: { path?: string; kind?: string; tags?: string[] },
   itemPath: string,
-  collection: RawCollection,
   itemContent: string
 ): PromptEntry {
   const { name, description } = extractItemMetadataByPath(itemContent, itemPath);
   const itemId = generateItemId(itemPath, item.kind || '');
-  const tags = Array.isArray(collection.tags) ? [...collection.tags] : [];
   const type = KIND_TO_TYPE_MAP[item.kind || ''] ?? item.kind ?? '';
+  const tags = itemTags(item);
   return {
     id: itemId,
     name: name || itemId,
     description,
     file: itemPath,
     type,
-    tags
+    ...(tags === undefined ? {} : { tags })
   };
 }
 
@@ -188,7 +191,7 @@ function buildPromptEntry(
  * @returns Array of prompt entries.
  */
 async function processCollectionItems(
-  items: { path?: string; kind?: string }[],
+  items: { path?: string; kind?: string; tags?: string[] }[],
   collection: RawCollection,
   ctx: Context,
   cwd: string
@@ -208,7 +211,7 @@ async function processCollectionItems(
       });
     }
     const itemContent = await ctx.fs.readFile(itemAbs);
-    prompts.push(buildPromptEntry(item, itemPath, collection, itemContent));
+    prompts.push(buildPromptEntry(item, itemPath, itemContent));
   }
   return prompts;
 }

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -137,17 +137,23 @@ export class DoctorDiagnosticsCommand extends BaseDoctorCommand {
       E2E user flow (target add, hub add, sync, profile activate, index build,
       install, uninstall), and reports every step with captured input/output.
 
-      The workspace is always cleaned up before exiting.
+      The workspace is cleaned up before exiting by default. Use
+      --retain-workspace when you need to inspect the generated fixtures or
+      artifacts after the run.
 
       Options:
         -o, --output <format>  Output format (text, json, yaml, ndjson)
         -v, --verbose          Print per-step progress to stderr
+        --retain-workspace     Keep the temporary diagnostic workspace
 
       Examples:
         ai-primitives-hub doctor diagnostics
         ai-primitives-hub doctor diagnostics -v
+        ai-primitives-hub doctor diagnostics --retain-workspace
     `
   });
+
+  public retainWorkspace = Option.Boolean('--retain-workspace', false);
 
   public async execute(): Promise<number> {
     const { ctx } = this.commandContext;
@@ -155,7 +161,8 @@ export class DoctorDiagnosticsCommand extends BaseDoctorCommand {
     const result = await runDiagnostics({
       ctx,
       commandClasses: getDiagnosticCommandClasses(),
-      verbose: this.verbose
+      verbose: this.verbose,
+      retainWorkspace: this.retainWorkspace
     });
     const status: OutputStatus = result.ok ? 'ok' : 'error';
     formatOutput({
@@ -755,7 +762,7 @@ const renderDoctorText = (result: DoctorResult): string => {
 const renderDiagnosticsText = (result: DiagnosticsResult): string => {
   const lines: string[] = [
     'ai-primitives-hub doctor diagnostics',
-    `  workspace: ${result.workspace}`,
+    `  workspace: ${result.workspace} (${result.workspaceRetained ? 'retained' : 'removed'})`,
     `  ${result.ok ? '[ OK ]' : '[FAIL]'} ${result.summary}`,
     ''
   ];

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -69,8 +69,13 @@ function getTargetTypeDisplayName(type: TargetType): string {
     'vscode-insiders': 'Visual Studio Code Insiders',
     'copilot-cli': 'GitHub Copilot CLI',
     kiro: 'Kiro IDE',
+    'kiro-cli': 'Kiro CLI',
     windsurf: 'Windsurf Editor',
-    'claude-code': 'Anthropic Claude Code'
+    'claude-code': 'Anthropic Claude Code',
+    cursor: 'Cursor',
+    opencode: 'OpenCode',
+    devin: 'Devin',
+    'devin-cli': 'Devin CLI'
   };
   return displayNames[type];
 }

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -30,6 +30,7 @@ import {
   upsertBundleEntry,
   upsertSource,
   writeLockfile,
+  writeTargetSafely,
 } from '@ai-primitives-hub/app';
 import type {
   BundleResolver,
@@ -39,6 +40,7 @@ import type {
   TokenProvider,
 } from '@ai-primitives-hub/core';
 import {
+  getInstallableBundleFiles,
   parseBundleSpec,
   validateManifest,
 } from '@ai-primitives-hub/core';
@@ -81,6 +83,7 @@ import {
   type OutputFormat,
   readTargetsSafely,
   RegistryError,
+  resolveEffectiveTarget,
   resolveTarget,
   resolveTargetName,
   validateInputs,
@@ -279,7 +282,8 @@ export class InstallCommand extends BaseInstallCommand {
     try {
       const targetName = await resolveTargetName(opts.target, 'install', ctx, () => readTargets({ cwd: ctx.cwd(), fs: ctx.fs }));
       checkAllowTarget(targetName, opts);
-      const target = await resolveTarget(targetName, 'install', ctx, () => readTargets({ cwd: ctx.cwd(), fs: ctx.fs }));
+      const configuredTarget = await resolveTarget(targetName, 'install', ctx, () => readTargets({ cwd: ctx.cwd(), fs: ctx.fs }));
+      const target = resolveEffectiveTarget(ctx, configuredTarget, opts);
 
       const mode = determineInstallMode(opts);
       if (mode === undefined) {
@@ -428,12 +432,16 @@ export const createWriterFactory = (
   });
 
   return (target: Target): TargetWriter => {
-    // Use CLI flags to override target scope if specified
-    const scope = opts.scope ?? target.scope;
-    const commitMode = opts.commitMode ?? target.commitMode ?? 'commit';
-    const workspaceRoot = target.rootPath ?? ctx.cwd();
+    const effectiveTarget = resolveEffectiveTarget(ctx, target, opts);
+    const scope = effectiveTarget.scope;
+    const commitMode = effectiveTarget.commitMode ?? 'commit';
+    const workspaceRoot = effectiveTarget.rootPath ?? ctx.cwd();
 
-    if (scope === 'repository') {
+    // Copilot / VS Code repository scope still writes the .github tree and
+    // supports commitMode / .git/info/exclude. Every other target uses the
+    // data-driven FileTreeTargetWriter with its repository scope layout.
+    const copilotLikeTargets = new Set<string>(['vscode', 'vscode-insiders', 'copilot-cli']);
+    if (scope === 'repository' && copilotLikeTargets.has(effectiveTarget.type)) {
       const writer = new RepositoryScopeWriter({
         fs: ctx.fs,
         workspaceRoot,
@@ -441,8 +449,7 @@ export const createWriterFactory = (
       });
       return new RepositoryScopeWriterAdapter(writer);
     }
-    // Default to FileTreeTargetWriter for user scope
-    const transformer = transformerRegistry.getTransformer(target.type);
+    const transformer = transformerRegistry.getTransformer(effectiveTarget.type);
     return new FileTreeTargetWriter({
       fs: ctx.fs,
       env: ctx.env,
@@ -702,6 +709,7 @@ async function performLocalInstall(
   fmt: OutputFormat
 ): Promise<number> {
   try {
+    const effectiveTarget = resolveEffectiveTarget(ctx, target, opts);
     const files = await readLocalBundle(opts.from as string, ctx.fs);
     const manifest = validateManifest(files, {
       expectedId: opts.bundle ?? '',
@@ -715,7 +723,7 @@ async function performLocalInstall(
         status: 'ok',
         data: {
           dryRun: true,
-          target: target.name,
+          target: effectiveTarget.name,
           bundle: { id: manifest.id, version: manifest.version },
           files: [...files.keys()]
         },
@@ -725,12 +733,13 @@ async function performLocalInstall(
       return 0;
     }
     const writerFactory = createWriterFactory(ctx, opts);
-    const writer = writerFactory(target);
-    const result = await writer.write(target, files);
+    const writer = writerFactory(effectiveTarget);
+    const targetFiles = getInstallableBundleFiles(files, manifest);
+    const result = await writeTargetSafely(writer, effectiveTarget, targetFiles);
 
-    const scope = opts.scope ?? target.scope;
-    const commitMode = opts.commitMode ?? target.commitMode ?? 'commit';
-    const lockPath = lockfilePathForTarget(ctx, target, commitMode);
+    const scope = effectiveTarget.scope;
+    const commitMode = effectiveTarget.commitMode ?? 'commit';
+    const lockPath = lockfilePathForTarget(ctx, effectiveTarget);
     const existing = await readLockfile(lockPath, ctx.fs) ?? emptyLockfile('ai-primitives-hub-cli');
     const localSourceId = `local-${path.basename(opts.from as string)}`;
     const entry: LockfileBundleEntry = {
@@ -738,7 +747,7 @@ async function performLocalInstall(
       sourceId: localSourceId,
       sourceType: 'local',
       installedAt: new Date().toISOString(),
-      files: checksumFiles(files)
+      files: checksumFiles(targetFiles, result.writtenBundlePaths ?? targetFiles.keys())
     };
     if (scope === 'repository') {
       entry.commitMode = commitMode;
@@ -750,7 +759,7 @@ async function performLocalInstall(
     });
     await writeLockfile(lockPath, nextLock, ctx.fs);
 
-    await updateTargetState(ctx, target.name, manifest.id, manifest.version);
+    await updateTargetState(ctx, effectiveTarget.name, manifest.id, manifest.version);
 
     formatOutput({
       ctx,
@@ -758,7 +767,7 @@ async function performLocalInstall(
       output: fmt,
       status: 'ok',
       data: {
-        target: target.name,
+        target: effectiveTarget.name,
         bundle: { id: manifest.id, version: manifest.version },
         written: result.written,
         skipped: result.skipped,
@@ -798,6 +807,7 @@ async function performLockfileInstall(
   ctx: Context,
   fmt: OutputFormat
 ): Promise<number> {
+  const effectiveTarget = resolveEffectiveTarget(ctx, target, opts);
   const lockfile = opts.lockfile as string;
   const lockPath = path.isAbsolute(lockfile)
     ? lockfile
@@ -807,7 +817,7 @@ async function performLockfileInstall(
   const http = opts.http ?? new NodeHttpClient();
   const tokens = opts.tokens ?? defaultTokenProvider(ctx.env);
   const writerFactory = createWriterFactory(ctx, opts);
-  const writer = writerFactory(target);
+  const writer = writerFactory(effectiveTarget);
 
   const { replayed, failures } = await replayLockfileEntries({
     bundleIds,
@@ -815,13 +825,13 @@ async function performLockfileInstall(
     http,
     tokens,
     writer,
-    target,
+    target: effectiveTarget,
     ctx,
     verbose: opts.verbose ?? false
   });
 
   if (replayed.length > 0) {
-    await updateTargetStateFromLockfile(ctx, target.name, lock, replayed);
+    await updateTargetStateFromLockfile(ctx, effectiveTarget.name, lock, replayed);
   }
 
   const status = failures.length === 0 ? 'ok' : 'warning';
@@ -832,7 +842,7 @@ async function performLockfileInstall(
     status,
     data: {
       lockfile: lockPath,
-      target: target.name,
+      target: effectiveTarget.name,
       replayPlanned: bundleIds.length,
       replayed,
       failures
@@ -871,6 +881,7 @@ async function performRemoteInstall(
   fmt: OutputFormat
 ): Promise<number> {
   try {
+    const effectiveTarget = resolveEffectiveTarget(ctx, target, opts);
     const spec = parseBundleSpec(opts.bundle as string);
     const repoSlug = opts.source ?? spec.sourceId;
     if (repoSlug === undefined || repoSlug.length === 0) {
@@ -924,7 +935,7 @@ async function performRemoteInstall(
         status: 'ok',
         data: {
           dryRun: true,
-          target: target.name,
+          target: effectiveTarget.name,
           bundle: { id: manifest.id, version: manifest.version },
           source: { type: 'github', repo: repoSlug, downloadUrl: installable.downloadUrl },
           sha256: dl.sha256,
@@ -936,13 +947,13 @@ async function performRemoteInstall(
       });
       return 0;
     }
-    const transformerRegistry = TransformerRegistry.withBuiltIns();
-    const transformer = transformerRegistry.getTransformer(target.type);
-    const writer = new FileTreeTargetWriter({ fs: ctx.fs, env: ctx.env, transformer });
-    const result = await writer.write(target, files);
-    const scope = opts.scope ?? target.scope;
-    const commitMode = opts.commitMode ?? target.commitMode ?? 'commit';
-    const lockPath = lockfilePathForTarget(ctx, target, commitMode);
+    const writerFactory = createWriterFactory(ctx, opts);
+    const writer = writerFactory(effectiveTarget);
+    const targetFiles = getInstallableBundleFiles(files, manifest);
+    const result = await writeTargetSafely(writer, effectiveTarget, targetFiles);
+    const scope = effectiveTarget.scope;
+    const commitMode = effectiveTarget.commitMode ?? 'commit';
+    const lockPath = lockfilePathForTarget(ctx, effectiveTarget);
     const existing = await readLockfile(lockPath, ctx.fs) ?? emptyLockfile('ai-primitives-hub-cli');
     const entry: LockfileBundleEntry = {
       version: manifest.version,
@@ -950,7 +961,7 @@ async function performRemoteInstall(
       sourceType: installable.ref.sourceType,
       checksum: dl.sha256,
       installedAt: new Date().toISOString(),
-      files: checksumFiles(files)
+      files: checksumFiles(targetFiles, result.writtenBundlePaths ?? targetFiles.keys())
     };
     if (scope === 'repository') {
       entry.commitMode = commitMode;
@@ -970,7 +981,7 @@ async function performRemoteInstall(
       output: fmt,
       status: 'ok',
       data: {
-        target: target.name,
+        target: effectiveTarget.name,
         bundle: { id: manifest.id, version: manifest.version },
         source: { type: 'github', repo: repoSlug, sourceId: installable.ref.sourceId },
         sha256: dl.sha256,
@@ -1127,7 +1138,8 @@ export const createInstallCommand = (
       try {
         const targetName = await resolveTargetName(opts.target, 'install', ctx, () => readTargets({ cwd: ctx.cwd(), fs: ctx.fs }));
         checkAllowTarget(targetName, opts);
-        const target = await resolveTarget(targetName, 'install', ctx, () => readTargets({ cwd: ctx.cwd(), fs: ctx.fs }));
+        const configuredTarget = await resolveTarget(targetName, 'install', ctx, () => readTargets({ cwd: ctx.cwd(), fs: ctx.fs }));
+        const target = resolveEffectiveTarget(ctx, configuredTarget, opts);
 
         if (opts.from !== undefined && opts.from.length > 0) {
           return await performLocalInstall(opts, target, ctx, fmt);
@@ -1237,11 +1249,11 @@ async function validateAndWrite(
   ctx: Context,
   verbose: boolean
 ): Promise<void> {
-  validateManifest(files, {
+  const manifest = validateManifest(files, {
     expectedId: bundleId,
     expectedVersion: entry.version
   });
-  await writer.write(target, files);
+  await writeTargetSafely(writer, target, getInstallableBundleFiles(files, manifest));
   if (verbose) {
     ctx.stdout.write(`[verbose] Successfully installed ${bundleId}\n`);
   }

--- a/packages/cli/src/commands/profile.ts
+++ b/packages/cli/src/commands/profile.ts
@@ -38,8 +38,10 @@ import {
   upsertBundleEntry,
   upsertSource,
   writeLockfile,
+  writeTargetSafely,
 } from '@ai-primitives-hub/app';
 import {
+  getInstallableBundleFiles,
   type HttpClient,
   type HubProfile,
   type HubProfileBundle,
@@ -62,6 +64,7 @@ import {
   lockfilePathForTarget,
   Option,
   requireActiveHubOrFail,
+  resolveEffectiveTarget,
 } from '../framework';
 import {
   type Context,
@@ -388,13 +391,14 @@ async function activateBundleForTarget(
       expectedId: bundleRef.id,
       expectedVersion: bundleRef.version === 'latest' ? undefined : bundleRef.version
     });
-    const result = await writer.write(target, files);
+    const targetFiles = getInstallableBundleFiles(files, manifest);
+    const result = await writeTargetSafely(writer, target, targetFiles);
     const entry: LockfileBundleEntry = {
       version: manifest.version,
       sourceId: src.id,
       sourceType: src.type,
       installedAt: new Date().toISOString(),
-      files: checksumFiles(files)
+      files: checksumFiles(targetFiles, result.writtenBundlePaths ?? targetFiles.keys())
     };
     if (target.scope === 'repository') {
       entry.commitMode = target.commitMode ?? 'commit';
@@ -418,7 +422,8 @@ async function activateBundleForTarget(
  * @param targets Targets to remove the profile's bundles from.
  */
 async function deactivateProfileBundles(ctx: Context, state: ProfileActivationState, targets: Target[]): Promise<void> {
-  for (const target of targets) {
+  for (const configuredTarget of targets) {
+    const target = resolveEffectiveTarget(ctx, configuredTarget);
     if (target.scope === 'repository') {
       const pipeline = new UninstallPipeline({
         fs: ctx.fs,
@@ -476,11 +481,12 @@ export async function runProfileActivation(
   profile: HubProfile,
   targets: Target[]
 ): Promise<ProfileActivationResult> {
+  const effectiveTargets = targets.map((target) => resolveEffectiveTarget(ctx, target));
   // Enforce a single globally-active profile: deactivate whatever was
   // previously active (if anything) before installing the new one.
   const previouslyActive = await built.activations.listAll();
   for (const prev of previouslyActive) {
-    await deactivateProfileBundles(ctx, prev, targets);
+    await deactivateProfileBundles(ctx, prev, effectiveTargets);
     await built.activations.delete(prev.hubId, prev.profileId);
     const prevActiveHub = await built.mgr.getActiveHub();
     if (prevActiveHub?.id === prev.hubId) {
@@ -497,7 +503,7 @@ export async function runProfileActivation(
   const failures: { bundleId: string; target: string; reason: string }[] = [];
   const writtenByTarget: Record<string, string[]> = {};
 
-  for (const target of targets) {
+  for (const target of effectiveTargets) {
     const writer = createWriterFactory(ctx, {})(target);
     const written: string[] = [];
     const lockPath = lockfilePathForTarget(ctx, target);

--- a/packages/cli/src/commands/target-add.ts
+++ b/packages/cli/src/commands/target-add.ts
@@ -17,6 +17,8 @@ import type {
   TargetType,
 } from '@ai-primitives-hub/core';
 import {
+  normalizePrimitiveKind,
+  PRIMITIVE_KINDS,
   TARGET_TYPES,
 } from '@ai-primitives-hub/core';
 import {
@@ -130,6 +132,20 @@ function validateTargetInputs(opts: TargetAddOptions): RegistryError | null {
   if (typeError) {
     return typeError;
   }
+  if (opts.allowedKinds !== undefined && opts.allowedKinds.length > 0) {
+    const invalidKinds = opts.allowedKinds
+      .split(',')
+      .map((kind) => kind.trim())
+      .filter((kind) => kind.length > 0 && normalizePrimitiveKind(kind) === null);
+    if (invalidKinds.length > 0) {
+      return new RegistryError({
+        code: 'USAGE.MISSING_FLAG',
+        message: `target add: invalid --allowed-kinds value${invalidKinds.length === 1 ? '' : 's'}: ${invalidKinds.join(', ')}`,
+        hint: `Use canonical primitive kinds: ${PRIMITIVE_KINDS.join(', ')}`,
+        context: { invalidKinds }
+      });
+    }
+  }
   return null;
 }
 
@@ -158,11 +174,14 @@ function buildTargetAddError(cause: unknown, opts: TargetAddOptions): RegistryEr
  * @param allowedKinds Comma-separated kinds.
  * @returns Array of kinds.
  */
-function parseAllowedKinds(allowedKinds: string | undefined): string[] | undefined {
+function parseAllowedKinds(allowedKinds: string | undefined): Target['allowedKinds'] | undefined {
   if (allowedKinds === undefined || allowedKinds.length === 0) {
     return undefined;
   }
-  return allowedKinds.split(',').map((s) => s.trim()).filter((s) => s.length > 0);
+  return allowedKinds
+    .split(',')
+    .map((s) => normalizePrimitiveKind(s))
+    .filter((kind): kind is NonNullable<typeof kind> => kind !== null);
 }
 
 /**
@@ -173,7 +192,7 @@ function parseAllowedKinds(allowedKinds: string | undefined): string[] | undefin
  * @param allowedKinds Allowed kinds.
  * @returns Target configuration.
  */
-function buildCopilotCliTarget(opts: TargetAddOptions, type: TargetType, allowedKinds: string[] | undefined): Target {
+function buildCopilotCliTarget(opts: TargetAddOptions, type: TargetType, allowedKinds: Target['allowedKinds']): Target {
   return {
     name: opts.name,
     type,
@@ -192,7 +211,7 @@ function buildCopilotCliTarget(opts: TargetAddOptions, type: TargetType, allowed
  * @param allowedKinds Allowed kinds.
  * @returns Target configuration.
  */
-function buildStandardTarget(opts: TargetAddOptions, type: TargetType, scope: string, allowedKinds: string[] | undefined): Target {
+function buildStandardTarget(opts: TargetAddOptions, type: TargetType, scope: string, allowedKinds: Target['allowedKinds']): Target {
   return {
     name: opts.name,
     type,

--- a/packages/cli/src/commands/target-types.ts
+++ b/packages/cli/src/commands/target-types.ts
@@ -26,8 +26,13 @@ const TARGET_DESCRIPTIONS: Record<string, string> = {
   'vscode-insiders': 'VS Code Insiders (user scope — ~/.config/Code - Insiders/User/prompts/)',
   'copilot-cli': 'GitHub Copilot CLI (user scope — ~/.config/github-copilot/prompts/)',
   kiro: 'Kiro IDE',
+  'kiro-cli': 'Kiro CLI',
   windsurf: 'Windsurf IDE (Codeium)',
-  'claude-code': 'Anthropic Claude Code'
+  'claude-code': 'Anthropic Claude Code',
+  cursor: 'Cursor',
+  opencode: 'OpenCode',
+  devin: 'Devin',
+  'devin-cli': 'Devin CLI'
 };
 
 /**

--- a/packages/cli/src/commands/uninstall.ts
+++ b/packages/cli/src/commands/uninstall.ts
@@ -46,6 +46,7 @@ import {
   loadTargets,
   lockfilePathForTarget,
   Option,
+  resolveEffectiveTarget,
 } from '../framework';
 import {
   type CommandDefinition,
@@ -196,7 +197,8 @@ export class UninstallCommand extends BaseUninstallCommand {
 
     try {
       const targetName = await resolveTargetName(opts.target, 'uninstall', ctx, () => readTargets({ cwd: ctx.cwd(), fs: ctx.fs }));
-      const target = await resolveTarget(targetName, 'uninstall', ctx, () => readTargets({ cwd: ctx.cwd(), fs: ctx.fs }));
+      const configuredTarget = await resolveTarget(targetName, 'uninstall', ctx, () => readTargets({ cwd: ctx.cwd(), fs: ctx.fs }));
+      const target = resolveEffectiveTarget(ctx, configuredTarget, opts);
 
       if (opts.all === true) {
         return await performAllUninstall(opts, target, ctx, fmt);
@@ -240,12 +242,13 @@ export const createWriterFactory = (
   });
 
   return (target: Target): TargetWriter => {
-    // Use CLI flags to override target scope if specified
-    const scope = opts.scope ?? target.scope;
-    const commitMode = opts.commitMode ?? target.commitMode ?? 'commit';
-    const workspaceRoot = target.rootPath ?? ctx.cwd();
+    const effectiveTarget = resolveEffectiveTarget(ctx, target, opts);
+    const scope = effectiveTarget.scope;
+    const commitMode = effectiveTarget.commitMode ?? 'commit';
+    const workspaceRoot = effectiveTarget.rootPath ?? ctx.cwd();
 
-    if (scope === 'repository') {
+    const copilotLikeTargets = new Set<string>(['vscode', 'vscode-insiders', 'copilot-cli']);
+    if (scope === 'repository' && copilotLikeTargets.has(effectiveTarget.type)) {
       const writer = new RepositoryScopeWriter({
         fs: ctx.fs,
         workspaceRoot,
@@ -254,7 +257,7 @@ export const createWriterFactory = (
       return new RepositoryScopeWriterAdapter(writer);
     }
     // Default to FileTreeTargetWriter for user scope
-    const transformer = transformerRegistry.getTransformer(target.type);
+    const transformer = transformerRegistry.getTransformer(effectiveTarget.type);
     return new FileTreeTargetWriter({
       fs: ctx.fs,
       env: ctx.env,
@@ -348,8 +351,7 @@ async function findBundleEntry(
   opts: UninstallOptions,
   ctx: Context
 ): Promise<LockfileBundleEntry | null> {
-  const scope = opts.scope ?? target.scope;
-  if (scope === 'repository') {
+  if (target.scope === 'repository') {
     const pipeline = new UninstallPipeline({
       fs: ctx.fs,
       target,
@@ -376,8 +378,7 @@ async function findAllBundleEntries(
   opts: UninstallOptions,
   ctx: Context
 ): Promise<Record<string, LockfileBundleEntry>> {
-  const scope = opts.scope ?? target.scope;
-  if (scope === 'repository') {
+  if (target.scope === 'repository') {
     const pipeline = new UninstallPipeline({
       fs: ctx.fs,
       target,
@@ -451,12 +452,11 @@ async function performBundleUninstall(
     return 0;
   }
 
-  const scope = opts.scope ?? target.scope;
   const writerFactory = createWriterFactory(ctx, opts);
   let result: UninstallResult;
   let lockPath: string;
-  if (scope === 'repository') {
-    const commitMode = entry.commitMode ?? opts.commitMode ?? target.commitMode ?? 'commit';
+  if (target.scope === 'repository') {
+    const commitMode = entry.commitMode ?? target.commitMode ?? 'commit';
     lockPath = lockfilePathForTarget(ctx, target, commitMode);
     const pipeline = new UninstallPipeline({
       fs: ctx.fs,
@@ -550,8 +550,7 @@ async function performLockfileUninstall(
 
   const writerFactory = createWriterFactory(ctx, opts);
   let results: UninstallResult[];
-  const scope = opts.scope ?? target.scope;
-  if (scope === 'repository') {
+  if (target.scope === 'repository') {
     const pipeline = new UninstallPipeline({
       fs: ctx.fs,
       target,
@@ -636,9 +635,8 @@ async function performAllUninstall(
   }
 
   const writerFactory = createWriterFactory(ctx, opts);
-  const scope = opts.scope ?? target.scope;
   let results: UninstallResult[];
-  if (scope === 'repository') {
+  if (target.scope === 'repository') {
     const pipeline = new UninstallPipeline({
       fs: ctx.fs,
       target,
@@ -745,7 +743,8 @@ export const createUninstallCommand = (
 
       try {
         const targetName = await resolveTargetName(opts.target, 'uninstall', ctx, () => readTargets({ cwd: ctx.cwd(), fs: ctx.fs }));
-        const target = await resolveTarget(targetName, 'uninstall', ctx, () => readTargets({ cwd: ctx.cwd(), fs: ctx.fs }));
+        const configuredTarget = await resolveTarget(targetName, 'uninstall', ctx, () => readTargets({ cwd: ctx.cwd(), fs: ctx.fs }));
+        const target = resolveEffectiveTarget(ctx, configuredTarget, opts);
 
         if (opts.all === true) {
           return await performAllUninstall(opts, target, ctx, fmt);

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -23,6 +23,7 @@ import {
   upsertBundleEntry,
   upsertSource,
   writeLockfile,
+  writeTargetSafely,
 } from '@ai-primitives-hub/app';
 import type {
   HttpClient,
@@ -33,6 +34,7 @@ import type {
   TokenProvider,
 } from '@ai-primitives-hub/core';
 import {
+  getInstallableBundleFiles,
   validateManifest,
 } from '@ai-primitives-hub/core';
 import {
@@ -60,6 +62,7 @@ import {
   loadTargets,
   lockfilePathForTarget,
   Option,
+  resolveEffectiveTarget,
 } from '../framework';
 import {
   type Context,
@@ -213,10 +216,11 @@ export class UpdateCommand extends BaseUpdateCommand {
 
     try {
       const targetName = await resolveTargetName(opts.target, 'update', ctx, () => readTargets({ cwd: ctx.cwd(), fs: ctx.fs }));
-      const target = await resolveTarget(targetName, 'update', ctx, () => readTargets({ cwd: ctx.cwd(), fs: ctx.fs }));
+      const configuredTarget = await resolveTarget(targetName, 'update', ctx, () => readTargets({ cwd: ctx.cwd(), fs: ctx.fs }));
+      const target = resolveEffectiveTarget(ctx, configuredTarget, opts);
 
-      const commitMode = opts.commitMode ?? target.commitMode ?? 'commit';
-      const scope = opts.scope ?? target.scope;
+      const commitMode = target.commitMode ?? 'commit';
+      const scope = target.scope;
       const lockPath = opts.lockfile !== undefined && opts.lockfile.length > 0
         ? (path.isAbsolute(opts.lockfile) ? opts.lockfile : path.join(ctx.cwd(), opts.lockfile))
         : lockfilePathForTarget(ctx, target, commitMode);
@@ -410,7 +414,8 @@ function renderNoUpdates(ctx: Context, fmt: OutputFormat, checked: number, skipp
  * @returns A TargetWriter.
  */
 function writerFor(ctx: Context, target: Target, scope: string, commitMode: RepositoryCommitMode): TargetWriter {
-  if (scope === 'repository') {
+  const effectiveScope = scope as Target['scope'];
+  if (effectiveScope === 'repository' && new Set(['vscode', 'vscode-insiders', 'copilot-cli']).has(target.type)) {
     const writer = new RepositoryScopeWriter({
       fs: ctx.fs,
       workspaceRoot: target.rootPath ?? ctx.cwd(),
@@ -489,7 +494,8 @@ async function applyUpdate(
   const manifest = validateManifest(files, { expectedId: undefined, expectedVersion: undefined });
 
   const writer = writerFor(ctx, target, scope, commitMode);
-  await writer.write(target, files);
+  const targetFiles = getInstallableBundleFiles(files, manifest);
+  const result = await writeTargetSafely(writer, target, targetFiles);
 
   const entry: LockfileBundleEntry = {
     version: manifest.version,
@@ -497,7 +503,7 @@ async function applyUpdate(
     sourceType: candidate.entry.sourceType,
     checksum: dl.sha256,
     installedAt: new Date().toISOString(),
-    files: checksumFiles(files)
+    files: checksumFiles(targetFiles, result.writtenBundlePaths ?? targetFiles.keys())
   };
   if (scope === 'repository') {
     entry.commitMode = commitMode;

--- a/packages/cli/src/doctor/diagnostics.ts
+++ b/packages/cli/src/doctor/diagnostics.ts
@@ -4,17 +4,41 @@
  * `doctor diagnostics` runs a self-contained end-to-end smoke test in a
  * temporary directory, exercising the same command sequence as the E2E user
  * flow script. It is fully idempotent and re-entrant: every run creates a
- * fresh temp workspace, and every run cleans up that workspace before exiting.
+ * fresh temp workspace, and every run cleans up that workspace before exiting
+ * unless retention is explicitly requested.
  *
  * The runner captures stdout/stderr and exit code for each step, so the
  * diagnostic report can show exactly what the system saw and produced.
  * @module doctor/diagnostics
  */
+import {
+  spawnSync,
+} from 'node:child_process';
+import {
+  readFile as readBinaryFile,
+} from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import {
+  resolveUserConfigPaths,
+} from '@ai-primitives-hub/app';
+import {
+  getInstallableBundleFiles,
+  isReleaseDeploymentManifest,
+  validateManifest,
+} from '@ai-primitives-hub/core';
+import {
+  ZipBundleExtractor,
+} from '@ai-primitives-hub/infra';
+import {
+  BundleBuildCommand,
+} from '../commands/bundle-build';
+import {
   BundleManifestCommand,
 } from '../commands/bundle-manifest';
+import {
+  CollectionAffectedCommand,
+} from '../commands/collection-affected';
 import {
   CollectionListCommand,
 } from '../commands/collection-list';
@@ -25,6 +49,9 @@ import {
   ConfigGetCommand,
 } from '../commands/config-get';
 import {
+  ConfigListCommand,
+} from '../commands/config-list';
+import {
   ExplainCommand,
 } from '../commands/explain';
 import {
@@ -32,9 +59,13 @@ import {
   HubCreateCommand,
   HubListCommand,
   HubRefreshCommand,
+  HubRemoveCommand,
   HubSyncCommand,
   HubUseCommand,
 } from '../commands/hub';
+import {
+  IndexBenchCommand,
+} from '../commands/index-bench';
 import {
   IndexBuildCommand,
 } from '../commands/index-build';
@@ -44,6 +75,9 @@ import {
 import {
   IndexExportCommand,
 } from '../commands/index-export';
+import {
+  IndexReportCommand,
+} from '../commands/index-report';
 import {
   IndexSearchCommand,
 } from '../commands/index-search';
@@ -84,6 +118,9 @@ import {
   TargetListCommand,
 } from '../commands/target-list';
 import {
+  TargetRemoveCommand,
+} from '../commands/target-remove';
+import {
   TargetTypesCommand,
 } from '../commands/target-types';
 import {
@@ -92,6 +129,9 @@ import {
 import {
   UpdateCommand,
 } from '../commands/update';
+import {
+  VersionComputeCommand,
+} from '../commands/version-compute';
 import {
   type CapturedOutputStream,
   type CommandClass,
@@ -108,6 +148,8 @@ export interface DiagnosticsOptions {
   commandClasses: CommandClass[];
   /** Print extra per-step progress to the parent stderr. */
   verbose?: boolean;
+  /** Keep the temporary workspace after the run for post-mortem inspection. */
+  retainWorkspace?: boolean;
 }
 
 /** A single step in the diagnostic report. */
@@ -140,6 +182,8 @@ export interface DiagnosticsResult {
   steps: DiagnosticStep[];
   /** Human-readable summary line. */
   summary: string;
+  /** True when the temporary workspace was intentionally retained. */
+  workspaceRetained: boolean;
 }
 
 const createCapturingStream = (): CapturedOutputStream => {
@@ -289,11 +333,17 @@ const prepareWorkspace = async (
   bundleId: string;
   sourceId: string;
   profileId: string;
+  governedCollectionFile: string;
+  governedBundleOutDir: string;
+  governedBundleSubDir: string;
+  governedBundleId: string;
 }> => {
   const fsPromises = ctx.fs;
   const bundleDir = path.join(workspace, 'bundle');
   const hubDir = path.join(workspace, 'hub');
   const targetDir = path.join(workspace, 'target');
+  const governedBundleOutDir = path.join(workspace, 'governed-dist');
+  const governedBundleSubDir = path.join(workspace, 'governed-bundle');
 
   await fsPromises.mkdir(bundleDir, { recursive: true });
   await fsPromises.mkdir(hubDir, { recursive: true });
@@ -315,6 +365,36 @@ const prepareWorkspace = async (
     TEST_SKILL
   );
 
+  await fsPromises.mkdir(path.join(workspace, 'prompts'), { recursive: true });
+  await fsPromises.mkdir(path.join(workspace, 'skills', 'governed-skill'), { recursive: true });
+  await fsPromises.mkdir(path.join(workspace, 'docs'), { recursive: true });
+  await fsPromises.writeFile(
+    path.join(workspace, 'prompts', 'governed.prompt.md'),
+    GOVERNED_PROMPT
+  );
+  await fsPromises.writeFile(
+    path.join(workspace, 'skills', 'governed-skill', 'SKILL.md'),
+    GOVERNED_SKILL
+  );
+  // This source file is intentionally committed so the governed planner's
+  // ignored-path handling is exercised for skill directories.
+  await fsPromises.writeFile(
+    path.join(workspace, 'skills', 'governed-skill', 'cached.pyc'),
+    'diagnostic cache bytes\n'
+  );
+  await fsPromises.writeFile(
+    path.join(workspace, 'docs', 'governed-readme.md'),
+    GOVERNED_README
+  );
+  await fsPromises.writeFile(
+    path.join(workspace, 'LICENSE'),
+    GOVERNED_LICENSE
+  );
+  await fsPromises.writeFile(
+    path.join(workspace, 'package.json'),
+    GOVERNED_PACKAGE_JSON
+  );
+
   const hubConfig = HUB_CONFIG
     .replace(/\{\{BUNDLE_DIR\}\}/g, localFooDir)
     .replace(/\{\{BUNDLE_ID\}\}/g, 'local-foo')
@@ -329,12 +409,18 @@ const prepareWorkspace = async (
     path.join(collectionsDir, 'foo.collection.yml'),
     COLLECTION_YML
   );
+  await fsPromises.writeFile(
+    path.join(collectionsDir, 'governed.collection.yml'),
+    GOVERNED_COLLECTION_YML
+  );
 
   const goldFile = path.join(workspace, 'gold-queries.json');
   await fsPromises.writeFile(goldFile, GOLD_QUERIES);
 
   const exportDir = path.join(workspace, 'exports');
   await fsPromises.mkdir(exportDir, { recursive: true });
+
+  initializeGitRepository(workspace);
 
   return {
     bundleDir,
@@ -348,8 +434,38 @@ const prepareWorkspace = async (
     hubId: 'local-test-hub',
     bundleId: 'local-foo',
     sourceId: 'local-foo-src',
-    profileId: 'backend'
+    profileId: 'backend',
+    governedCollectionFile: 'collections/governed.collection.yml',
+    governedBundleOutDir,
+    governedBundleSubDir,
+    governedBundleId: 'governed-foo'
   };
+};
+
+/**
+ * Initialize the synthetic repository required by governed release planning.
+ * @param workspace Diagnostic workspace.
+ */
+const initializeGitRepository = (workspace: string): void => {
+  const runGit = (args: string[]): void => {
+    const result = spawnSync('git', args, {
+      cwd: workspace,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+    if (result.status !== 0) {
+      const stderr = typeof result.stderr === 'string' ? result.stderr.trim() : '';
+      throw new Error(`Git command failed: git ${args.join(' ')}${stderr ? `: ${stderr}` : ''}`);
+    }
+  };
+
+  runGit(['init']);
+  runGit(['config', 'user.email', 'doctor-diagnostics@example.invalid']);
+  runGit(['config', 'user.name', 'AI Primitives Hub Diagnostics']);
+  runGit(['config', 'commit.gpgsign', 'false']);
+  runGit(['remote', 'add', 'origin', 'https://github.com/example/diagnostic-collection.git']);
+  runGit(['add', '.']);
+  runGit(['commit', '-m', 'diagnostic governed collection']);
 };
 
 const DEPLOYMENT_MANIFEST = `id: local-foo
@@ -371,6 +487,34 @@ const TEST_SKILL = `# Test Skill
 
 A diagnostic skill.
 `;
+
+const GOVERNED_PROMPT = `# Governed Prompt
+
+## Description: A governed diagnostic prompt.
+`;
+
+const GOVERNED_SKILL = `# Governed Skill
+
+## Description: A governed diagnostic skill.
+`;
+
+const GOVERNED_README = `# Governed Diagnostic Collection
+
+Evidence-bearing README included in the release archive.
+`;
+
+const GOVERNED_LICENSE = `Diagnostic license text.
+`;
+
+const GOVERNED_PACKAGE_JSON = JSON.stringify({
+  name: 'diagnostic-collection',
+  version: '1.0.0',
+  description: 'Synthetic governed collection for diagnostics',
+  license: 'MIT',
+  repository: {
+    url: 'https://github.com/example/diagnostic-collection.git'
+  }
+}, null, 2) + '\n';
 
 const HUB_CONFIG = `version: 1.0.0
 metadata:
@@ -404,6 +548,18 @@ items:
   - path: bundle/local-foo/prompts/hello.prompt.md
     kind: prompt
   - path: bundle/local-foo/skills/test-skill/SKILL.md
+    kind: skill
+`;
+
+const GOVERNED_COLLECTION_YML = `id: governed-foo
+name: Governed Diagnostic Collection
+description: Synthetic governed collection for release diagnostics
+readme:
+  path: docs/governed-readme.md
+items:
+  - path: prompts/governed.prompt.md
+    kind: prompt
+  - path: skills/governed-skill/SKILL.md
     kind: skill
 `;
 
@@ -448,6 +604,113 @@ const extractFirstPrimitiveId = (stdout: string): string => {
 };
 
 /**
+ * Extract a bundle asset path from a JSON command response.
+ * @param stdout Captured stdout from `bundle build`.
+ * @param fallbackPath Expected path when the command did not emit JSON.
+ * @returns Bundle ZIP path.
+ */
+const extractBundleZipPath = (stdout: string, fallbackPath: string): string => {
+  try {
+    const parsed = JSON.parse(stdout) as { data?: { zipAsset?: string } };
+    return parsed.data?.zipAsset ?? fallbackPath;
+  } catch {
+    return fallbackPath;
+  }
+};
+
+/**
+ * Verify a governed bundle archive end-to-end, including its inventory,
+ * immutable provenance, evidence files, and installable projection.
+ * @param zipPath Bundle ZIP path.
+ * @param expectedId Expected collection/bundle id.
+ * @param expectedVersion Expected bundle version.
+ * @returns Safe, serializable verification details.
+ */
+const verifyGovernedArchive = async (
+  zipPath: string,
+  expectedId: string,
+  expectedVersion: string
+): Promise<Record<string, unknown>> => {
+  const files = await new ZipBundleExtractor().extract(await readBinaryFile(zipPath));
+  const manifest = validateManifest(files, {
+    expectedId,
+    expectedVersion
+  });
+  if (!isReleaseDeploymentManifest(manifest)) {
+    throw new Error('governed bundle did not declare formatVersion: 1');
+  }
+
+  const archiveFiles = [...files.keys()].toSorted();
+  const inventoryFiles = manifest.files.map((file) => file.path).toSorted();
+  const actualNonManifestFiles = archiveFiles
+    .filter((filePath) => filePath !== 'deployment-manifest.yml');
+  if (JSON.stringify(inventoryFiles) !== JSON.stringify(actualNonManifestFiles)) {
+    throw new Error('governed manifest inventory does not cover the complete archive');
+  }
+
+  const expectedInstallableFiles = [
+    'deployment-manifest.yml',
+    'prompts/governed.prompt.md',
+    'skills/governed-skill/SKILL.md'
+  ];
+  const installableFiles = [...getInstallableBundleFiles(files, manifest).keys()].toSorted();
+  if (JSON.stringify(installableFiles) !== JSON.stringify(expectedInstallableFiles.toSorted())) {
+    throw new Error('governed installable projection includes unexpected metadata or misses content');
+  }
+  if (archiveFiles.some((filePath) => filePath.endsWith('.pyc'))) {
+    throw new Error('ignored cache content leaked into the governed archive');
+  }
+
+  const provenance = manifest.provenance;
+  if (!/^[a-f0-9]{40,64}$/i.test(provenance.revision)) {
+    throw new Error('governed provenance does not contain an immutable Git revision');
+  }
+  if (provenance.source !== 'https://github.com/example/diagnostic-collection') {
+    throw new Error(`unexpected governed provenance source: ${provenance.source}`);
+  }
+  if (provenance.sourceSnapshotPath !== 'metadata/source/collections/governed.collection.yml') {
+    throw new Error('governed provenance is missing the collection source snapshot path');
+  }
+  if (provenance.licensePath !== 'LICENSE' || manifest.readme !== 'README.md') {
+    throw new Error('governed release evidence paths are incomplete');
+  }
+
+  return {
+    formatVersion: manifest.formatVersion,
+    archiveFiles,
+    inventoryFiles,
+    installableFiles,
+    inventoryCount: inventoryFiles.length,
+    revision: provenance.revision,
+    source: provenance.source,
+    readme: manifest.readme,
+    licensePath: provenance.licensePath
+  };
+};
+
+/**
+ * Materialize a governed ZIP into a local bundle directory for install/replay
+ * diagnostics. The synthetic archive intentionally contains text-only files.
+ * @param fsAbstraction Filesystem abstraction.
+ * @param zipPath Bundle ZIP path.
+ * @param destination Directory to write.
+ * @returns Archive paths written.
+ */
+const materializeBundleArchive = async (
+  fsAbstraction: FsAbstraction,
+  zipPath: string,
+  destination: string
+): Promise<string[]> => {
+  const files = await new ZipBundleExtractor().extract(await readBinaryFile(zipPath));
+  for (const [filePath, content] of files) {
+    const fullPath = path.join(destination, filePath);
+    await fsAbstraction.mkdir(path.dirname(fullPath), { recursive: true });
+    await fsAbstraction.writeFile(fullPath, new TextDecoder().decode(content));
+  }
+  return [...files.keys()].toSorted();
+};
+
+/**
  * Verify that a file exists on disk and record the result.
  * @param fsAbstraction fs abstraction.
  * @param file File to check.
@@ -465,8 +728,9 @@ const fileExists = async (fsAbstraction: FsAbstraction, file: string): Promise<b
  * Run the full diagnostic suite.
  *
  * The workspace is created fresh, populated with fixtures, exercised, and
- * then removed. If a step fails, subsequent steps still run so the report
- * shows the full picture; `ok` is false if any step exited non-zero.
+ * then removed unless retention is requested. If a step fails, subsequent
+ * steps still run so the report shows the full picture; `ok` is false if any
+ * step exited non-zero.
  * @param opts Runner options.
  * @returns Aggregate diagnostics result.
  */
@@ -485,6 +749,41 @@ export const runDiagnostics = async (
     const step = await runDiagnosticStep(opts, workspace, name, argv, input);
     steps.push(step);
     return step;
+  };
+
+  const runVerificationStep = async (
+    name: string,
+    verify: () => Promise<Record<string, unknown>>,
+    input?: Record<string, unknown>
+  ): Promise<DiagnosticStep> => {
+    const started = Date.now();
+    try {
+      const output = await verify();
+      const step: DiagnosticStep = {
+        name,
+        argv: [],
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+        input,
+        output,
+        durationMs: Date.now() - started
+      };
+      steps.push(step);
+      return step;
+    } catch (err) {
+      const step: DiagnosticStep = {
+        name,
+        argv: [],
+        exitCode: 1,
+        stdout: '',
+        stderr: err instanceof Error ? err.message : String(err),
+        input,
+        durationMs: Date.now() - started
+      };
+      steps.push(step);
+      return step;
+    }
   };
 
   try {
@@ -552,9 +851,13 @@ export const runDiagnostics = async (
       fsAbstraction,
       path.join(fixtures.targetDir, 'skills', 'test-skill', 'SKILL.md')
     );
-    await runStep('verify-installed', [
+    const verifyInstalledStep = await runStep('verify-installed', [
       'status', '-o', 'json'
     ], { promptInstalled, skillInstalled });
+    if (!promptInstalled || !skillInstalled) {
+      verifyInstalledStep.exitCode = 1;
+      verifyInstalledStep.stderr = 'installed fixture files were not found in the target';
+    }
 
     // Step 10: Build a local primitive index.
     const indexPath = path.join(workspace, 'primitive-index.json');
@@ -643,13 +946,30 @@ export const runDiagnostics = async (
       '-o', 'json'
     ], { goldFile: fixtures.goldFile });
 
-    // Step 20: Deactivate the profile.
+    // Step 20: Run the local search benchmark against the generated index.
+    await runStep('index-bench', [
+      'index', 'bench',
+      '--gold', fixtures.goldFile,
+      '--index', indexPath,
+      '--iterations', '1',
+      '-o', 'json'
+    ], { goldFile: fixtures.goldFile, indexPath, iterations: 1 });
+
+    // Step 21: Render an empty local harvest report without network access.
+    await runStep('index-report', [
+      'index', 'report',
+      '--progress-file', path.join(workspace, 'harvest-progress.jsonl'),
+      '--cache-dir', path.join(workspace, 'harvest-cache'),
+      '-o', 'json'
+    ]);
+
+    // Step 22: Deactivate the profile.
     await runStep('deactivate-profile', [
       'profile', 'deactivate',
       '-o', 'json'
     ]);
 
-    // Step 21: Verify resources were removed.
+    // Step 23: Verify resources were removed.
     const promptRemoved = !(await fileExists(
       fsAbstraction,
       path.join(fixtures.targetDir, 'prompts', 'hello.prompt.md')
@@ -658,11 +978,15 @@ export const runDiagnostics = async (
       fsAbstraction,
       path.join(fixtures.targetDir, 'skills', 'test-skill', 'SKILL.md')
     ));
-    await runStep('verify-removed', [
+    const verifyRemovedStep = await runStep('verify-removed', [
       'status', '-o', 'json'
     ], { promptRemoved, skillRemoved });
+    if (!promptRemoved || !skillRemoved) {
+      verifyRemovedStep.exitCode = 1;
+      verifyRemovedStep.stderr = 'deactivated profile left fixture files in the target';
+    }
 
-    // Step 22: Direct bundle install.
+    // Step 24: Direct bundle install.
     await runStep('install-bundle', [
       'install', fixtures.bundleId,
       '--from', fixtures.bundleSubDir,
@@ -670,81 +994,95 @@ export const runDiagnostics = async (
       '-o', 'json'
     ], { bundleSubDir: fixtures.bundleSubDir });
 
-    // Step 23: Update dry-run (should report 0 updates).
+    // Step 25: Update dry-run (should report 0 updates).
     await runStep('update-dry-run', [
       'update', '--dry-run', '--no-hub-sync', '--target', 'copilot',
       '-o', 'json'
     ]);
 
-    // Step 24: Uninstall all bundles for the target.
+    // Step 26: Uninstall all bundles for the target.
     await runStep('uninstall-bundle', [
       'uninstall', '--target', 'copilot', '--all',
       '-o', 'json'
     ]);
 
-    // Step 25: List configured targets.
+    // Step 27: List configured targets.
     await runStep('target-list', [
       'target', 'list',
       '-o', 'json'
     ]);
 
-    // Step 26: List supported target types.
+    // Step 28: List supported target types.
     await runStep('target-types', [
       'target', 'types',
       '-o', 'json'
     ]);
 
-    // Step 27: List imported hubs.
+    // Step 29: List imported hubs.
     await runStep('hub-list', [
       'hub', 'list',
       '-o', 'json'
     ]);
 
-    // Step 28: Refresh the active hub.
+    // Step 30: Refresh the active hub.
     await runStep('hub-refresh', [
       'hub', 'refresh',
       '-o', 'json'
     ]);
 
-    // Step 29: Scaffold a hub-config.yml skeleton.
+    // Step 31: Scaffold a hub-config.yml skeleton.
     await runStep('hub-create', [
       'hub', 'create', '--name', 'Diagnostic Hub',
       '--out', path.join(workspace, 'scaffolded-hub'),
       '-o', 'json'
     ]);
 
-    // Step 30: Add a detached source.
+    // Step 32: Add a detached source.
     await runStep('source-add', [
       'source', 'add', '--type', 'local', '--url', fixtures.bundleSubDir,
       '--id', 'diag-source', '--name', 'Diagnostic Source',
       '-o', 'json'
     ], { bundleSubDir: fixtures.bundleSubDir });
 
-    // Step 31: List sources across all hubs.
+    // Step 33: List sources across all hubs.
     await runStep('source-list', [
       'source', 'list',
       '-o', 'json'
     ]);
 
-    // Step 32: Remove the detached source.
+    // Step 34: Remove the detached source.
     await runStep('source-remove', [
       'source', 'remove', 'diag-source',
       '-o', 'json'
     ]);
 
-    // Step 33: List collections (from collections/ dir in workspace).
+    // Step 35: List collections (from collections/ dir in workspace).
     await runStep('collection-list', [
       'collection', 'list',
       '-o', 'json'
     ], { collectionsDir: fixtures.collectionsDir });
 
-    // Step 34: Validate collections.
+    // Step 36: Validate collections.
     await runStep('collection-validate', [
       'collection', 'validate',
       '-o', 'json'
     ]);
 
-    // Step 35: Generate a deployment manifest from the collection.
+    // Step 37: Identify collections affected by a changed primitive.
+    await runStep('collection-affected', [
+      'collection', 'affected',
+      '--changed-path', 'prompts/governed.prompt.md',
+      '-o', 'json'
+    ]);
+
+    // Step 38: Compute a deterministic next version from local Git tags.
+    await runStep('version-compute', [
+      'version', 'compute',
+      '--collection-file', fixtures.governedCollectionFile,
+      '-o', 'json'
+    ], { collectionFile: fixtures.governedCollectionFile });
+
+    // Step 39: Generate a deployment manifest from the collection.
     await runStep('bundle-manifest', [
       'bundle', 'manifest',
       '--version', '1.0.0',
@@ -753,35 +1091,149 @@ export const runDiagnostics = async (
       '-o', 'json'
     ]);
 
-    // Step 36: Explain an error code.
+    // Build a governed release from the committed Git fixture.
+    const governedZipFallback = path.join(
+      fixtures.governedBundleOutDir,
+      fixtures.governedBundleId,
+      `${fixtures.governedBundleId}.bundle.zip`
+    );
+    const governedBuildStep = await runStep('build-governed-bundle', [
+      'bundle', 'build',
+      '--version', '2.3.4',
+      '--collection-file', fixtures.governedCollectionFile,
+      '--out-dir', fixtures.governedBundleOutDir,
+      '-o', 'json'
+    ], {
+      collectionFile: fixtures.governedCollectionFile,
+      outDir: fixtures.governedBundleOutDir
+    });
+    const governedZipPath = extractBundleZipPath(governedBuildStep.stdout, governedZipFallback);
+    await runVerificationStep('verify-governed-archive', () => verifyGovernedArchive(
+      governedZipPath,
+      fixtures.governedBundleId,
+      '2.3.4'
+    ), { zipPath: governedZipPath });
+    await runVerificationStep('materialize-governed-bundle', async () => ({
+      files: await materializeBundleArchive(
+        fsAbstraction,
+        governedZipPath,
+        fixtures.governedBundleSubDir
+      )
+    }), { zipPath: governedZipPath, bundleDir: fixtures.governedBundleSubDir });
+
+    // Install the governed archive through the normal local install path so
+    // the runtime's metadata/evidence filtering is covered as well.
+    await runStep('install-governed-bundle', [
+      'install', fixtures.governedBundleId,
+      '--from', fixtures.governedBundleSubDir,
+      '--target', 'copilot',
+      '-o', 'json'
+    ], { bundleSubDir: fixtures.governedBundleSubDir });
+    await runVerificationStep('verify-governed-install', async () => {
+      const targetInstallablePaths = [
+        'prompts/governed.prompt.md',
+        'skills/governed-skill/SKILL.md'
+      ];
+      const targetInstallable = await Promise.all(targetInstallablePaths.map(async (relativePath) => ({
+        path: relativePath,
+        present: await fileExists(fsAbstraction, path.join(fixtures.targetDir, relativePath))
+      })));
+      const metadataPaths = [
+        'README.md',
+        'LICENSE',
+        'metadata/source/collections/governed.collection.yml'
+      ];
+      const metadataPresent = await Promise.all(metadataPaths.map(async (relativePath) => ({
+        path: relativePath,
+        present: await fileExists(fsAbstraction, path.join(fixtures.targetDir, relativePath))
+      })));
+      const lockfilePath = resolveUserConfigPaths(buildDiagnosticEnv(opts.ctx, workspace)).userLockfile;
+      const lockfile = await fsAbstraction.readJson<{
+        bundles?: Record<string, { files?: { path: string }[] }>;
+      }>(lockfilePath);
+      const lockEntry = lockfile.bundles?.[fixtures.governedBundleId];
+      const lockfilePaths = lockEntry?.files?.map((file) => file.path).toSorted() ?? [];
+      if (targetInstallable.some((file) => !file.present)) {
+        throw new Error('governed install did not write every installable primitive');
+      }
+      if (metadataPresent.some((file) => file.present)) {
+        throw new Error('governed metadata or evidence was written into the target');
+      }
+      if (lockEntry === undefined || lockfilePaths.some((filePath) => metadataPaths.includes(filePath))) {
+        throw new Error('governed lockfile entry is missing or contains metadata paths');
+      }
+      return {
+        targetInstallable,
+        metadataPresent,
+        lockfilePath,
+        lockfilePaths
+      };
+    }, { targetDir: fixtures.targetDir });
+    await runStep('uninstall-governed-bundle', [
+      'uninstall', '--target', 'copilot', '--all',
+      '-o', 'json'
+    ]);
+    await runVerificationStep('verify-governed-removed', async () => {
+      const pathsToCheck = [
+        'prompts/governed.prompt.md',
+        'skills/governed-skill/SKILL.md'
+      ];
+      const removed = await Promise.all(pathsToCheck.map(async (relativePath) => ({
+        path: relativePath,
+        removed: !(await fileExists(fsAbstraction, path.join(fixtures.targetDir, relativePath)))
+      })));
+      if (removed.some((file) => !file.removed)) {
+        throw new Error('governed uninstall left installable files in the target');
+      }
+      return { removed };
+    }, { targetDir: fixtures.targetDir });
+
+    // Step 40: Explain an error code.
     await runStep('explain', [
       'explain', 'INDEX.NOT_FOUND',
       '-o', 'json'
     ]);
 
-    // Step 37: List CLI plugins.
+    // Step 41: List CLI plugins.
     await runStep('plugins-list', [
       'plugins', 'list',
       '-o', 'json'
     ]);
 
-    // Step 38: Read a config value.
+    // Step 42: Read a config value.
     await runStep('config-get', [
       'config', 'get', 'output.json.indent',
       '-o', 'json'
     ]);
 
-    // Step 39: Final status check.
+    // Step 43: List the complete resolved config.
+    await runStep('config-list', [
+      'config', 'list',
+      '-o', 'json'
+    ]);
+
+    // Step 44: Final status check.
     await runStep('final-status', [
       'status', '-o', 'json'
     ]);
 
-    // Step 40: Search alias as top-level command.
+    // Step 45: Search alias as top-level command.
     await runStep('search-alias', [
       'search', '--query', 'hello',
       '--index', indexPath,
       '-o', 'json'
     ]);
+
+    // Step 46: Exercise local target and hub cleanup commands last, after all
+    // other diagnostic flows no longer need either resource.
+    await runStep('target-remove', [
+      'target', 'remove', 'copilot',
+      '-o', 'json'
+    ]);
+    await runStep('hub-remove', [
+      'hub', 'remove', fixtures.hubId,
+      '-o', 'json'
+    ], { hubId: fixtures.hubId });
   } catch (err) {
     // Record the unexpected error as a synthetic step so the report always
     // explains why the run stopped.
@@ -795,23 +1247,28 @@ export const runDiagnostics = async (
       durationMs: 0
     });
   } finally {
-    // Always remove the workspace, even when steps fail.
-    try {
-      await fsAbstraction.remove(workspace, { recursive: true });
-    } catch {
-      // Best-effort cleanup; do not mask the real failure.
+    // Retention is deliberately opt-in, but it also applies to failed runs so
+    // callers can inspect the exact state that produced the failure.
+    if (opts.retainWorkspace !== true) {
+      try {
+        await fsAbstraction.remove(workspace, { recursive: true });
+      } catch {
+        // Best-effort cleanup; do not mask the real failure.
+      }
     }
   }
 
   const failed = steps.filter((s) => s.exitCode !== 0);
   const ok = failed.length === 0;
+  const workspaceRetained = await fileExists(fsAbstraction, workspace);
   return {
     ok,
     workspace,
     steps,
     summary: ok
       ? `all ${steps.length} diagnostic steps passed`
-      : `${failed.length} of ${steps.length} diagnostic steps failed`
+      : `${failed.length} of ${steps.length} diagnostic steps failed`,
+    workspaceRetained
   };
 };
 
@@ -821,23 +1278,29 @@ export const runDiagnostics = async (
  */
 export const getDiagnosticCommandClasses = (): CommandClass[] => [
   StatusCommand,
+  BundleBuildCommand,
+  ConfigListCommand,
   TargetAddCommand,
   TargetListCommand,
+  TargetRemoveCommand,
   TargetTypesCommand,
   HubAddCommand,
   HubUseCommand,
   HubSyncCommand,
   HubListCommand,
   HubRefreshCommand,
+  HubRemoveCommand,
   HubCreateCommand,
   ProfileListCommand,
   ProfileShowCommand,
   ProfileCurrentCommand,
   ProfileActivateCommand,
   ProfileDeactivateCommand,
+  IndexBenchCommand,
   IndexBuildCommand,
   IndexSearchCommand,
   IndexStatsCommand,
+  IndexReportCommand,
   IndexShortlistNewCommand,
   IndexShortlistAddCommand,
   IndexShortlistRemoveCommand,
@@ -851,9 +1314,11 @@ export const getDiagnosticCommandClasses = (): CommandClass[] => [
   SourceListCommand,
   SourceRemoveCommand,
   CollectionListCommand,
+  CollectionAffectedCommand,
   CollectionValidateCommand,
   BundleManifestCommand,
   ExplainCommand,
   PluginsListCommand,
-  ConfigGetCommand
+  ConfigGetCommand,
+  VersionComputeCommand
 ];

--- a/packages/cli/src/framework/index.ts
+++ b/packages/cli/src/framework/index.ts
@@ -100,6 +100,10 @@ export {
   findProjectLockfile,
   loadTargets,
   lockfilePathForTarget,
+  resolveEffectiveTarget,
+} from './target';
+export type {
+  TargetOverrides,
 } from './target';
 export {
   copyCommandPrototype,

--- a/packages/cli/src/framework/target.ts
+++ b/packages/cli/src/framework/target.ts
@@ -31,6 +31,46 @@ export const loadTargets = async (ctx: Context): Promise<Target[]> => {
 };
 
 /**
+ * CLI-only overrides that can change how a configured target is used for one
+ * command invocation.
+ */
+export interface TargetOverrides {
+  scope?: Target['scope'];
+  commitMode?: RepositoryCommitMode;
+}
+
+/**
+ * Derive the concrete target used by an operation.
+ *
+ * Scope and commit-mode flags must travel with the target all the way to the
+ * writer and lockfile helpers. Keeping them as separate local variables lets
+ * layout-aware writers observe the stale configured scope. Repository targets
+ * also need an explicit root so every downstream consumer resolves the same
+ * workspace when `--scope repository` is used without `--workspace-root`.
+ * @param ctx CLI context.
+ * @param target Configured target.
+ * @param overrides Per-invocation CLI overrides.
+ * @returns A new target containing the effective operation values.
+ */
+export const resolveEffectiveTarget = (
+  ctx: Context,
+  target: Target,
+  overrides: TargetOverrides = {}
+): Target => {
+  const scope = overrides.scope ?? target.scope;
+  const rootPath = target.rootPath === undefined || target.rootPath.length === 0
+    ? (scope === 'repository' ? ctx.cwd() : target.rootPath)
+    : target.rootPath;
+
+  return {
+    ...target,
+    ...(overrides.scope === undefined ? {} : { scope: overrides.scope }),
+    ...(overrides.commitMode === undefined ? {} : { commitMode: overrides.commitMode }),
+    ...(rootPath === undefined ? {} : { rootPath })
+  };
+};
+
+/**
  * Find the lockfile path for the current working directory.
  * @param ctx CLI context.
  * @returns Lockfile path or null if not found.

--- a/packages/cli/test/commands/collection-bundle.test.ts
+++ b/packages/cli/test/commands/collection-bundle.test.ts
@@ -23,7 +23,12 @@ import {
 import * as os from 'node:os';
 import * as path from 'node:path';
 import {
+  getInstallableBundleFiles,
+  validateManifest,
+} from '@ai-primitives-hub/core';
+import {
   NodeFileSystem,
+  ZipBundleExtractor,
 } from '@ai-primitives-hub/infra';
 import * as yaml from 'js-yaml';
 import {
@@ -78,6 +83,10 @@ interface JsonEnvelope<T> {
   warnings: string[];
 }
 
+// Windows CI can take longer than Vitest's default 10-second hook timeout
+// while initializing and removing a Git-backed real-filesystem fixture.
+const REAL_FS_HOOK_TIMEOUT_MS = 30_000;
+
 describe('collection/bundle/version/skill commands', () => {
   let workspace: string;
 
@@ -97,6 +106,11 @@ describe('collection/bundle/version/skill commands', () => {
 
   const parseJson = <T>(stdout: string): JsonEnvelope<T> => JSON.parse(stdout) as JsonEnvelope<T>;
 
+  const commitFixtureChanges = (): void => {
+    execFileSync('git', ['add', '.'], { cwd: workspace });
+    execFileSync('git', ['commit', '-m', 'fixture update'], { cwd: workspace, stdio: 'ignore' });
+  };
+
   beforeEach(async () => {
     workspace = await mkdtemp(path.join(os.tmpdir(), 'cli-collection-test-'));
     await mkdir(path.join(workspace, 'collections'), { recursive: true });
@@ -112,11 +126,18 @@ items:
     kind: prompt
 `
     );
-  });
+    await writeFile(path.join(workspace, 'LICENSE'), 'Test fixture license\n');
+    execFileSync('git', ['init'], { cwd: workspace, stdio: 'ignore' });
+    execFileSync('git', ['config', 'user.email', 'test@example.invalid'], { cwd: workspace });
+    execFileSync('git', ['config', 'user.name', 'Test Fixture'], { cwd: workspace });
+    execFileSync('git', ['remote', 'add', 'origin', 'https://github.com/example/test-collection.git'], { cwd: workspace });
+    execFileSync('git', ['add', '.'], { cwd: workspace });
+    execFileSync('git', ['commit', '-m', 'fixture'], { cwd: workspace, stdio: 'ignore' });
+  }, REAL_FS_HOOK_TIMEOUT_MS);
 
   afterEach(async () => {
     await rm(workspace, { recursive: true, force: true });
-  });
+  }, REAL_FS_HOOK_TIMEOUT_MS);
 
   describe('collection create', () => {
     it('creates a new collection file', async () => {
@@ -220,6 +241,7 @@ items:
     kind: prompt
 `
       );
+      commitFixtureChanges();
 
       const result = await run([
         'collection', 'affected', '--changed-path', 'docs/collection-overview.md', '-o', 'json'
@@ -252,6 +274,70 @@ items:
       const content = await readFile(outFile, 'utf8');
       expect(content).toContain('id: foo');
       expect(content).not.toContain('readme:');
+    });
+
+    it('keeps collection tags at the root and does not clone them onto items', async () => {
+      await writeFile(
+        path.join(workspace, 'collections', 'foo.collection.yml'),
+        `id: foo
+name: Foo Collection
+description: Test collection
+author: Test Author
+tags: [argos, splunk]
+items:
+  - path: prompts/hello.prompt.md
+    kind: prompt
+`
+      );
+
+      const outFile = path.join(workspace, 'deployment-manifest.yml');
+      const result = await run([
+        'bundle', 'manifest',
+        '--version', '1.0.0',
+        '--collection-file', 'collections/foo.collection.yml',
+        '--out-file', outFile,
+        '-o', 'json'
+      ]);
+      expect(result.exitCode).toBe(0);
+
+      const manifest = yaml.load(await readFile(outFile, 'utf8')) as {
+        tags?: string[];
+        prompts: { tags?: string[] }[];
+      };
+      expect(manifest.tags).toEqual(['argos', 'splunk']);
+      expect(manifest.prompts).toHaveLength(1);
+      expect(manifest.prompts[0].tags).toBeUndefined();
+    });
+
+    it('preserves item-specific tags without copying collection tags', async () => {
+      await writeFile(
+        path.join(workspace, 'collections', 'foo.collection.yml'),
+        `id: foo
+name: Foo Collection
+tags: [argos, pack]
+items:
+  - path: prompts/hello.prompt.md
+    kind: prompt
+    tags: [splunk]
+`
+      );
+
+      const outFile = path.join(workspace, 'deployment-manifest.yml');
+      const result = await run([
+        'bundle', 'manifest',
+        '--version', '1.0.0',
+        '--collection-file', 'collections/foo.collection.yml',
+        '--out-file', outFile,
+        '-o', 'json'
+      ]);
+      expect(result.exitCode).toBe(0);
+
+      const manifest = yaml.load(await readFile(outFile, 'utf8')) as {
+        tags?: string[];
+        prompts: { tags?: string[] }[];
+      };
+      expect(manifest.tags).toEqual(['argos', 'pack']);
+      expect(manifest.prompts[0].tags).toEqual(['splunk']);
     });
 
     it('generates the expected MCP fields and matches the legacy generator', async () => {
@@ -417,15 +503,117 @@ items:
   });
 
   describe('bundle build', () => {
+    it('builds a self-contained governed archive and retains metadata outside target content', async () => {
+      await mkdir(path.join(workspace, 'docs'), { recursive: true });
+      await writeFile(path.join(workspace, 'docs', 'collection-overview.md'), '# Overview\n');
+      await writeFile(path.join(workspace, 'LICENSE'), 'Example license\n');
+      await writeFile(
+        path.join(workspace, 'package.json'),
+        JSON.stringify({
+          name: 'example-collection',
+          license: 'Example-License',
+          repository: { url: 'https://github.com/example/example-collection.git' }
+        })
+      );
+      await writeFile(
+        path.join(workspace, 'collections', 'foo.collection.yml'),
+        `id: foo
+name: Foo Collection
+description: Test collection
+readme:
+  path: docs/collection-overview.md
+items:
+  - path: prompts/hello.prompt.md
+    kind: prompt
+`
+      );
+      commitFixtureChanges();
+
+      const result = await run([
+        'bundle', 'build', '--version', '1.0.0', '--collection-file', 'collections/foo.collection.yml', '-o', 'json'
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ zipAsset: string; manifestAsset: string }>(result.stdout);
+      const files = await new ZipBundleExtractor().extract(await readFile(envelope.data.zipAsset));
+      const manifest = validateManifest(files, { expectedId: 'foo', expectedVersion: '1.0.0' });
+
+      expect(manifest).toMatchObject({
+        formatVersion: 1,
+        items: [{ id: 'hello.prompt', path: 'prompts/hello.prompt.md', kind: 'prompt' }],
+        provenance: {
+          source: 'https://github.com/example/example-collection',
+          collectionPath: 'collections/foo.collection.yml',
+          sourceSnapshotPath: 'metadata/source/collections/foo.collection.yml',
+          license: 'Example-License',
+          licensePath: 'LICENSE'
+        }
+      });
+      expect([...files.keys()].toSorted()).toEqual([
+        'LICENSE',
+        'README.md',
+        'deployment-manifest.yml',
+        'metadata/source/collections/foo.collection.yml',
+        'prompts/hello.prompt.md'
+      ]);
+      expect([...getInstallableBundleFiles(files, manifest).keys()]).toEqual([
+        'deployment-manifest.yml',
+        'prompts/hello.prompt.md'
+      ]);
+      expect(yaml.load(await readFile(envelope.data.manifestAsset, 'utf8'))).toEqual(
+        yaml.load(new TextDecoder().decode(files.get('deployment-manifest.yml')))
+      );
+    });
+
     it('builds a non-trivial, reproducible bundle zip', async () => {
       const result = await run([
         'bundle', 'build', '--version', '1.0.0', '--collection-file', 'collections/foo.collection.yml', '-o', 'json'
       ]);
-      expect(result.exitCode).toBe(0);
+      expect(result.exitCode, `${result.stderr}\n${result.stdout}`).toBe(0);
       const envelope = parseJson<{ zipAsset: string; manifestAsset: string; readmeAsset?: string }>(result.stdout);
       const zipStat = await stat(envelope.data.zipAsset);
       expect(zipStat.size).toBeGreaterThan(0);
       expect(envelope.data.readmeAsset).toBeUndefined();
+    });
+
+    it('builds a legacy bundle with a warning when committed license text is absent', async () => {
+      await rm(path.join(workspace, 'LICENSE'));
+      await writeFile(
+        path.join(workspace, 'collections', 'foo.collection.yml'),
+        `id: foo
+name: Foo Collection
+license: MIT
+items:
+  - path: prompts/hello.prompt.md
+    kind: prompt
+`
+      );
+      commitFixtureChanges();
+
+      const result = await run([
+        'bundle', 'build', '--collection-file', 'collections/foo.collection.yml', '-o', 'json'
+      ]);
+
+      expect(result.exitCode, `${result.stderr}\n${result.stdout}`).toBe(0);
+      const envelope = parseJson<{ zipAsset: string; manifestAsset: string; version: string }>(result.stdout);
+      expect(envelope.data.version).toBe('0.0.0-dev');
+      expect(envelope.status).toBe('warning');
+      expect(envelope.warnings).toContain(
+        'No committed LICENSE, COPYING, or NOTICE file was found; building a legacy bundle without governed release evidence. Add license text to enable governed self-contained releases.'
+      );
+
+      const files = await new ZipBundleExtractor().extract(await readFile(envelope.data.zipAsset));
+      const manifest = validateManifest(files, { expectedId: 'foo', expectedVersion: '0.0.0-dev' });
+      expect(manifest).not.toHaveProperty('formatVersion');
+      expect(manifest).not.toHaveProperty('files');
+      expect(manifest).not.toHaveProperty('provenance');
+      expect([...files.keys()].toSorted()).toEqual([
+        'deployment-manifest.yml',
+        'prompts/hello.prompt.md'
+      ]);
+      expect(yaml.load(await readFile(envelope.data.manifestAsset, 'utf8'))).toEqual(
+        yaml.load(new TextDecoder().decode(files.get('deployment-manifest.yml')))
+      );
     });
 
     it('returns the declared README as a release asset', async () => {
@@ -442,24 +630,25 @@ items:
     kind: prompt
 `
       );
+      commitFixtureChanges();
 
       const result = await run([
         'bundle', 'build', '--version', '1.0.0', '--collection-file', 'collections/foo.collection.yml', '-o', 'json'
       ]);
 
-      expect(result.exitCode).toBe(0);
+      expect(result.exitCode, `${result.stderr}\n${result.stdout}`).toBe(0);
       const envelope = parseJson<{ readmeAsset?: string }>(result.stdout);
       expect(envelope.data.readmeAsset).toBe('docs/collection-overview.md');
       expect(await readFile(path.join(workspace, envelope.data.readmeAsset!), 'utf8')).toBe('# Overview\n');
       const manifest = yaml.load(await readFile(path.join(workspace, 'dist', 'foo', 'deployment-manifest.yml'), 'utf8')) as { readme: string };
-      expect(manifest.readme).toBe(path.basename(envelope.data.readmeAsset!));
+      expect(manifest.readme).toBe('README.md');
     });
 
     it('defaults to the first collection file under collections/ when --collection-file is omitted', async () => {
       const result = await run([
         'bundle', 'build', '--version', '1.0.0', '-o', 'json'
       ]);
-      expect(result.exitCode).toBe(0);
+      expect(result.exitCode, `${result.stderr}\n${result.stdout}`).toBe(0);
       const envelope = parseJson<{ zipAsset: string; manifestAsset: string }>(result.stdout);
       expect(envelope.data.manifestAsset).toContain('deployment-manifest.yml');
       expect(envelope.data.zipAsset).toContain('foo.bundle.zip');

--- a/packages/cli/test/commands/doctor-status-init-update.test.ts
+++ b/packages/cli/test/commands/doctor-status-init-update.test.ts
@@ -11,6 +11,7 @@
  * approach in install.test.ts/uninstall.test.ts.
  */
 import {
+  access,
   mkdir,
   mkdtemp,
   rm,
@@ -118,11 +119,77 @@ describe('doctor/status/init/update commands', () => {
   describe('doctor diagnostics', () => {
     it('runs the full self-contained smoke test successfully', async () => {
       const result = await run(['doctor', 'diagnostics', '-o', 'json']);
-      const envelope = parseJson<{ ok: boolean; steps: { name: string; exitCode: number }[] }>(result.stdout);
+      const envelope = parseJson<{
+        ok: boolean;
+        workspace: string;
+        workspaceRetained: boolean;
+        steps: { name: string; exitCode: number }[];
+      }>(result.stdout);
       const failed = envelope.data.steps.filter((s) => s.exitCode !== 0);
+      const stepNames = envelope.data.steps.map((step) => step.name);
       expect(failed).toEqual([]);
       expect(envelope.data.ok).toBe(true);
+      expect(envelope.data.workspaceRetained).toBe(false);
+      expect(stepNames).toEqual(expect.arrayContaining([
+        'index-bench',
+        'index-report',
+        'build-governed-bundle',
+        'verify-governed-archive',
+        'materialize-governed-bundle',
+        'install-governed-bundle',
+        'verify-governed-install',
+        'uninstall-governed-bundle',
+        'verify-governed-removed',
+        'collection-affected',
+        'version-compute',
+        'config-list',
+        'target-remove',
+        'hub-remove'
+      ]));
+      await expect(access(envelope.data.workspace)).rejects.toThrow();
       expect(result.exitCode).toBe(0);
+    }, 60_000);
+
+    it('retains the diagnostic workspace when explicitly requested', async () => {
+      const result = await run(['doctor', 'diagnostics', '--retain-workspace', '-o', 'json']);
+      const envelope = parseJson<{
+        ok: boolean;
+        workspace: string;
+        workspaceRetained: boolean;
+        steps: {
+          name: string;
+          exitCode: number;
+          output?: { formatVersion?: number; inventoryCount?: number };
+        }[];
+      }>(result.stdout);
+
+      try {
+        expect(result.exitCode).toBe(0);
+        expect(envelope.data.ok).toBe(true);
+        expect(envelope.data.workspaceRetained).toBe(true);
+        await expect(access(envelope.data.workspace)).resolves.toBeUndefined();
+        await expect(access(path.join(
+          envelope.data.workspace,
+          'collections',
+          'governed.collection.yml'
+        ))).resolves.toBeUndefined();
+        await expect(access(path.join(
+          envelope.data.workspace,
+          'governed-dist',
+          'governed-foo',
+          'governed-foo.bundle.zip'
+        ))).resolves.toBeUndefined();
+        await expect(access(path.join(envelope.data.workspace, '.git', 'HEAD'))).resolves.toBeUndefined();
+
+        const archiveStep = envelope.data.steps.find((step) => step.name === 'verify-governed-archive');
+        expect(archiveStep?.exitCode).toBe(0);
+        expect(archiveStep?.output).toMatchObject({
+          formatVersion: 1
+        });
+        expect(archiveStep?.output?.inventoryCount).toBeGreaterThan(0);
+      } finally {
+        await rm(envelope.data.workspace, { recursive: true, force: true });
+      }
     }, 60_000);
   });
 

--- a/packages/cli/test/commands/install.test.ts
+++ b/packages/cli/test/commands/install.test.ts
@@ -10,11 +10,18 @@ import {
   mkdtemp,
   readFile,
   rm,
-  writeFile,
 } from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import type {
+  HttpClient,
+  HttpRequest,
+  HttpResponse,
+  RegistrySource,
+  Target,
+} from '@ai-primitives-hub/core';
 import {
+  buildZip,
   NodeFileSystem,
 } from '@ai-primitives-hub/infra';
 import {
@@ -25,14 +32,21 @@ import {
   it,
 } from 'vitest';
 import {
+  installBundleWithSource,
   InstallCommand,
 } from '../../src/commands/install';
 import {
   TargetAddCommand,
 } from '../../src/commands/target-add';
 import {
+  createTestContext,
   runCommand,
 } from '../../src/framework';
+import {
+  createGovernedReleaseArchive,
+  createLegacyReleaseArchive,
+  writeReleaseArchive,
+} from '../fixtures/release-archives';
 
 const COMMAND_CLASSES = [
   TargetAddCommand,
@@ -70,13 +84,8 @@ describe('install command (local --from mode)', () => {
     bundleDir = path.join(workspace, 'bundle');
     targetDir = path.join(workspace, 'target');
 
-    await mkdir(path.join(bundleDir, 'prompts'), { recursive: true });
     await mkdir(targetDir, { recursive: true });
-    await writeFile(
-      path.join(bundleDir, 'deployment-manifest.yml'),
-      'id: local-foo\nversion: 1.0.0\nname: Local Foo\nitems:\n  - path: prompts/hello.prompt.md\n    kind: prompt\n'
-    );
-    await writeFile(path.join(bundleDir, 'prompts', 'hello.prompt.md'), '# Hello Prompt\n');
+    await writeReleaseArchive(bundleDir, createLegacyReleaseArchive({ id: 'local-foo' }));
 
     expect((await run([
       'target', 'add', 'copilot', '--type', 'copilot-cli', '--path', targetDir, '-o', 'json'
@@ -105,6 +114,65 @@ describe('install command (local --from mode)', () => {
 
     const lockContent = await readFile(envelope.data.lockfile, 'utf8');
     expect(lockContent).toContain('local-foo');
+  });
+
+  it('does not write or lock governed archive metadata', async () => {
+    await writeReleaseArchive(bundleDir, createGovernedReleaseArchive({ id: 'local-foo' }));
+
+    const result = await run([
+      'install', 'local-foo', '--from', bundleDir, '--target', 'copilot', '-o', 'json'
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    const envelope = parseJson<{ lockfile: string }>(result.stdout);
+    await expect(readFile(path.join(targetDir, 'metadata', 'source-collection.yml'), 'utf8')).rejects.toThrow();
+    await expect(readFile(path.join(targetDir, 'LICENSE'), 'utf8')).rejects.toThrow();
+    await expect(readFile(path.join(targetDir, 'ignored', 'build', 'cache.pyc'), 'utf8')).rejects.toThrow();
+    const lockfile = JSON.parse(await readFile(envelope.data.lockfile, 'utf8')) as {
+      bundles: Record<string, { files: { path: string }[] }>;
+    };
+    expect(lockfile.bundles['local-foo'].files.map((file) => file.path)).toEqual([
+      'prompts/hello.prompt.md'
+    ]);
+  });
+
+  it('preserves legacy archive compatibility while routing only target-supported files', async () => {
+    const result = await run([
+      'install', 'local-foo', '--from', bundleDir, '--target', 'copilot', '-o', 'json'
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    const envelope = parseJson<{ lockfile: string }>(result.stdout);
+    await expect(readFile(path.join(targetDir, 'prompts', 'hello.prompt.md'), 'utf8'))
+      .resolves.toContain('Hello Prompt');
+    const lockfile = JSON.parse(await readFile(envelope.data.lockfile, 'utf8')) as {
+      bundles: Record<string, { files: { path: string }[] }>;
+    };
+    expect(lockfile.bundles['local-foo'].files.map((file) => file.path)).toEqual([
+      'prompts/hello.prompt.md'
+    ]);
+  });
+
+  it('replays a governed archive from its lockfile without restoring metadata evidence', async () => {
+    await writeReleaseArchive(bundleDir, createGovernedReleaseArchive({ id: 'local-foo' }));
+    const firstInstall = await run([
+      'install', 'local-foo', '--from', bundleDir, '--target', 'copilot', '-o', 'json'
+    ]);
+    expect(firstInstall.exitCode).toBe(0);
+    const firstEnvelope = parseJson<{ lockfile: string }>(firstInstall.stdout);
+
+    await rm(path.join(targetDir, 'prompts', 'hello.prompt.md'));
+    const replay = await run([
+      'install', '--lockfile', firstEnvelope.data.lockfile, '--target', 'copilot', '-o', 'json'
+    ]);
+
+    expect(replay.exitCode).toBe(0);
+    const replayEnvelope = parseJson<{ replayed: string[]; failures: unknown[] }>(replay.stdout);
+    expect(replayEnvelope.data.replayed).toEqual(['local-foo']);
+    expect(replayEnvelope.data.failures).toEqual([]);
+    await expect(readFile(path.join(targetDir, 'prompts', 'hello.prompt.md'), 'utf8'))
+      .resolves.toContain('Hello Prompt');
+    await expect(readFile(path.join(targetDir, 'README.md'), 'utf8')).rejects.toThrow();
   });
 
   it('dry-run: reports the plan but writes nothing', async () => {
@@ -139,5 +207,204 @@ describe('install command (local --from mode)', () => {
       'install', 'local-foo', '--from', bundleDir, '--target', 'does-not-exist', '-o', 'json'
     ]);
     expect(result.exitCode).toBe(1);
+  });
+
+  it('fails without writing or locking content excluded by the target allowlist', async () => {
+    const addTarget = await run([
+      'target', 'add', 'skills-only', '--type', 'copilot-cli', '--path', targetDir,
+      '--allowed-kinds', 'skill', '-o', 'json'
+    ]);
+    expect(addTarget.exitCode).toBe(0);
+
+    const result = await run([
+      'install', 'local-foo', '--from', bundleDir, '--target', 'skills-only', '-o', 'json'
+    ]);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toContain('BUNDLE.UNSUPPORTED_CONTENT');
+    expect(result.stdout).toContain('prompts/hello.prompt.md');
+    await expect(readFile(path.join(targetDir, 'prompts', 'hello.prompt.md'), 'utf8')).rejects.toThrow();
+    await expect(readFile(path.join(workspace, 'prompt-registry.lock.json'), 'utf8')).rejects.toThrow();
+    await expect(readFile(path.join(workspace, 'prompt-registry.local.lock.json'), 'utf8')).rejects.toThrow();
+  });
+
+  it('uses the effective repository scope for both writing and lockfile selection', async () => {
+    const result = await run([
+      'install', 'local-foo', '--from', bundleDir, '--target', 'copilot',
+      '--scope', 'repository', '--commit-mode', 'local-only', '-o', 'json'
+    ]);
+    expect(result.exitCode).toBe(0);
+
+    const envelope = parseJson<{ lockfile: string }>(result.stdout);
+    expect(envelope.data.lockfile).toBe(path.join(workspace, 'prompt-registry.local.lock.json'));
+    await expect(
+      readFile(path.join(workspace, '.github', 'copilot', 'prompts', 'hello.prompt.md'), 'utf8')
+    ).resolves.toContain('Hello Prompt');
+  });
+
+  it('uses the effective user scope when it overrides a repository target', async () => {
+    const addTarget = await run([
+      'target', 'add', 'repository-vscode', '--type', 'vscode', '--scope', 'repository',
+      '--workspace-root', workspace, '-o', 'json'
+    ]);
+    expect(addTarget.exitCode).toBe(0);
+
+    const result = await run([
+      'install', 'local-foo', '--from', bundleDir, '--target', 'repository-vscode',
+      '--scope', 'user', '-o', 'json'
+    ]);
+    expect(result.exitCode).toBe(0);
+
+    await expect(
+      readFile(path.join(workspace, '.copilot', 'prompts', 'hello.prompt.md'), 'utf8')
+    ).resolves.toContain('Hello Prompt');
+    await expect(
+      readFile(path.join(workspace, '.github', 'prompts', 'hello.prompt.md'), 'utf8')
+    ).rejects.toThrow();
+  });
+
+  it('uses the repository-scope writer for remote installs', async () => {
+    const zipBytes = buildZip([
+      {
+        path: 'deployment-manifest.yml',
+        bytes: new TextEncoder().encode(
+          'id: remote-foo\nversion: 1.0.0\nname: Remote Foo\nprompts:\n'
+          + '  - id: hello\n    file: prompts/hello.prompt.md\n    type: prompt\n'
+        )
+      },
+      {
+        path: 'prompts/hello.prompt.md',
+        bytes: new TextEncoder().encode('# Hello from a remote bundle\n')
+      }
+    ]);
+    const http: HttpClient = {
+      fetch: async (request: HttpRequest): Promise<HttpResponse> => {
+        if (request.url === 'https://api.github.com/repos/owner/repo/releases') {
+          return {
+            statusCode: 200,
+            body: new TextEncoder().encode(JSON.stringify([{
+              tag_name: 'remote-foo-v1.0.0',
+              assets: [{ name: 'bundle.zip', url: 'https://api.github.com/assets/remote-foo' }]
+            }])),
+            finalUrl: request.url,
+            headers: {}
+          };
+        }
+        if (request.url === 'https://api.github.com/assets/remote-foo') {
+          return { statusCode: 200, body: zipBytes, finalUrl: request.url, headers: {} };
+        }
+        throw new Error(`Unexpected request: ${request.url}`);
+      }
+    };
+    const source: RegistrySource = {
+      id: 'github-source',
+      name: 'GitHub source',
+      type: 'github',
+      url: 'https://github.com/owner/repo',
+      enabled: true,
+      priority: 0
+    };
+    const target: Target = {
+      name: 'repository-copilot',
+      type: 'copilot-cli',
+      scope: 'repository',
+      rootPath: workspace
+    };
+    const ctx = createTestContext({
+      cwd: workspace,
+      fs: new NodeFileSystem(),
+      env: {
+        HOME: workspace,
+        USERPROFILE: workspace,
+        XDG_CONFIG_HOME: path.join(workspace, 'xdg-config'),
+        XDG_CACHE_HOME: path.join(workspace, 'xdg-cache')
+      }
+    });
+
+    const result = await installBundleWithSource(
+      'remote-foo',
+      source,
+      target,
+      ctx,
+      http,
+      { getToken: async () => undefined },
+      'json'
+    );
+
+    expect(result).toBe(0);
+    await expect(
+      readFile(path.join(workspace, '.github', 'copilot', 'prompts', 'hello.prompt.md'), 'utf8')
+    ).resolves.toContain('Hello from a remote bundle');
+    await expect(
+      readFile(path.join(workspace, '.github', 'prompts', 'hello.prompt.md'), 'utf8')
+    ).rejects.toThrow();
+  });
+
+  it('installs a governed remote archive without writing its metadata evidence', async () => {
+    const governedFiles = createGovernedReleaseArchive({ id: 'remote-governed' });
+    const zipBytes = buildZip([...governedFiles.entries()].map(([filePath, content]) => ({
+      path: filePath,
+      bytes: content
+    })));
+    const http: HttpClient = {
+      fetch: async (request: HttpRequest): Promise<HttpResponse> => {
+        if (request.url === 'https://api.github.com/repos/owner/repo/releases') {
+          return {
+            statusCode: 200,
+            body: new TextEncoder().encode(JSON.stringify([{
+              tag_name: 'remote-governed-v1.0.0',
+              assets: [{ name: 'bundle.zip', url: 'https://api.github.com/assets/remote-governed' }]
+            }])),
+            finalUrl: request.url,
+            headers: {}
+          };
+        }
+        if (request.url === 'https://api.github.com/assets/remote-governed') {
+          return { statusCode: 200, body: zipBytes, finalUrl: request.url, headers: {} };
+        }
+        throw new Error(`Unexpected request: ${request.url}`);
+      }
+    };
+    const source: RegistrySource = {
+      id: 'github-source',
+      name: 'GitHub source',
+      type: 'github',
+      url: 'https://github.com/owner/repo',
+      enabled: true,
+      priority: 0
+    };
+    const target: Target = {
+      name: 'repository-copilot',
+      type: 'copilot-cli',
+      scope: 'repository',
+      rootPath: workspace
+    };
+    const ctx = createTestContext({
+      cwd: workspace,
+      fs: new NodeFileSystem(),
+      env: {
+        HOME: workspace,
+        USERPROFILE: workspace,
+        XDG_CONFIG_HOME: path.join(workspace, 'xdg-config'),
+        XDG_CACHE_HOME: path.join(workspace, 'xdg-cache')
+      }
+    });
+
+    const result = await installBundleWithSource(
+      'remote-governed',
+      source,
+      target,
+      ctx,
+      http,
+      { getToken: async () => undefined },
+      'json'
+    );
+
+    expect(result).toBe(0);
+    await expect(
+      readFile(path.join(workspace, '.github', 'copilot', 'prompts', 'hello.prompt.md'), 'utf8')
+    ).resolves.toContain('Hello Prompt');
+    await expect(readFile(path.join(workspace, '.github', 'README.md'), 'utf8')).rejects.toThrow();
+    await expect(readFile(path.join(workspace, '.github', 'LICENSE'), 'utf8')).rejects.toThrow();
   });
 });

--- a/packages/cli/test/commands/profile.test.ts
+++ b/packages/cli/test/commands/profile.test.ts
@@ -19,6 +19,9 @@ import {
 import * as os from 'node:os';
 import * as path from 'node:path';
 import {
+  resolveUserConfigPaths,
+} from '@ai-primitives-hub/app';
+import {
   NodeFileSystem,
 } from '@ai-primitives-hub/infra';
 import {
@@ -46,6 +49,11 @@ import {
 import {
   runCommand,
 } from '../../src/framework';
+import {
+  createGovernedReleaseArchive,
+  createLegacyReleaseArchive,
+  writeReleaseArchive,
+} from '../fixtures/release-archives';
 
 const COMMAND_CLASSES = [
   TargetAddCommand,
@@ -92,14 +100,8 @@ describe('profile activate/deactivate', () => {
     targetDir = path.join(workspace, 'target');
     hubConfigFile = path.join(workspace, 'hub-config.yml');
 
-    await mkdir(path.join(bundleDir, 'prompts'), { recursive: true });
     await mkdir(targetDir, { recursive: true });
-
-    await writeFile(
-      path.join(bundleDir, 'deployment-manifest.yml'),
-      'id: local-foo\nversion: 1.0.0\nname: Local Foo\nitems:\n  - path: prompts/hello.prompt.md\n    kind: prompt\n'
-    );
-    await writeFile(path.join(bundleDir, 'prompts', 'hello.prompt.md'), '# Hello Prompt\n');
+    await writeReleaseArchive(bundleDir, createLegacyReleaseArchive({ id: 'local-foo' }));
     await writeFile(
       hubConfigFile,
       `version: 1.0.0
@@ -178,6 +180,33 @@ profiles:
     expect(currentResult.exitCode).toBe(0);
     const currentEnvelope = parseJson<{ active: { hubId: string; profileId: string } }>(currentResult.stdout);
     expect(currentEnvelope.data.active).toEqual({ hubId: 'test-hub', profileId: 'backend' });
+  });
+
+  it('activates a governed profile without writing archive metadata or ignored files', async () => {
+    await writeReleaseArchive(bundleDir, createGovernedReleaseArchive({ id: 'local-foo' }));
+    expect((await run(['hub', 'sync', 'test-hub', '-o', 'json'])).exitCode).toBe(0);
+
+    const activateResult = await run(['profile', 'activate', 'backend', '--target', 'copilot', '-o', 'json']);
+    expect(activateResult.exitCode).toBe(0);
+
+    await expect(readFile(path.join(targetDir, 'prompts', 'hello.prompt.md'), 'utf8'))
+      .resolves.toContain('Hello Prompt');
+    await expect(readFile(path.join(targetDir, 'README.md'), 'utf8')).rejects.toThrow();
+    await expect(readFile(path.join(targetDir, 'LICENSE'), 'utf8')).rejects.toThrow();
+    await expect(readFile(path.join(targetDir, 'ignored', 'build', 'cache.pyc'), 'utf8'))
+      .rejects.toThrow();
+
+    const lockfilePath = resolveUserConfigPaths({
+      XDG_CONFIG_HOME: path.join(workspace, 'xdg-config'),
+      HOME: workspace,
+      USERPROFILE: workspace
+    }).userLockfile;
+    const lockfile = JSON.parse(await readFile(lockfilePath, 'utf8')) as {
+      bundles: Record<string, { files: { path: string }[] }>;
+    };
+    expect(lockfile.bundles['local-foo'].files.map((file) => file.path)).toEqual([
+      'prompts/hello.prompt.md'
+    ]);
   });
 
   it('deactivates a profile: removes installed files and clears the active profile', async () => {

--- a/packages/cli/test/commands/target.test.ts
+++ b/packages/cli/test/commands/target.test.ts
@@ -125,6 +125,23 @@ describe('target commands', () => {
       expect(result.exitCode).toBe(1);
     });
 
+    it('rejects an unknown allowed primitive kind', async () => {
+      const result = await run([
+        'target', 'add', 'bad-kinds', '--type', 'vscode', '--allowed-kinds', 'prompt,not-a-kind', '-o', 'json'
+      ]);
+      expect(result.exitCode).toBe(1);
+    });
+
+    it('accepts canonical primitive kinds and legacy route aliases', async () => {
+      const result = await run([
+        'target', 'add', 'restricted', '--type', 'vscode',
+        '--allowed-kinds', 'prompt,chat-mode,skills', '-o', 'json'
+      ]);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ target: { allowedKinds: string[] } }>(result.stdout);
+      expect(envelope.data.target.allowedKinds).toEqual(['prompt', 'chat-mode', 'skill']);
+    });
+
     it('fails with exit 1 when adding a duplicate name', async () => {
       await run(['target', 'add', 'dup', '--type', 'vscode', '-o', 'json']);
       const result = await run(['target', 'add', 'dup', '--type', 'vscode', '-o', 'json']);

--- a/packages/cli/test/commands/uninstall.test.ts
+++ b/packages/cli/test/commands/uninstall.test.ts
@@ -37,6 +37,10 @@ import {
 import {
   runCommand,
 } from '../../src/framework';
+import {
+  createGovernedReleaseArchive,
+  writeReleaseArchive,
+} from '../fixtures/release-archives';
 
 const COMMAND_CLASSES = [
   TargetAddCommand,
@@ -108,6 +112,28 @@ describe('uninstall command', () => {
     expect(lockContent.bundles).toEqual({});
   });
 
+  it('uninstalls a governed bundle using installable-only lockfile paths', async () => {
+    const initialUninstall = await run(['uninstall', '--bundle', 'local-foo', '--target', 'copilot', '-o', 'json']);
+    expect(initialUninstall.exitCode).toBe(0);
+    await writeReleaseArchive(bundleDir, createGovernedReleaseArchive({ id: 'local-foo' }));
+
+    const installResult = await run([
+      'install', 'local-foo', '--from', bundleDir, '--target', 'copilot', '-o', 'json'
+    ]);
+    expect(installResult.exitCode).toBe(0);
+    await expect(readFile(installedFile(), 'utf8')).resolves.toContain('Hello Prompt');
+
+    const uninstallResult = await run(['uninstall', '--bundle', 'local-foo', '--target', 'copilot', '-o', 'json']);
+    expect(uninstallResult.exitCode).toBe(0);
+    await expect(readFile(installedFile(), 'utf8')).rejects.toThrow();
+
+    const envelope = parseJson<{ lockfile: string }>(uninstallResult.stdout);
+    const lockContent = JSON.parse(await readFile(envelope.data.lockfile, 'utf8')) as {
+      bundles: Record<string, unknown>;
+    };
+    expect(lockContent.bundles).toEqual({});
+  });
+
   it('is a warning no-op (exit 0) when the bundle is not installed', async () => {
     await run(['uninstall', '--bundle', 'local-foo', '--target', 'copilot', '-o', 'json']);
     const result = await run(['uninstall', '--bundle', 'local-foo', '--target', 'copilot', '-o', 'json']);
@@ -126,6 +152,27 @@ describe('uninstall command', () => {
 
     const stillInstalled = await readFile(installedFile(), 'utf8');
     expect(stillInstalled).toContain('Hello Prompt');
+  });
+
+  it('round-trips repository scope: removes files from the same layout used by install', async () => {
+    const installResult = await run([
+      'install', 'local-foo', '--from', bundleDir, '--target', 'copilot',
+      '--scope', 'repository', '-o', 'json'
+    ]);
+    expect(installResult.exitCode).toBe(0);
+
+    const repositoryFile = path.join(workspace, '.github', 'copilot', 'prompts', 'hello.prompt.md');
+    await expect(readFile(repositoryFile, 'utf8')).resolves.toContain('Hello Prompt');
+
+    const uninstallResult = await run([
+      'uninstall', '--bundle', 'local-foo', '--target', 'copilot',
+      '--scope', 'repository', '-o', 'json'
+    ]);
+    expect(uninstallResult.exitCode).toBe(0);
+    const envelope = parseJson<{ removed: string[]; lockfile: string }>(uninstallResult.stdout);
+    expect(envelope.data.removed.length).toBeGreaterThan(0);
+    await expect(readFile(repositoryFile, 'utf8')).rejects.toThrow();
+    await expect(readFile(envelope.data.lockfile, 'utf8')).rejects.toThrow();
   });
 
   it('--all removes every installed bundle for the target', async () => {

--- a/packages/cli/test/fixtures/release-archives.ts
+++ b/packages/cli/test/fixtures/release-archives.ts
@@ -1,0 +1,29 @@
+import {
+  mkdir,
+  writeFile,
+} from 'node:fs/promises';
+import * as path from 'node:path';
+import type {
+  ExtractedFiles,
+} from '@ai-primitives-hub/core';
+
+export {
+  createGovernedReleaseArchive,
+  createLegacyReleaseArchive,
+} from '../../../core/test/fixtures/release-archives';
+
+/**
+ * Write an extracted archive fixture to a local bundle directory.
+ * @param root
+ * @param files
+ */
+export const writeReleaseArchive = async (
+  root: string,
+  files: ExtractedFiles
+): Promise<void> => {
+  for (const [filePath, content] of files) {
+    const fullPath = path.join(root, filePath);
+    await mkdir(path.dirname(fullPath), { recursive: true });
+    await writeFile(fullPath, content);
+  }
+};

--- a/packages/core/src/domain/collection/manifest-validator.ts
+++ b/packages/core/src/domain/collection/manifest-validator.ts
@@ -16,6 +16,9 @@
  * @module domain/collection/manifest-validator
  */
 import {
+  createHash,
+} from 'node:crypto';
+import {
   load as parseYaml,
 } from 'js-yaml';
 import type {
@@ -24,6 +27,15 @@ import type {
 import {
   isManifestIdMatch,
 } from '../bundle/id';
+import {
+  isPrimitiveKind,
+} from '../primitive/types';
+import {
+  RELEASE_DEPLOYMENT_MANIFEST_FORMAT_VERSION,
+  type ReleaseDeploymentManifest,
+  type ReleaseManifestFile,
+  type ReleaseManifestFileRole,
+} from './types';
 
 export const MANIFEST_FILENAME = 'deployment-manifest.yml';
 
@@ -43,15 +55,25 @@ export interface ManifestValidationOptions {
 }
 
 /**
- * Validated manifest with required fields.
+ * Legacy manifest with the minimum required runtime identity fields.
  */
-export interface ValidatedManifest {
+export interface LegacyValidatedManifest {
   id: string;
   version: string;
   name: string;
   /** Open-ended remainder. */
   [key: string]: unknown;
 }
+
+/**
+ * Parsed manifest accepted by the runtime.
+ *
+ * Releases that declare `formatVersion: 1` are validated against the
+ * self-contained archive contract. Manifests without a format version retain
+ * legacy compatibility validation so already-published bundles remain
+ * installable until their publishers migrate.
+ */
+export type ValidatedManifest = LegacyValidatedManifest | ReleaseDeploymentManifest;
 
 /**
  * Error thrown when manifest validation fails.
@@ -127,5 +149,361 @@ export const validateManifest = (
       'BUNDLE.VERSION_MISMATCH'
     );
   }
-  return m as ValidatedManifest;
+  if (m.formatVersion === undefined) {
+    return m as LegacyValidatedManifest;
+  }
+  if (m.formatVersion !== RELEASE_DEPLOYMENT_MANIFEST_FORMAT_VERSION) {
+    throw invalidManifest(
+      `${MANIFEST_FILENAME} has unsupported formatVersion ${describeFormatVersion(m.formatVersion)}`
+    );
+  }
+
+  validateReleaseManifest(m, files);
+  return m as unknown as ReleaseDeploymentManifest;
 };
+
+/**
+ * Determine whether a validated manifest opted into the self-contained
+ * release contract.
+ * @param manifest - Parsed and validated deployment manifest.
+ * @returns True only for a governed release manifest.
+ */
+export const isReleaseDeploymentManifest = (
+  manifest: ValidatedManifest
+): manifest is ReleaseDeploymentManifest =>
+  manifest.formatVersion === RELEASE_DEPLOYMENT_MANIFEST_FORMAT_VERSION;
+
+/**
+ * Return the files that may be supplied to a target writer.
+ *
+ * A governed archive carries its provenance, license, documentation and
+ * inventory inside the ZIP, but those files are evidence rather than target
+ * content. The root deployment manifest remains available because
+ * manifest-driven repository writers need it to determine primitive routing.
+ * Legacy manifests return their complete extracted file map to preserve the
+ * pre-contract installation behavior.
+ * @param files - Full extracted archive contents.
+ * @param manifest - Previously validated manifest.
+ * @returns A deterministic map containing target-installable files.
+ */
+export const getInstallableBundleFiles = (
+  files: ExtractedFiles,
+  manifest: ValidatedManifest
+): ExtractedFiles => {
+  if (!isReleaseDeploymentManifest(manifest)) {
+    return files;
+  }
+
+  const allowedPaths = new Set<string>([
+    MANIFEST_FILENAME,
+    ...manifest.files
+      .filter((file) => file.role === 'installable')
+      .map((file) => file.path)
+  ]);
+  const installableFiles = new Map<string, Uint8Array>();
+  for (const [filePath, content] of files) {
+    if (allowedPaths.has(filePath)) {
+      installableFiles.set(filePath, content);
+    }
+  }
+  return installableFiles;
+};
+
+const RELEASE_FILE_ROLES: ReadonlySet<ReleaseManifestFileRole> = new Set([
+  'installable',
+  'metadata',
+  'ignored'
+]);
+
+const SHA256_PATTERN = /^sha256:[a-f0-9]{64}$/;
+
+/**
+ * Apply semantic rules that JSON Schema alone cannot express: full archive
+ * coverage, exact byte sizes and digests, canonical paths, and relationships
+ * between primitive/provenance declarations and the file inventory.
+ * @param manifest - Parsed YAML mapping with `formatVersion: 1`.
+ * @param files - Full extracted archive contents.
+ * @throws {ManifestValidationError} When the governed archive is incomplete or inconsistent.
+ */
+const validateReleaseManifest = (
+  manifest: Record<string, unknown>,
+  files: ExtractedFiles
+): void => {
+  const inventory = validateFileInventory(manifest.files, files);
+  validateReleaseItems(manifest.items, inventory);
+  validateLegacyProjection(manifest.prompts, inventory);
+  validateReleaseProvenance(manifest.provenance, inventory);
+  validateDeclaredMetadataPath(manifest.readme, 'readme', inventory);
+};
+
+/**
+ * Validate full archive inventory, including hashes calculated from the exact
+ * extracted bytes. The deployment manifest itself is intentionally excluded:
+ * storing its own hash in the document would create a circular value.
+ * @param value
+ * @param files
+ */
+const validateFileInventory = (
+  value: unknown,
+  files: ExtractedFiles
+): ReadonlyMap<string, ReleaseManifestFile> => {
+  if (!Array.isArray(value)) {
+    throw invalidManifest('governed release manifest requires a "files" array');
+  }
+
+  const inventory = new Map<string, ReleaseManifestFile>();
+  for (const [index, rawRecord] of value.entries()) {
+    const prefix = `files[${index}]`;
+    if (!isRecord(rawRecord)) {
+      throw invalidManifest(`${prefix} must be an object`);
+    }
+    const filePath = readCanonicalBundlePath(rawRecord.path, `${prefix}.path`);
+    if (filePath === MANIFEST_FILENAME) {
+      throw invalidManifest(`${prefix}.path must not list ${MANIFEST_FILENAME}`);
+    }
+    if (inventory.has(filePath)) {
+      throw invalidManifest(`${prefix}.path duplicates "${filePath}"`);
+    }
+    if (!isReleaseManifestFileRole(rawRecord.role)) {
+      throw invalidManifest(`${prefix}.role must be installable, metadata, or ignored`);
+    }
+    if (!Number.isSafeInteger(rawRecord.size) || (rawRecord.size as number) < 0) {
+      throw invalidManifest(`${prefix}.size must be a non-negative integer`);
+    }
+    if (typeof rawRecord.sha256 !== 'string' || !SHA256_PATTERN.test(rawRecord.sha256)) {
+      throw invalidManifest(`${prefix}.sha256 must be sha256:<64 lowercase hexadecimal characters>`);
+    }
+
+    const actual = files.get(filePath);
+    if (actual === undefined) {
+      throw invalidManifest(`${prefix}.path "${filePath}" is missing from the archive`);
+    }
+    if (actual.byteLength !== rawRecord.size) {
+      throw invalidManifest(`${prefix}.size does not match archive content for "${filePath}"`);
+    }
+    if (sha256(actual) !== rawRecord.sha256) {
+      throw invalidManifest(`${prefix}.sha256 does not match archive content for "${filePath}"`);
+    }
+
+    inventory.set(filePath, {
+      path: filePath,
+      role: rawRecord.role,
+      size: rawRecord.size,
+      sha256: rawRecord.sha256
+    });
+  }
+
+  for (const filePath of files.keys()) {
+    if (filePath === MANIFEST_FILENAME) {
+      continue;
+    }
+    assertCanonicalBundlePath(filePath, 'archive entry');
+    if (!inventory.has(filePath)) {
+      throw invalidManifest(`archive entry "${filePath}" is not declared in files`);
+    }
+  }
+  return inventory;
+};
+
+/**
+ * Validate canonical primitive entries and their installable inventory records.
+ * @param value
+ * @param inventory
+ */
+const validateReleaseItems = (
+  value: unknown,
+  inventory: ReadonlyMap<string, ReleaseManifestFile>
+): void => {
+  if (!Array.isArray(value)) {
+    throw invalidManifest('governed release manifest requires an "items" array');
+  }
+  const ids = new Set<string>();
+  const paths = new Set<string>();
+  for (const [index, rawItem] of value.entries()) {
+    const prefix = `items[${index}]`;
+    if (!isRecord(rawItem)) {
+      throw invalidManifest(`${prefix} must be an object`);
+    }
+    if (!isNonEmptyString(rawItem.id)) {
+      throw invalidManifest(`${prefix}.id must be a non-empty string`);
+    }
+    if (ids.has(rawItem.id)) {
+      throw invalidManifest(`${prefix}.id duplicates "${rawItem.id}"`);
+    }
+    ids.add(rawItem.id);
+    const filePath = readCanonicalBundlePath(rawItem.path, `${prefix}.path`);
+    if (paths.has(filePath)) {
+      throw invalidManifest(`${prefix}.path duplicates "${filePath}"`);
+    }
+    paths.add(filePath);
+    if (!isPrimitiveKind(rawItem.kind)) {
+      throw invalidManifest(`${prefix}.kind must be a canonical primitive kind`);
+    }
+    assertInstallableInventoryPath(filePath, prefix, inventory);
+    validateOptionalString(rawItem.name, `${prefix}.name`);
+    validateOptionalString(rawItem.description, `${prefix}.description`);
+    validateOptionalStringArray(rawItem.tags, `${prefix}.tags`);
+  }
+};
+
+/**
+ * Validate the optional legacy `prompts[]` compatibility projection.
+ * @param value
+ * @param inventory
+ */
+const validateLegacyProjection = (
+  value: unknown,
+  inventory: ReadonlyMap<string, ReleaseManifestFile>
+): void => {
+  if (value === undefined) {
+    return;
+  }
+  if (!Array.isArray(value)) {
+    throw invalidManifest('prompts must be an array when present');
+  }
+  for (const [index, rawItem] of value.entries()) {
+    const prefix = `prompts[${index}]`;
+    if (!isRecord(rawItem)) {
+      throw invalidManifest(`${prefix} must be an object`);
+    }
+    if (!isNonEmptyString(rawItem.id) || !isNonEmptyString(rawItem.type)) {
+      throw invalidManifest(`${prefix}.id and ${prefix}.type must be non-empty strings`);
+    }
+    const filePath = readCanonicalBundlePath(rawItem.file, `${prefix}.file`);
+    assertInstallableInventoryPath(filePath, prefix, inventory);
+    validateOptionalString(rawItem.name, `${prefix}.name`);
+    validateOptionalString(rawItem.description, `${prefix}.description`);
+    validateOptionalStringArray(rawItem.tags, `${prefix}.tags`);
+  }
+};
+
+/**
+ * Validate the provenance snapshot and embedded license relationship.
+ * @param value
+ * @param inventory
+ */
+const validateReleaseProvenance = (
+  value: unknown,
+  inventory: ReadonlyMap<string, ReleaseManifestFile>
+): void => {
+  if (!isRecord(value)) {
+    throw invalidManifest('governed release manifest requires a "provenance" object');
+  }
+  for (const field of ['source', 'revision', 'license'] as const) {
+    if (!isNonEmptyString(value[field])) {
+      throw invalidManifest(`provenance.${field} must be a non-empty string`);
+    }
+  }
+  readCanonicalBundlePath(value.collectionPath, 'provenance.collectionPath');
+  const sourceSnapshotPath = readCanonicalBundlePath(
+    value.sourceSnapshotPath,
+    'provenance.sourceSnapshotPath'
+  );
+  const licensePath = readCanonicalBundlePath(value.licensePath, 'provenance.licensePath');
+  assertMetadataInventoryPath(sourceSnapshotPath, 'provenance.sourceSnapshotPath', inventory);
+  assertMetadataInventoryPath(licensePath, 'provenance.licensePath', inventory);
+};
+
+/**
+ * Validate an optional top-level metadata path such as `readme`.
+ * @param value
+ * @param field
+ * @param inventory
+ */
+const validateDeclaredMetadataPath = (
+  value: unknown,
+  field: string,
+  inventory: ReadonlyMap<string, ReleaseManifestFile>
+): void => {
+  if (value === undefined) {
+    return;
+  }
+  const filePath = readCanonicalBundlePath(value, field);
+  assertMetadataInventoryPath(filePath, field, inventory);
+};
+
+const assertInstallableInventoryPath = (
+  filePath: string,
+  field: string,
+  inventory: ReadonlyMap<string, ReleaseManifestFile>
+): void => {
+  const file = inventory.get(filePath);
+  if (file === undefined) {
+    throw invalidManifest(`${field} references undeclared archive file "${filePath}"`);
+  }
+  if (file.role !== 'installable') {
+    throw invalidManifest(`${field} must reference an installable archive file`);
+  }
+};
+
+const assertMetadataInventoryPath = (
+  filePath: string,
+  field: string,
+  inventory: ReadonlyMap<string, ReleaseManifestFile>
+): void => {
+  const file = inventory.get(filePath);
+  if (file === undefined) {
+    throw invalidManifest(`${field} references undeclared archive file "${filePath}"`);
+  }
+  if (file.role !== 'metadata') {
+    throw invalidManifest(`${field} must reference a metadata archive file`);
+  }
+};
+
+/**
+ * Strict archive-relative path validation; never normalize an ambiguous path.
+ * @param value
+ * @param field
+ */
+const readCanonicalBundlePath = (value: unknown, field: string): string => {
+  if (!isNonEmptyString(value)) {
+    throw invalidManifest(`${field} must be a non-empty string`);
+  }
+  assertCanonicalBundlePath(value, field);
+  return value;
+};
+
+const assertCanonicalBundlePath = (filePath: string, field: string): void => {
+  if (filePath.startsWith('/')
+    || filePath.includes('\\')
+    || filePath.split('/').some((segment) => segment === '' || segment === '.' || segment === '..')) {
+    throw invalidManifest(`${field} must be a canonical bundle-relative path`);
+  }
+};
+
+const validateOptionalString = (value: unknown, field: string): void => {
+  if (value !== undefined && typeof value !== 'string') {
+    throw invalidManifest(`${field} must be a string when present`);
+  }
+};
+
+const validateOptionalStringArray = (value: unknown, field: string): void => {
+  if (value === undefined) {
+    return;
+  }
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== 'string')) {
+    throw invalidManifest(`${field} must be an array of strings when present`);
+  }
+};
+
+const isReleaseManifestFileRole = (value: unknown): value is ReleaseManifestFileRole =>
+  typeof value === 'string' && RELEASE_FILE_ROLES.has(value as ReleaseManifestFileRole);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === 'object' && !Array.isArray(value);
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === 'string' && value.length > 0;
+
+const describeFormatVersion = (value: unknown): string => {
+  if (value === null || typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return `"${String(value)}"`;
+  }
+  return 'of a non-scalar type';
+};
+
+const sha256 = (bytes: Uint8Array): string =>
+  `sha256:${createHash('sha256').update(bytes).digest('hex')}`;
+
+const invalidManifest = (message: string): ManifestValidationError =>
+  new ManifestValidationError(`${MANIFEST_FILENAME} ${message}`, 'BUNDLE.MANIFEST_INVALID');

--- a/packages/core/src/domain/collection/types.ts
+++ b/packages/core/src/domain/collection/types.ts
@@ -12,6 +12,9 @@
  * YAML schema and must not be reformatted to camelCase).
  * @module domain/collection/types
  */
+import type {
+  PrimitiveKind,
+} from '../primitive/types';
 
 /**
  * Compression formats supported when packaging a bundle.
@@ -27,6 +30,7 @@ export interface CollectionItem {
   kind: string;
   name?: string;
   description?: string;
+  tags?: string[];
 }
 
 /**
@@ -233,4 +237,110 @@ export interface DeploymentManifest {
    * `domain/mcp` module — not required by any Phase 2 consumer yet.
    */
   mcpServers?: Record<string, unknown>;
+}
+
+/**
+ * Version of the self-contained release deployment-manifest contract.
+ *
+ * This is deliberately separate from the legacy {@link DeploymentManifest}
+ * build-spec shape above. The legacy format remains readable for existing
+ * releases; a release opts into the governed archive contract by declaring
+ * this format version.
+ */
+export const RELEASE_DEPLOYMENT_MANIFEST_FORMAT_VERSION = 1 as const;
+
+/**
+ * How a file carried by a release archive participates in installation.
+ *
+ * `installable` files are passed to a target writer. `metadata` files retain
+ * provenance, licensing, and documentation evidence inside the archive but
+ * are never routed into an IDE target. `ignored` records make intentionally
+ * retained non-runtime content visible to policy without installing it.
+ */
+export type ReleaseManifestFileRole = 'installable' | 'metadata' | 'ignored';
+
+/** A canonical primitive item in a versioned release manifest. */
+export interface ReleaseManifestItem {
+  /** Stable identifier within the release. */
+  id: string;
+  /** Canonical bundle-relative path to the primitive entry point. */
+  path: string;
+  /** Canonical runtime primitive vocabulary. */
+  kind: PrimitiveKind;
+  name?: string;
+  description?: string;
+  tags?: string[];
+}
+
+/** A file inventory record for a self-contained release archive. */
+export interface ReleaseManifestFile {
+  /** Canonical bundle-relative path, excluding deployment-manifest.yml itself. */
+  path: string;
+  role: ReleaseManifestFileRole;
+  /** Exact uncompressed byte length. */
+  size: number;
+  /** Lowercase SHA-256 digest in canonical sha256:<hex> form. */
+  sha256: string;
+}
+
+/** Source facts resolved before packaging a self-contained release. */
+export interface ReleaseManifestProvenance {
+  /** Immutable source location, such as a repository URL. */
+  source: string;
+  /** Immutable source revision used for both discovery and packaging. */
+  revision: string;
+  /** Path of the collection in the source tree at {@link revision}. */
+  collectionPath: string;
+  /** Archive-relative snapshot of the source collection definition. */
+  sourceSnapshotPath: string;
+  /** License identifier or source declaration. */
+  license: string;
+  /** Archive-relative path containing the applicable license text. */
+  licensePath: string;
+}
+
+/**
+ * Legacy item representation retained for older bundle consumers.
+ * New producers must treat {@link ReleaseDeploymentManifest.items} as
+ * canonical and may emit this representation as a compatibility projection.
+ */
+export interface LegacyReleaseManifestItem {
+  id: string;
+  file: string;
+  type: string;
+  name?: string;
+  description?: string;
+  tags?: string[];
+}
+
+/**
+ * Self-contained, versioned deployment manifest published inside a release
+ * archive. The manifest intentionally does not contain the ZIP's own digest:
+ * that digest must remain a detached release asset or attestation to avoid a
+ * circular archive hash.
+ */
+export interface ReleaseDeploymentManifest {
+  formatVersion: typeof RELEASE_DEPLOYMENT_MANIFEST_FORMAT_VERSION;
+  id: string;
+  version: string;
+  name: string;
+  description?: string;
+  author?: string;
+  tags?: string[];
+  environments?: string[];
+  /** Archive-relative README when the source declares one. */
+  readme?: string;
+  /** Legacy/package-level license declaration. */
+  license?: string;
+  repository?: string;
+  /** Canonical release primitive representation. */
+  items: ReleaseManifestItem[];
+  /** Complete inventory of every archive file except this manifest. */
+  files: ReleaseManifestFile[];
+  provenance: ReleaseManifestProvenance;
+  /** Compatibility projection for legacy consumers. */
+  prompts?: LegacyReleaseManifestItem[];
+  dependencies?: unknown[];
+  mcpServers?: Record<string, unknown>;
+  mcpInputs?: unknown[];
 }

--- a/packages/core/src/domain/collection/validate.ts
+++ b/packages/core/src/domain/collection/validate.ts
@@ -13,6 +13,9 @@
  * so repeating it here would create an ambiguous star-export binding.
  */
 import * as path from 'node:path';
+import {
+  PRIMITIVE_KINDS,
+} from '../primitive/types';
 import type {
   CollectionFieldValidationResult,
   ObjectValidationResult,
@@ -21,7 +24,7 @@ import type {
 
 /**
  * Default validation rules for collections.
- * Item kinds are loaded from the JSON schema for single source of truth.
+ * Item kinds are sourced from the canonical PRIMITIVE_KINDS list.
  */
 export const DEFAULT_VALIDATION_RULES: ValidationRules = {
   collectionId: {
@@ -34,7 +37,7 @@ export const DEFAULT_VALIDATION_RULES: ValidationRules = {
     default: '1.0.0',
     description: 'semantic versioning format (X.Y.Z)'
   },
-  itemKinds: ['prompt', 'instruction', 'chat-mode', 'agent', 'skill', 'plugin', 'hook'],
+  itemKinds: [...PRIMITIVE_KINDS],
   deprecatedKinds: {
     chatmode: 'agent'
   }

--- a/packages/core/src/domain/install/target.ts
+++ b/packages/core/src/domain/install/target.ts
@@ -16,6 +16,12 @@
  * @module domain/install/target
  */
 import type {
+  PrimitiveKind,
+} from '../primitive/types';
+import {
+  isPrimitiveKind,
+} from '../primitive/types';
+import type {
   InstallationScope,
   RepositoryCommitMode,
 } from './types';
@@ -28,8 +34,13 @@ export const TARGET_TYPES = [
   'vscode-insiders',
   'copilot-cli',
   'kiro',
+  'kiro-cli',
   'windsurf',
-  'claude-code'
+  'claude-code',
+  'cursor',
+  'opencode',
+  'devin',
+  'devin-cli'
 ] as const;
 
 /**
@@ -52,7 +63,7 @@ export interface TargetBase {
   /** Override the platform-default config path for this target. */
   path?: string;
   /** Restrict which primitive kinds this target accepts, e.g. `['prompt', 'agent']`. */
-  allowedKinds?: string[];
+  allowedKinds?: PrimitiveKind[];
 }
 
 export interface VsCodeTarget extends TargetBase {
@@ -67,12 +78,32 @@ export interface KiroTarget extends TargetBase {
   type: 'kiro';
 }
 
+export interface KiroCliTarget extends TargetBase {
+  type: 'kiro-cli';
+}
+
 export interface WindsurfTarget extends TargetBase {
   type: 'windsurf';
 }
 
 export interface ClaudeCodeTarget extends TargetBase {
   type: 'claude-code';
+}
+
+export interface CursorTarget extends TargetBase {
+  type: 'cursor';
+}
+
+export interface OpencodeTarget extends TargetBase {
+  type: 'opencode';
+}
+
+export interface DevinTarget extends TargetBase {
+  type: 'devin';
+}
+
+export interface DevinCliTarget extends TargetBase {
+  type: 'devin-cli';
 }
 
 /**
@@ -82,8 +113,13 @@ export type Target =
   | VsCodeTarget
   | CopilotCliTarget
   | KiroTarget
+  | KiroCliTarget
   | WindsurfTarget
-  | ClaudeCodeTarget;
+  | ClaudeCodeTarget
+  | CursorTarget
+  | OpencodeTarget
+  | DevinTarget
+  | DevinCliTarget;
 
 const INSTALLATION_SCOPES: readonly string[] = ['user', 'workspace', 'repository'];
 const COMMIT_MODES: readonly string[] = ['commit', 'local-only'];
@@ -110,6 +146,11 @@ export function isTarget(value: unknown): value is Target {
     return false;
   }
   if (candidate.commitMode !== undefined && !COMMIT_MODES.includes(candidate.commitMode as string)) {
+    return false;
+  }
+  if (candidate.allowedKinds !== undefined
+    && (!Array.isArray(candidate.allowedKinds)
+      || candidate.allowedKinds.some((kind) => !isPrimitiveKind(kind)))) {
     return false;
   }
   return true;

--- a/packages/core/src/domain/primitive/types.ts
+++ b/packages/core/src/domain/primitive/types.ts
@@ -32,7 +32,16 @@ export const PRIMITIVE_KINDS = [
   'skill',
   'plugin',
   'hook',
-  'mcp-server'
+  'mcp-server',
+  'steering',
+  'spec',
+  'command',
+  'rule',
+  'output-style',
+  'tool',
+  'power',
+  'knowledge',
+  'playbook'
 ] as const;
 
 export type PrimitiveKind = typeof PRIMITIVE_KINDS[number];
@@ -43,6 +52,56 @@ export type PrimitiveKind = typeof PRIMITIVE_KINDS[number];
  */
 export function isPrimitiveKind(value: unknown): value is PrimitiveKind {
   return typeof value === 'string' && (PRIMITIVE_KINDS as readonly string[]).includes(value);
+}
+
+/**
+ * Translate legacy route names and manifest aliases into canonical primitive
+ * kinds. Persisted target configuration may contain route names from older
+ * releases, but all runtime comparisons use the semantic vocabulary above.
+ * @param value - Canonical kind or legacy route/manifest alias.
+ * @returns Canonical primitive kind, or null for an unknown value.
+ */
+export function normalizePrimitiveKind(value: unknown): PrimitiveKind | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const normalized = value.trim().toLowerCase();
+  const aliases: Record<string, PrimitiveKind> = {
+    prompt: 'prompt',
+    prompts: 'prompt',
+    instruction: 'instruction',
+    instructions: 'instruction',
+    'chat-mode': 'chat-mode',
+    chatmode: 'chat-mode',
+    'chat-modes': 'chat-mode',
+    agent: 'agent',
+    agents: 'agent',
+    skill: 'skill',
+    skills: 'skill',
+    plugin: 'plugin',
+    plugins: 'plugin',
+    hook: 'hook',
+    hooks: 'hook',
+    'mcp-server': 'mcp-server',
+    mcp: 'mcp-server',
+    steering: 'steering',
+    spec: 'spec',
+    specs: 'spec',
+    command: 'command',
+    commands: 'command',
+    rule: 'rule',
+    rules: 'rule',
+    'output-style': 'output-style',
+    'output-styles': 'output-style',
+    tool: 'tool',
+    tools: 'tool',
+    power: 'power',
+    powers: 'power',
+    knowledge: 'knowledge',
+    playbook: 'playbook',
+    playbooks: 'playbook'
+  };
+  return aliases[normalized] ?? null;
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,6 +26,13 @@ export const SCHEMA_DIR = path.join(__dirname, './public/schemas');
 export { default as COLLECTION_SCHEMA } from './public/schemas/collection.schema.json';
 
 /**
+ * Versioned self-contained release deployment-manifest schema.
+ * Legacy manifests without `formatVersion` remain runtime-compatible but do
+ * not satisfy this governed release contract.
+ */
+export { default as DEPLOYMENT_MANIFEST_SCHEMA } from './public/schemas/deployment-manifest.schema.json';
+
+/**
  * Phase 1 scaffolding marker, kept until `infra`/`app`/`cli` each have real
  * code of their own to depend on instead of this placeholder re-export
  * chain (see those packages' `src/index.ts`) — removed in Phase 5 once

--- a/packages/core/src/ports/target-writer.ts
+++ b/packages/core/src/ports/target-writer.ts
@@ -20,6 +20,27 @@ export interface TargetWriteResult {
   written: string[];
   /** Files in the bundle that were skipped (kind not allowed). */
   skipped: string[];
+  /**
+   * Bundle-relative paths that were actually written.
+   *
+   * Optional for compatibility with external writers. Installers should use
+   * this when present instead of assuming every extracted file was installed.
+   */
+  writtenBundlePaths?: string[];
+}
+
+/**
+ * Side-effect-free assessment of a target write.
+ *
+ * Paths in both arrays are bundle-relative. A writer may omit this optional
+ * operation when it has no capability filtering to perform; callers must
+ * still inspect `TargetWriteResult.skipped` after writing.
+ */
+export interface TargetWritePlan {
+  /** Bundle-relative files the writer can place. */
+  writable: string[];
+  /** Bundle-relative files the writer cannot place. */
+  skipped: string[];
 }
 
 /**
@@ -27,12 +48,34 @@ export interface TargetWriteResult {
  */
 export interface TargetWriter {
   /**
+   * Assess the write without changing the target filesystem.
+   *
+   * Implementations should report unsupported or unrouted bundle content so
+   * an install orchestrator can fail before any file is written.
+   * @param target Target chosen via `--target <name>`.
+   * @param files Extracted bundle files.
+   * @returns A deterministic write plan.
+   */
+  preflight?(target: Target, files: ExtractedFiles): Promise<TargetWritePlan>;
+
+  /**
    * Write the bundle into the target.
    * @param target Target chosen via `--target <name>`.
    * @param files Extracted bundle files.
    * @returns TargetWriteResult.
    */
   write(target: Target, files: ExtractedFiles): Promise<TargetWriteResult>;
+
+  /**
+   * Best-effort rollback for paths returned in `TargetWriteResult.written`.
+   *
+   * This is optional for compatibility with existing custom writers. Built-in
+   * writers implement it so a late skipped result or write-policy failure does
+   * not leave files behind without a lockfile entry.
+   * @param target Target chosen via `--target <name>`.
+   * @param written Absolute paths returned by a prior write.
+   */
+  rollback?(target: Target, written: readonly string[]): Promise<void>;
 
   /**
    * Remove a single file from the target.

--- a/packages/core/src/public/schemas/collection.schema.json
+++ b/packages/core/src/public/schemas/collection.schema.json
@@ -57,7 +57,21 @@
             "examples": [
               "prompts/my-prompt.prompt.md",
               "instructions/code-style.instructions.md",
-              "skills/my-skill/SKILL.md"
+              "chat-modes/review.chatmode.md",
+              "agents/security.agent.md",
+              "skills/my-skill/SKILL.md",
+              "plugins/my-plugin/plugin.json",
+              "hooks/pre-commit.hook.json",
+              "mcp-servers/github.mcp.json",
+              ".kiro/steering/api-standards.md",
+              ".kiro/specs/feature/requirements.md",
+              ".claude/commands/deploy.md",
+              ".cursor/rules/backend.mdc",
+              ".claude/output-styles/terse.md",
+              ".opencode/tools/database.py",
+              "powers/stripe/POWER.md",
+              "knowledge/onboarding.md",
+              "playbooks/bug-fix.md"
             ]
           },
           "kind": {
@@ -70,7 +84,17 @@
               "agent",
               "skill",
               "plugin",
-              "hook"
+              "hook",
+              "mcp-server",
+              "steering",
+              "spec",
+              "command",
+              "rule",
+              "output-style",
+              "tool",
+              "power",
+              "knowledge",
+              "playbook"
             ]
           },
           "title": {

--- a/packages/core/src/public/schemas/deployment-manifest.schema.json
+++ b/packages/core/src/public/schemas/deployment-manifest.schema.json
@@ -1,0 +1,254 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/AmadeusITGroup/ai-primitives-hub/schemas/deployment-manifest.schema.json",
+  "title": "AI Primitives Hub release deployment manifest",
+  "description": "Versioned, self-contained release archive manifest. Legacy manifests without formatVersion remain compatibility content and are validated by the runtime compatibility validator.",
+  "type": "object",
+  "required": [
+    "formatVersion",
+    "id",
+    "version",
+    "name",
+    "items",
+    "files",
+    "provenance"
+  ],
+  "properties": {
+    "formatVersion": {
+      "const": 1,
+      "description": "Version of the self-contained release manifest contract."
+    },
+    "id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "description": {
+      "type": "string"
+    },
+    "author": {
+      "type": "string"
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "environments": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "readme": {
+      "type": "string",
+      "minLength": 1
+    },
+    "license": {
+      "type": "string",
+      "minLength": 1
+    },
+    "repository": {
+      "type": "string"
+    },
+    "items": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/item"
+      }
+    },
+    "prompts": {
+      "type": "array",
+      "description": "Legacy compatibility projection of canonical items.",
+      "items": {
+        "$ref": "#/definitions/legacyItem"
+      }
+    },
+    "files": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/file"
+      }
+    },
+    "provenance": {
+      "$ref": "#/definitions/provenance"
+    },
+    "dependencies": {
+      "type": "array"
+    },
+    "mcpServers": {
+      "type": "object"
+    },
+    "mcpInputs": {
+      "type": "array"
+    }
+  },
+  "additionalProperties": true,
+  "definitions": {
+    "bundlePath": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?!/)(?!.*\\\\)(?!.*(?:^|/)\\.\\.(?:/|$)).+$"
+    },
+    "item": {
+      "type": "object",
+      "required": [
+        "id",
+        "path",
+        "kind"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "path": {
+          "$ref": "#/definitions/bundlePath"
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "prompt",
+            "instruction",
+            "chat-mode",
+            "agent",
+            "skill",
+            "plugin",
+            "hook",
+            "mcp-server",
+            "steering",
+            "spec",
+            "command",
+            "rule",
+            "output-style",
+            "tool",
+            "power",
+            "knowledge",
+            "playbook"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "legacyItem": {
+      "type": "object",
+      "required": [
+        "id",
+        "file",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "file": {
+          "$ref": "#/definitions/bundlePath"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "file": {
+      "type": "object",
+      "required": [
+        "path",
+        "role",
+        "size",
+        "sha256"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/bundlePath"
+        },
+        "role": {
+          "type": "string",
+          "enum": [
+            "installable",
+            "metadata",
+            "ignored"
+          ]
+        },
+        "size": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        }
+      },
+      "additionalProperties": false
+    },
+    "provenance": {
+      "type": "object",
+      "required": [
+        "source",
+        "revision",
+        "collectionPath",
+        "sourceSnapshotPath",
+        "license",
+        "licensePath"
+      ],
+      "properties": {
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "revision": {
+          "type": "string",
+          "minLength": 1
+        },
+        "collectionPath": {
+          "$ref": "#/definitions/bundlePath"
+        },
+        "sourceSnapshotPath": {
+          "$ref": "#/definitions/bundlePath"
+        },
+        "license": {
+          "type": "string",
+          "minLength": 1
+        },
+        "licensePath": {
+          "$ref": "#/definitions/bundlePath"
+        }
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/packages/core/test/domain/collection/manifest-validator.test.ts
+++ b/packages/core/test/domain/collection/manifest-validator.test.ts
@@ -4,16 +4,23 @@ import {
   it,
 } from 'vitest';
 import {
+  getInstallableBundleFiles,
   ManifestValidationError,
   validateManifest,
 } from '../../../src/domain/collection/manifest-validator';
 import type {
   ExtractedFiles,
 } from '../../../src/ports/bundle-extractor';
+import {
+  createGovernedReleaseArchive,
+  createLegacyReleaseArchive,
+} from '../../fixtures/release-archives';
 
 const filesWith = (yaml: string): ExtractedFiles => new Map([
   ['deployment-manifest.yml', new TextEncoder().encode(yaml)]
 ]);
+
+const bytes = (content: string): Uint8Array => new TextEncoder().encode(content);
 
 describe('validateManifest', () => {
   it('returns the parsed manifest when id/version/name are present and nothing is expected', () => {
@@ -96,5 +103,54 @@ describe('validateManifest', () => {
     );
 
     expect(manifest.version).toBe('1.0.0');
+  });
+
+  it('keeps every legacy archive entry available to compatibility writers', () => {
+    const files = createLegacyReleaseArchive({ id: 'legacy-bundle' });
+
+    const manifest = validateManifest(files, {});
+
+    expect(manifest.formatVersion).toBeUndefined();
+    expect([...getInstallableBundleFiles(files, manifest).keys()]).toEqual([...files.keys()]);
+  });
+
+  it('validates a fully governed release and exposes only installable files', () => {
+    const files = createGovernedReleaseArchive({ id: 'governed-bundle' });
+
+    const manifest = validateManifest(files, {});
+
+    expect(manifest.formatVersion).toBe(1);
+    expect(manifest.items).toEqual([{
+      id: 'hello',
+      path: 'prompts/hello.prompt.md',
+      kind: 'prompt'
+    }]);
+    expect(manifest.files).toEqual(expect.arrayContaining([
+      expect.objectContaining({ path: 'README.md', role: 'metadata' }),
+      expect.objectContaining({ path: 'LICENSE', role: 'metadata' }),
+      expect.objectContaining({ path: 'ignored/build/cache.pyc', role: 'ignored' })
+    ]));
+    expect([...getInstallableBundleFiles(files, manifest).keys()]).toEqual([
+      'deployment-manifest.yml',
+      'prompts/hello.prompt.md'
+    ]);
+  });
+
+  it('rejects a versioned manifest when archive content is not declared in its inventory', () => {
+    const malformed = new Map(createGovernedReleaseArchive());
+    malformed.set('unexpected.txt', bytes('not declared'));
+
+    expect(() => validateManifest(malformed, {})).toThrowError(
+      expect.objectContaining({ code: 'BUNDLE.MANIFEST_INVALID' })
+    );
+  });
+
+  it('rejects a versioned manifest when an inventoried file is tampered with', () => {
+    const malformed = new Map(createGovernedReleaseArchive());
+    malformed.set('prompts/hello.prompt.md', bytes('# Tampered\n'));
+
+    expect(() => validateManifest(malformed, {})).toThrowError(
+      expect.objectContaining({ code: 'BUNDLE.MANIFEST_INVALID' })
+    );
   });
 });

--- a/packages/core/test/domain/install/target.test.ts
+++ b/packages/core/test/domain/install/target.test.ts
@@ -30,6 +30,47 @@ describe('isTarget', () => {
     ).toBe(true);
   });
 
+  it('accepts canonical primitive kinds in an allowlist', () => {
+    expect(
+      isTarget({
+        name: 'restricted-vscode',
+        type: 'vscode',
+        scope: 'user',
+        allowedKinds: ['prompt', 'skill', 'mcp-server']
+      })
+    ).toBe(true);
+  });
+
+  it('rejects legacy route aliases and unknown kinds in an allowlist', () => {
+    expect(
+      isTarget({
+        name: 'legacy-vscode',
+        type: 'vscode',
+        scope: 'user',
+        allowedKinds: ['skills']
+      })
+    ).toBe(false);
+    expect(
+      isTarget({
+        name: 'unknown-vscode',
+        type: 'vscode',
+        scope: 'user',
+        allowedKinds: ['not-a-kind']
+      })
+    ).toBe(false);
+  });
+
+  it('rejects a non-array allowlist', () => {
+    expect(
+      isTarget({
+        name: 'invalid-vscode',
+        type: 'vscode',
+        scope: 'user',
+        allowedKinds: 'prompt'
+      })
+    ).toBe(false);
+  });
+
   it('rejects a missing or empty name', () => {
     expect(isTarget({ type: 'vscode' })).toBe(false);
     expect(isTarget({ name: '', type: 'vscode' })).toBe(false);

--- a/packages/core/test/domain/primitive/types.test.ts
+++ b/packages/core/test/domain/primitive/types.test.ts
@@ -5,6 +5,7 @@ import {
 } from 'vitest';
 import {
   isPrimitiveKind,
+  normalizePrimitiveKind,
   PRIMITIVE_KINDS,
 } from '../../../src/domain/primitive/types';
 
@@ -23,5 +24,31 @@ describe('isPrimitiveKind', () => {
     expect(isPrimitiveKind(undefined)).toBe(false);
     expect(isPrimitiveKind(null)).toBe(false);
     expect(isPrimitiveKind(42)).toBe(false);
+  });
+});
+
+describe('normalizePrimitiveKind', () => {
+  it('returns canonical kinds unchanged', () => {
+    for (const kind of PRIMITIVE_KINDS) {
+      expect(normalizePrimitiveKind(kind)).toBe(kind);
+    }
+  });
+
+  it('maps legacy route and manifest aliases to canonical kinds', () => {
+    expect(normalizePrimitiveKind('prompts')).toBe('prompt');
+    expect(normalizePrimitiveKind('instructions')).toBe('instruction');
+    expect(normalizePrimitiveKind('chatmode')).toBe('chat-mode');
+    expect(normalizePrimitiveKind('skills')).toBe('skill');
+    expect(normalizePrimitiveKind('mcp')).toBe('mcp-server');
+  });
+
+  it('normalizes surrounding whitespace and casing', () => {
+    expect(normalizePrimitiveKind('  OUTPUT-STYLES ')).toBe('output-style');
+  });
+
+  it('returns null for unknown and non-string values', () => {
+    expect(normalizePrimitiveKind('not-a-kind')).toBeNull();
+    expect(normalizePrimitiveKind(undefined)).toBeNull();
+    expect(normalizePrimitiveKind(null)).toBeNull();
   });
 });

--- a/packages/core/test/fixtures/release-archives.ts
+++ b/packages/core/test/fixtures/release-archives.ts
@@ -1,0 +1,91 @@
+import {
+  createHash,
+} from 'node:crypto';
+import {
+  dump as dumpYaml,
+} from 'js-yaml';
+import type {
+  ExtractedFiles,
+} from '../../src/ports/bundle-extractor';
+
+export interface ReleaseArchiveFixtureOptions {
+  id?: string;
+  version?: string;
+}
+
+const bytes = (content: string): Uint8Array => new TextEncoder().encode(content);
+
+const sha256 = (content: string): string =>
+  `sha256:${createHash('sha256').update(bytes(content)).digest('hex')}`;
+
+/**
+ * Minimal historical archive shape: no formatVersion and no governed
+ * inventory. Its archive entries represent the historical installable
+ * content emitted by the legacy builder.
+ * @param options
+ */
+export const createLegacyReleaseArchive = (
+  options: ReleaseArchiveFixtureOptions = {}
+): ExtractedFiles => {
+  const id = options.id ?? 'legacy-bundle';
+  const version = options.version ?? '1.0.0';
+  const archiveFiles = { 'prompts/hello.prompt.md': '# Hello Prompt\n' };
+  const manifest = `id: ${id}\nversion: ${version}\nname: Legacy Bundle\nprompts:\n  - id: hello\n    file: prompts/hello.prompt.md\n    type: prompt\n`;
+
+  return new Map([
+    ['deployment-manifest.yml', bytes(manifest)],
+    ...Object.entries(archiveFiles).map(([filePath, content]) => [filePath, bytes(content)] as const)
+  ]);
+};
+
+/**
+ * Fully governed archive shape: canonical items, complete file inventory,
+ * immutable provenance, embedded source/license evidence, and explicit
+ * metadata-only and ignored classifications.
+ * @param options
+ */
+export const createGovernedReleaseArchive = (
+  options: ReleaseArchiveFixtureOptions = {}
+): ExtractedFiles => {
+  const id = options.id ?? 'governed-bundle';
+  const version = options.version ?? '1.0.0';
+  const sourceSnapshotPath = 'metadata/source/collections/governed.collection.yml';
+  const archiveFiles = {
+    'prompts/hello.prompt.md': '# Hello Prompt\n',
+    [sourceSnapshotPath]: `id: ${id}\n`,
+    'README.md': '# Governed bundle\n',
+    LICENSE: 'Governed license text\n',
+    'ignored/build/cache.pyc': 'cache bytes\n'
+  };
+  const files = Object.entries(archiveFiles).map(([filePath, content]) => ({
+    path: filePath,
+    role: filePath.startsWith('prompts/')
+      ? 'installable'
+      : (filePath.startsWith('ignored/') ? 'ignored' : 'metadata'),
+    size: bytes(content).byteLength,
+    sha256: sha256(content)
+  }));
+  const manifest = {
+    formatVersion: 1,
+    id,
+    version,
+    name: 'Governed Bundle',
+    readme: 'README.md',
+    items: [{ id: 'hello', path: 'prompts/hello.prompt.md', kind: 'prompt' }],
+    prompts: [{ id: 'hello', file: 'prompts/hello.prompt.md', type: 'prompt' }],
+    provenance: {
+      source: 'https://github.com/example/governed-bundle',
+      revision: '0123456789abcdef0123456789abcdef01234567',
+      collectionPath: 'collections/governed.collection.yml',
+      sourceSnapshotPath,
+      license: 'Governed-License',
+      licensePath: 'LICENSE'
+    },
+    files
+  };
+
+  return new Map([
+    ['deployment-manifest.yml', bytes(dumpYaml(manifest, { lineWidth: -1 }))],
+    ...Object.entries(archiveFiles).map(([filePath, content]) => [filePath, bytes(content)] as const)
+  ]);
+};

--- a/packages/infra/src/writers/default-layouts.json
+++ b/packages/infra/src/writers/default-layouts.json
@@ -5,7 +5,7 @@
         "baseDir": "${HOME}/.copilot",
         "kindRoutes": {
           "prompts/": "prompts/",
-          "chatmodes/": "agents/",
+          "chat-modes/": "agents/",
           "instructions/": "instructions/",
           "agents/": "agents/",
           "skills/": "skills/",
@@ -23,7 +23,7 @@
         "baseDir": "${workspaceRoot}/.github",
         "kindRoutes": {
           "prompts/": "prompts/",
-          "chatmodes/": "agents/",
+          "chat-modes/": "agents/",
           "instructions/": "instructions/",
           "agents/": "agents/",
           "skills/": "skills/",
@@ -43,7 +43,7 @@
         "baseDir": "${HOME}/.copilot",
         "kindRoutes": {
           "prompts/": "prompts/",
-          "chatmodes/": "agents/",
+          "chat-modes/": "agents/",
           "instructions/": "instructions/",
           "agents/": "agents/",
           "skills/": "skills/",
@@ -61,7 +61,7 @@
         "baseDir": "${workspaceRoot}/.github",
         "kindRoutes": {
           "prompts/": "prompts/",
-          "chatmodes/": "agents/",
+          "chat-modes/": "agents/",
           "instructions/": "instructions/",
           "agents/": "agents/",
           "skills/": "skills/",
@@ -114,9 +114,13 @@
       "user": {
         "baseDir": "${HOME}/.kiro",
         "kindRoutes": {
+          ".kiro/steering/": "steering/",
+          ".kiro/specs/": "specs/",
+          "powers/": "powers/",
           "prompts/": "steering/",
-          "agents/": "agents/",
           "instructions/": "steering/",
+          "chat-modes/": "agents/",
+          "agents/": "agents/",
           "skills/": "skills/"
         },
         "skipPaths": ["deployment-manifest.yml", "README.md"],
@@ -128,10 +132,56 @@
       "repository": {
         "baseDir": "${workspaceRoot}/.kiro",
         "kindRoutes": {
+          ".kiro/steering/": "steering/",
+          ".kiro/specs/": "specs/",
+          "powers/": "powers/",
           "prompts/": "steering/",
-          "agents/": "agents/",
           "instructions/": "steering/",
+          "chat-modes/": "agents/",
+          "agents/": "agents/",
           "skills/": "skills/"
+        },
+        "skipPaths": ["deployment-manifest.yml", "README.md"],
+        "mcpConfig": {
+          "path": "${workspaceRoot}/.kiro/settings/mcp.json",
+          "serversKey": "mcpServers"
+        }
+      }
+    },
+    "kiro-cli": {
+      "user": {
+        "baseDir": "${HOME}/.kiro",
+        "kindRoutes": {
+          ".kiro/steering/": "steering/",
+          ".kiro/specs/": "specs/",
+          "powers/": "powers/",
+          "prompts/": "steering/",
+          "instructions/": "steering/",
+          "chat-modes/": "agents/",
+          "agents/": "agents/",
+          "skills/": "skills/",
+          "hooks/": "hooks/",
+          "plugins/": "plugins/"
+        },
+        "skipPaths": ["deployment-manifest.yml", "README.md"],
+        "mcpConfig": {
+          "path": "${HOME}/.kiro/settings/mcp.json",
+          "serversKey": "mcpServers"
+        }
+      },
+      "repository": {
+        "baseDir": "${workspaceRoot}/.kiro",
+        "kindRoutes": {
+          ".kiro/steering/": "steering/",
+          ".kiro/specs/": "specs/",
+          "powers/": "powers/",
+          "prompts/": "steering/",
+          "instructions/": "steering/",
+          "chat-modes/": "agents/",
+          "agents/": "agents/",
+          "skills/": "skills/",
+          "hooks/": "hooks/",
+          "plugins/": "plugins/"
         },
         "skipPaths": ["deployment-manifest.yml", "README.md"],
         "mcpConfig": {
@@ -146,9 +196,11 @@
         "kindRoutes": {
           "prompts/": "rules/",
           "instructions/": "rules/",
-          "chatmodes/": "agents/",
+          "chat-modes/": "agents/",
           "agents/": "agents/",
-          "skills/": "skills/"
+          "skills/": "skills/",
+          "hooks/": "hooks/",
+          "plugins/": "plugins/"
         },
         "skipPaths": ["deployment-manifest.yml", "README.md"],
         "mcpConfig": {
@@ -161,9 +213,11 @@
         "kindRoutes": {
           "prompts/": "rules/",
           "instructions/": "rules/",
-          "chatmodes/": "agents/",
+          "chat-modes/": "agents/",
           "agents/": "agents/",
-          "skills/": "skills/"
+          "skills/": "skills/",
+          "hooks/": "hooks/",
+          "plugins/": "plugins/"
         },
         "skipPaths": ["deployment-manifest.yml", "README.md"]
       }
@@ -172,10 +226,12 @@
       "user": {
         "baseDir": "${HOME}/.claude",
         "kindRoutes": {
+          ".claude/commands/": "commands/",
+          ".claude/output-styles/": "output-styles/",
           "prompts/": "commands/",
-          "agents/": "agents/",
           "instructions/": "instructions/",
-          "chatmodes/": "agents/",
+          "chat-modes/": "agents/",
+          "agents/": "agents/",
           "skills/": "skills/",
           "hooks/": "hooks/",
           "plugins/": "plugins/"
@@ -189,10 +245,12 @@
       "repository": {
         "baseDir": "${workspaceRoot}/.claude",
         "kindRoutes": {
+          ".claude/commands/": "commands/",
+          ".claude/output-styles/": "output-styles/",
           "prompts/": "commands/",
-          "agents/": "agents/",
           "instructions/": "instructions/",
-          "chatmodes/": "agents/",
+          "chat-modes/": "agents/",
+          "agents/": "agents/",
           "skills/": "skills/",
           "hooks/": "hooks/",
           "plugins/": "plugins/"
@@ -200,6 +258,184 @@
         "skipPaths": ["deployment-manifest.yml", "README.md"],
         "mcpConfig": {
           "path": "${workspaceRoot}/.mcp.json",
+          "serversKey": "mcpServers"
+        }
+      }
+    },
+    "cursor": {
+      "user": {
+        "baseDir": "${HOME}/.cursor",
+        "kindRoutes": {
+          ".cursor/rules/": "rules/",
+          ".cursor/agents/": "agents/",
+          ".cursor/skills/": "skills/",
+          ".cursor/commands/": "commands/",
+          "prompts/": "rules/",
+          "instructions/": "rules/",
+          "chat-modes/": "agents/",
+          "agents/": "agents/",
+          "skills/": "skills/",
+          "hooks/": "hooks/",
+          "plugins/": "plugins/"
+        },
+        "skipPaths": ["deployment-manifest.yml", "README.md"],
+        "mcpConfig": {
+          "path": "${HOME}/.cursor/mcp.json",
+          "serversKey": "mcpServers"
+        }
+      },
+      "repository": {
+        "baseDir": "${workspaceRoot}",
+        "kindRoutes": {
+          ".cursor/rules/": ".cursor/rules/",
+          ".cursor/agents/": ".cursor/agents/",
+          ".cursor/skills/": ".cursor/skills/",
+          ".cursor/commands/": ".cursor/commands/",
+          "prompts/": ".cursor/rules/",
+          "instructions/": ".cursor/rules/",
+          "chat-modes/": ".cursor/agents/",
+          "agents/": ".cursor/agents/",
+          "skills/": ".cursor/skills/",
+          "hooks/": ".cursor/hooks/",
+          "plugins/": ".cursor/plugins/"
+        },
+        "skipPaths": ["deployment-manifest.yml", "README.md"],
+        "mcpConfig": {
+          "path": "${workspaceRoot}/.cursor/mcp.json",
+          "serversKey": "mcpServers"
+        }
+      }
+    },
+    "opencode": {
+      "user": {
+        "baseDir": "${HOME}/.opencode",
+        "kindRoutes": {
+          ".opencode/tools/": "tools/",
+          ".opencode/commands/": "commands/",
+          ".opencode/agents/": "agents/",
+          ".opencode/skills/": "skills/",
+          ".opencode/rules/": "rules/",
+          ".opencode/hooks/": "hooks/",
+          ".opencode/plugins/": "plugins/",
+          "prompts/": "commands/",
+          "instructions/": "rules/",
+          "chat-modes/": "agents/",
+          "agents/": "agents/",
+          "skills/": "skills/",
+          "hooks/": "hooks/",
+          "plugins/": "plugins/"
+        },
+        "skipPaths": ["deployment-manifest.yml", "README.md"],
+        "mcpConfig": {
+          "path": "${HOME}/.opencode/mcp.json",
+          "serversKey": "mcpServers"
+        }
+      },
+      "repository": {
+        "baseDir": "${workspaceRoot}",
+        "kindRoutes": {
+          ".opencode/tools/": ".opencode/tools/",
+          ".opencode/commands/": ".opencode/commands/",
+          ".opencode/agents/": ".opencode/agents/",
+          ".opencode/skills/": ".opencode/skills/",
+          ".opencode/rules/": ".opencode/rules/",
+          ".opencode/hooks/": ".opencode/hooks/",
+          ".opencode/plugins/": ".opencode/plugins/",
+          "prompts/": ".opencode/commands/",
+          "instructions/": ".opencode/rules/",
+          "chat-modes/": ".opencode/agents/",
+          "agents/": ".opencode/agents/",
+          "skills/": ".opencode/skills/",
+          "hooks/": ".opencode/hooks/",
+          "plugins/": ".opencode/plugins/"
+        },
+        "skipPaths": ["deployment-manifest.yml", "README.md"],
+        "mcpConfig": {
+          "path": "${workspaceRoot}/.opencode/mcp.json",
+          "serversKey": "mcpServers"
+        }
+      }
+    },
+    "devin": {
+      "user": {
+        "baseDir": "${HOME}/.devin",
+        "kindRoutes": {
+          "knowledge/": "knowledge/",
+          "playbooks/": "playbooks/",
+          "powers/": "powers/",
+          "prompts/": "prompts/",
+          "instructions/": "instructions/",
+          "chat-modes/": "agents/",
+          "agents/": "agents/",
+          "skills/": "skills/",
+          "hooks/": "hooks/",
+          "plugins/": "plugins/"
+        },
+        "skipPaths": ["deployment-manifest.yml", "README.md"],
+        "mcpConfig": {
+          "path": "${HOME}/.devin/mcp.json",
+          "serversKey": "mcpServers"
+        }
+      },
+      "repository": {
+        "baseDir": "${workspaceRoot}",
+        "kindRoutes": {
+          "knowledge/": ".devin/knowledge/",
+          "playbooks/": ".devin/playbooks/",
+          "powers/": ".devin/powers/",
+          "prompts/": ".devin/prompts/",
+          "instructions/": ".devin/instructions/",
+          "chat-modes/": ".devin/agents/",
+          "agents/": ".devin/agents/",
+          "skills/": ".devin/skills/",
+          "hooks/": ".devin/hooks/",
+          "plugins/": ".devin/plugins/"
+        },
+        "skipPaths": ["deployment-manifest.yml", "README.md"],
+        "mcpConfig": {
+          "path": "${workspaceRoot}/.devin/mcp.json",
+          "serversKey": "mcpServers"
+        }
+      }
+    },
+    "devin-cli": {
+      "user": {
+        "baseDir": "${HOME}/.devin",
+        "kindRoutes": {
+          "knowledge/": "knowledge/",
+          "playbooks/": "playbooks/",
+          "powers/": "powers/",
+          "prompts/": "prompts/",
+          "instructions/": "instructions/",
+          "chat-modes/": "agents/",
+          "agents/": "agents/",
+          "skills/": "skills/",
+          "hooks/": "hooks/",
+          "plugins/": "plugins/"
+        },
+        "skipPaths": ["deployment-manifest.yml", "README.md"],
+        "mcpConfig": {
+          "path": "${HOME}/.devin/mcp.json",
+          "serversKey": "mcpServers"
+        }
+      },
+      "repository": {
+        "baseDir": "${workspaceRoot}",
+        "kindRoutes": {
+          "knowledge/": ".devin/knowledge/",
+          "playbooks/": ".devin/playbooks/",
+          "powers/": ".devin/powers/",
+          "prompts/": ".devin/prompts/",
+          "instructions/": ".devin/instructions/",
+          "chat-modes/": ".devin/agents/",
+          "agents/": ".devin/agents/",
+          "skills/": ".devin/skills/",
+          "hooks/": ".devin/hooks/",
+          "plugins/": ".devin/plugins/"
+        },
+        "skipPaths": ["deployment-manifest.yml", "README.md"],
+        "mcpConfig": {
+          "path": "${workspaceRoot}/.devin/mcp.json",
           "serversKey": "mcpServers"
         }
       }

--- a/packages/infra/src/writers/repo-scope-writer.ts
+++ b/packages/infra/src/writers/repo-scope-writer.ts
@@ -17,11 +17,14 @@ import * as path from 'node:path';
 import type {
   ExtractedFiles,
   FileSystem,
+  PrimitiveKind,
   Target,
+  TargetWritePlan,
   TargetWriter,
   TargetWriteResult,
 } from '@ai-primitives-hub/core';
 import {
+  normalizePrimitiveKind,
   verifyWrittenBytes,
 } from '@ai-primitives-hub/core';
 import {
@@ -57,10 +60,12 @@ export interface RepositoryScopeWriterOptions {
  * Deployment manifest structure (matches test format).
  */
 interface DeploymentManifest {
+  formatVersion?: number;
   id?: string;
   version?: string;
   name?: string;
   description?: string;
+  items?: { path: string; kind: string; id?: string }[];
   prompts?: { id: string; file: string; type: string }[];
   agents?: { id: string; file: string; type: string }[];
   instructions?: { id: string; file: string; type: string }[];
@@ -76,6 +81,7 @@ interface WriteResult {
   written: string[];
   skipped: string[];
   skillDirs: string[];
+  writtenBundlePaths: string[];
 }
 
 /**
@@ -142,10 +148,10 @@ export class RepositoryScopeWriter {
     if (typeLower === 'prompt') {
       return 'copilot/prompts';
     }
-    if (typeLower === 'instruction') {
+    if (typeLower === 'instruction' || typeLower === 'instructions') {
       return 'copilot/instructions';
     }
-    if (typeLower === 'agent') {
+    if (typeLower === 'agent' || typeLower === 'chatmode' || typeLower === 'chat-mode') {
       return 'copilot/agents';
     }
     if (typeLower === 'skill') {
@@ -200,12 +206,14 @@ export class RepositoryScopeWriter {
    * @param files Extracted bundle files.
    * @param written Accumulates written file paths.
    * @param skillDirs Accumulates skill directory paths.
+   * @param writtenBundlePaths
    */
   private async installSkillItem(
     p: { file: string; id?: string },
     files: ExtractedFiles,
     written: string[],
-    skillDirs: string[]
+    skillDirs: string[],
+    writtenBundlePaths: string[]
   ): Promise<void> {
     const sourceSkillId = this.extractSkillId(p.file);
     const sourcePrefix = `skills/${sourceSkillId}`;
@@ -217,6 +225,7 @@ export class RepositoryScopeWriter {
         const targetPath = path.join(skillDir, relativePath);
         await this.writeBytesVerified(targetPath, bytes);
         written.push(targetPath);
+        writtenBundlePaths.push(bundlePath);
       }
     }
     skillDirs.push(skillDir);
@@ -230,12 +239,14 @@ export class RepositoryScopeWriter {
    * @param files Extracted bundle files.
    * @param written Accumulates written file paths.
    * @param skillDirs Accumulates plugin directory paths (reusing skillDirs for cleanup).
+   * @param writtenBundlePaths
    */
   private async installPluginItem(
     p: { file: string; id?: string },
     files: ExtractedFiles,
     written: string[],
-    skillDirs: string[]
+    skillDirs: string[],
+    writtenBundlePaths: string[]
   ): Promise<void> {
     const sourcePluginId = this.extractPluginId(p.file);
     const sourcePrefix = `plugins/${sourcePluginId}`;
@@ -247,6 +258,7 @@ export class RepositoryScopeWriter {
         const targetPath = path.join(pluginDir, relativePath);
         await this.writeBytesVerified(targetPath, bytes);
         written.push(targetPath);
+        writtenBundlePaths.push(bundlePath);
       }
     }
     skillDirs.push(pluginDir);
@@ -257,13 +269,20 @@ export class RepositoryScopeWriter {
     files: ExtractedFiles,
     written: string[],
     skipped: string[],
-    skillDirs: string[]
+    skillDirs: string[],
+    writtenBundlePaths: string[],
+    allowedKinds: ReadonlySet<PrimitiveKind> | null
   ): Promise<void> {
     for (const p of items) {
+      const kind = normalizePrimitiveKind(p.type);
+      if (allowedKinds !== null && (kind === null || !allowedKinds.has(kind))) {
+        skipped.push(p.file);
+        continue;
+      }
       if (p.type.toLowerCase() === 'skill') {
-        await this.installSkillItem(p, files, written, skillDirs);
+        await this.installSkillItem(p, files, written, skillDirs, writtenBundlePaths);
       } else if (p.type.toLowerCase() === 'plugin') {
-        await this.installPluginItem(p, files, written, skillDirs);
+        await this.installPluginItem(p, files, written, skillDirs, writtenBundlePaths);
       } else {
         const bytes = files.get(p.file);
         if (bytes) {
@@ -271,6 +290,7 @@ export class RepositoryScopeWriter {
           if (targetPath) {
             await this.writeBytesVerified(targetPath, bytes);
             written.push(targetPath);
+            writtenBundlePaths.push(p.file);
           } else {
             skipped.push(p.file);
           }
@@ -400,69 +420,117 @@ export class RepositoryScopeWriter {
     }
   }
 
+  private getManifestItems(manifest: DeploymentManifest): { file: string; type: string; id?: string }[] {
+    if (manifest.formatVersion === 1 && manifest.items !== undefined) {
+      return manifest.items.map((item) => ({ file: item.path, type: item.kind, id: item.id }));
+    }
+    return [
+      ...(manifest.items?.map((item) => ({ file: item.path, type: item.kind, id: item.id })) ?? []),
+      ...(manifest.prompts ?? []),
+      ...(manifest.agents ?? []),
+      ...(manifest.instructions ?? []),
+      ...(manifest.hooks ?? []),
+      ...(manifest.plugins ?? []),
+      // Legacy skill IDs were descriptive metadata rather than installation
+      // destination overrides. Preserve the historical source-directory route
+      // for unversioned manifests; canonical `items[]` remains authoritative
+      // for governed releases above.
+      ...(manifest.skills?.map((item) => ({ file: item.file, type: item.type })) ?? [])
+    ];
+  }
+
+  /**
+   * Plan a repository write without changing the filesystem.
+   * @param files Extracted bundle files.
+   * @param allowedKinds Optional canonical target allowlist.
+   * @returns Bundle-relative writable and skipped paths.
+   */
+  public async preflight(
+    files: ExtractedFiles,
+    allowedKinds?: readonly PrimitiveKind[]
+  ): Promise<TargetWritePlan> {
+    const manifestBytes = files.get('deployment-manifest.yml');
+    if (manifestBytes === undefined) {
+      return { writable: [], skipped: [] };
+    }
+    const manifest = await this.parseManifest(manifestBytes);
+    const allowed = allowedKinds === undefined ? null : new Set(allowedKinds);
+    const writable: string[] = [];
+    const skipped: string[] = [];
+
+    for (const item of this.getManifestItems(manifest)) {
+      const kind = normalizePrimitiveKind(item.type);
+      if (kind === null || (allowed !== null && !allowed.has(kind))) {
+        skipped.push(item.file);
+        continue;
+      }
+      if (kind === 'skill' || kind === 'plugin') {
+        const prefix = `${path.posix.dirname(item.file)}/`;
+        const matches = [...files.keys()].filter((file) => file.startsWith(prefix));
+        if (matches.length === 0) {
+          skipped.push(item.file);
+        } else {
+          writable.push(...matches);
+        }
+        continue;
+      }
+      if (files.has(item.file) && this.getTargetPath({ type: item.type, file: item.file }) !== null) {
+        writable.push(item.file);
+      } else {
+        skipped.push(item.file);
+      }
+    }
+
+    return { writable, skipped };
+  }
+
   /**
    * Write bundle files to repository scope.
    * @param files - Extracted bundle files.
+   * @param allowedKinds
    * @returns Write result with written paths.
    */
-  public async write(files: ExtractedFiles): Promise<WriteResult> {
+  public async write(files: ExtractedFiles, allowedKinds?: readonly PrimitiveKind[]): Promise<WriteResult> {
     const written: string[] = [];
     const skipped: string[] = [];
     const skillDirs: string[] = [];
+    const writtenBundlePaths: string[] = [];
+    const allowed = allowedKinds === undefined ? null : new Set(allowedKinds);
 
     const manifestBytes = files.get('deployment-manifest.yml');
     if (!manifestBytes) {
-      return { written, skipped, skillDirs };
+      return { written, skipped, skillDirs, writtenBundlePaths };
     }
 
     const manifest = await this.parseManifest(manifestBytes);
 
-    // Process prompts, agents, and instructions (skill items get directory install)
-    if (manifest.prompts) {
-      await this.processManifestItems(manifest.prompts, files, written, skipped, skillDirs);
-    }
-    if (manifest.agents) {
-      await this.processManifestItems(manifest.agents, files, written, skipped, skillDirs);
-    }
-    if (manifest.instructions) {
-      await this.processManifestItems(manifest.instructions, files, written, skipped, skillDirs);
-    }
-    // Process hooks and plugins
-    if (manifest.hooks) {
-      await this.processManifestItems(manifest.hooks, files, written, skipped, skillDirs);
-    }
-    if (manifest.plugins) {
-      await this.processManifestItems(manifest.plugins, files, written, skipped, skillDirs);
-    }
-
-    // Process skills
-    if (manifest.skills) {
-      for (const skillFile of manifest.skills) {
-        const skillId = this.extractSkillId(skillFile.file);
-        const skillPrefix = `skills/${skillId}`;
-        const skillDir = path.join(this.workspaceRoot, '.github', skillPrefix);
-
-        // Install all files in the skill directory
-        for (const [bundlePath, bytes] of files) {
-          if (bundlePath.startsWith(skillPrefix)) {
-            const relativePath = bundlePath.slice(skillPrefix.length);
-            const targetPath = path.join(skillDir, relativePath);
-
-            await this.writeBytesVerified(targetPath, bytes);
-            written.push(targetPath);
-          }
-        }
-
-        skillDirs.push(skillDir);
-      }
-    }
+    await this.processManifestItems(
+      this.getManifestItems(manifest),
+      files,
+      written,
+      skipped,
+      skillDirs,
+      writtenBundlePaths,
+      allowed
+    );
 
     // Update git exclude for local-only mode
     if (this.commitMode === 'local-only') {
       await this.updateGitExclude(written);
     }
 
-    return { written, skipped, skillDirs };
+    return { written, skipped, skillDirs, writtenBundlePaths };
+  }
+
+  /**
+   * Remove paths written by a rejected repository installation.
+   * @param written Absolute paths returned by `write`.
+   */
+  public async rollback(written: readonly string[]): Promise<void> {
+    await this.removePaths([...written]);
+    if (this.commitMode === 'local-only') {
+      await this.removeFromGitExclude([...written]);
+    }
   }
 
   /**
@@ -475,6 +543,34 @@ export class RepositoryScopeWriter {
   }
 
   /**
+   * Remove a bundle-relative file using the same route mapping as `write()`.
+   * Lockfiles record source paths from the bundle, whereas repository output
+   * lives below `.github/` and may use a different subdirectory.
+   * @param filePath - Bundle-relative path recorded in the lockfile.
+   */
+  public async removeBundleFile(filePath: string): Promise<void> {
+    const normalized = filePath.replaceAll('\\', '/');
+    const route = [
+      ['prompts/', 'copilot/prompts/'],
+      ['instructions/', 'copilot/instructions/'],
+      ['chat-modes/', 'copilot/agents/'],
+      ['chatmodes/', 'copilot/agents/'],
+      ['agents/', 'copilot/agents/'],
+      ['skills/', 'skills/'],
+      ['hooks/', 'hooks/'],
+      ['plugins/', 'plugins/']
+    ].find(([sourcePrefix]) => normalized.startsWith(sourcePrefix));
+
+    const targetPath = route === undefined
+      ? path.join(this.workspaceRoot, normalized)
+      : path.join(this.workspaceRoot, '.github', route[1], normalized.slice(route[0].length));
+    await this.removePaths([targetPath]);
+    if (this.commitMode === 'local-only') {
+      await this.removeFromGitExclude([targetPath]);
+    }
+  }
+
+  /**
    * Remove files for a bundle from repository scope.
    * @param bundleId - Bundle identifier (used for logging).
    * @param manifest - Deployment manifest to determine which files to remove.
@@ -483,24 +579,28 @@ export class RepositoryScopeWriter {
     const pathsToRemove: string[] = [];
     const skillDirsToRemove: string[] = [];
 
-    // Collect paths to remove for prompts, agents, and instructions
-    if (manifest.prompts) {
-      this.collectRemovePaths(manifest.prompts, pathsToRemove, skillDirsToRemove);
-    }
-    if (manifest.agents) {
-      this.collectRemovePaths(manifest.agents, pathsToRemove, skillDirsToRemove);
-    }
-    if (manifest.instructions) {
-      this.collectRemovePaths(manifest.instructions, pathsToRemove, skillDirsToRemove);
-    }
+    if (manifest.formatVersion === 1 && manifest.items !== undefined) {
+      this.collectRemovePaths(this.getManifestItems(manifest), pathsToRemove, skillDirsToRemove);
+    } else {
+      // Collect paths to remove for prompts, agents, and instructions
+      if (manifest.prompts) {
+        this.collectRemovePaths(manifest.prompts, pathsToRemove, skillDirsToRemove);
+      }
+      if (manifest.agents) {
+        this.collectRemovePaths(manifest.agents, pathsToRemove, skillDirsToRemove);
+      }
+      if (manifest.instructions) {
+        this.collectRemovePaths(manifest.instructions, pathsToRemove, skillDirsToRemove);
+      }
 
-    // Process skills
-    if (manifest.skills) {
-      for (const skillFile of manifest.skills) {
-        const skillId = this.extractSkillId(skillFile.file);
-        const skillPrefix = `skills/${skillId}`;
-        const skillDir = path.join(this.workspaceRoot, '.github', skillPrefix);
-        skillDirsToRemove.push(skillDir);
+      // Process legacy skills using their historic source-directory route.
+      if (manifest.skills) {
+        for (const skillFile of manifest.skills) {
+          const skillId = this.extractSkillId(skillFile.file);
+          const skillPrefix = `skills/${skillId}`;
+          const skillDir = path.join(this.workspaceRoot, '.github', skillPrefix);
+          skillDirsToRemove.push(skillDir);
+        }
       }
     }
 
@@ -557,19 +657,40 @@ export class RepositoryScopeWriterAdapter implements TargetWriter {
    * @param files
    */
   public async write(_target: Target, files: ExtractedFiles): Promise<TargetWriteResult> {
-    const result = await this.writer.write(files);
+    const result = await this.writer.write(files, _target.allowedKinds);
     return {
       written: result.written,
-      skipped: result.skipped
+      skipped: result.skipped,
+      writtenBundlePaths: result.writtenBundlePaths
     };
   }
 
+  public async preflight(target: Target, files: ExtractedFiles): Promise<TargetWritePlan> {
+    return this.writer.preflight(files, target.allowedKinds);
+  }
+
+  public async rollback(_target: Target, written: readonly string[]): Promise<void> {
+    await this.writer.rollback(written);
+  }
+
   /**
-   * TargetWriter.remove implementation - delegates to RepositoryScopeWriter.removeFile.
+   * TargetWriter.remove implementation - translates bundle-relative lockfile
+   * paths back through the repository writer's output routes. Legacy paths
+   * already relative to `.github/` retain the old behavior.
    * @param _target
    * @param filePath
    */
   public async remove(_target: Target, filePath: string): Promise<void> {
-    await this.writer.removeFile(filePath);
+    const normalized = filePath.replaceAll('\\', '/');
+    if (normalized.startsWith('.github/')) {
+      await this.writer.removeBundleFile(normalized);
+      return;
+    }
+    const knownBundlePrefix = /^(prompts|instructions|chat-modes|chatmodes|agents|skills|hooks|plugins)\//;
+    if (knownBundlePrefix.test(normalized)) {
+      await this.writer.removeBundleFile(normalized);
+      return;
+    }
+    await this.writer.removeFile(normalized);
   }
 }

--- a/packages/infra/test/writers/repo-scope-writer.test.ts
+++ b/packages/infra/test/writers/repo-scope-writer.test.ts
@@ -16,6 +16,10 @@ import {
   it,
 } from 'vitest';
 import {
+  createGovernedReleaseArchive,
+  createLegacyReleaseArchive,
+} from '../../../core/test/fixtures/release-archives';
+import {
   RepositoryScopeWriter,
   RepositoryScopeWriterAdapter,
 } from '../../src/writers/repo-scope-writer';
@@ -63,6 +67,78 @@ describe('RepositoryScopeWriter', () => {
     expect(await fs.exists(expected)).toBe(true);
   });
 
+  it('writes canonical collection items to the repository target', async () => {
+    const fs = new InMemoryFileSystem();
+    const writer = new RepositoryScopeWriter({ fs, workspaceRoot: WORKSPACE_ROOT, commitMode: 'commit' });
+
+    const manifest = `id: collection-bundle
+version: 1.0.0
+name: Collection Bundle
+items:
+  - path: prompts/hello.prompt.md
+    kind: prompt`;
+    const files = new Map<string, Uint8Array>([
+      ['deployment-manifest.yml', new TextEncoder().encode(manifest)],
+      ['prompts/hello.prompt.md', new TextEncoder().encode('# Hello')]
+    ]);
+
+    const result = await writer.write(files);
+
+    const expected = path.join(WORKSPACE_ROOT, '.github', 'copilot', 'prompts', 'hello.prompt.md');
+    expect(result.written).toContain(expected);
+    expect(await fs.exists(expected)).toBe(true);
+  });
+
+  it('uses canonical items once for governed manifests with a legacy projection', async () => {
+    const fs = new InMemoryFileSystem();
+    const writer = new RepositoryScopeWriter({ fs, workspaceRoot: WORKSPACE_ROOT, commitMode: 'commit' });
+    const manifest = `formatVersion: 1
+id: collection-bundle
+version: 1.0.0
+name: Collection Bundle
+items:
+  - id: hello
+    path: prompts/hello.prompt.md
+    kind: prompt
+prompts:
+  - id: hello
+    file: prompts/hello.prompt.md
+    type: prompt`;
+    const files = new Map<string, Uint8Array>([
+      ['deployment-manifest.yml', new TextEncoder().encode(manifest)],
+      ['prompts/hello.prompt.md', new TextEncoder().encode('# Hello')]
+    ]);
+
+    const result = await writer.write(files);
+
+    expect(result.writtenBundlePaths).toEqual(['prompts/hello.prompt.md']);
+    expect(result.written).toHaveLength(1);
+  });
+
+  it('routes the complete legacy archive fixture through its legacy projection', async () => {
+    const fs = new InMemoryFileSystem();
+    const writer = new RepositoryScopeWriter({ fs, workspaceRoot: WORKSPACE_ROOT, commitMode: 'commit' });
+
+    const result = await writer.write(createLegacyReleaseArchive({ id: 'legacy-bundle' }));
+
+    expect(result.writtenBundlePaths).toEqual(['prompts/hello.prompt.md']);
+    expect(result.written).toEqual([
+      path.join(WORKSPACE_ROOT, '.github', 'copilot', 'prompts', 'hello.prompt.md')
+    ]);
+  });
+
+  it('routes only canonical installable items from the complete governed archive fixture', async () => {
+    const fs = new InMemoryFileSystem();
+    const writer = new RepositoryScopeWriter({ fs, workspaceRoot: WORKSPACE_ROOT, commitMode: 'commit' });
+
+    const result = await writer.write(createGovernedReleaseArchive({ id: 'governed-bundle' }));
+
+    expect(result.writtenBundlePaths).toEqual(['prompts/hello.prompt.md']);
+    expect(result.written).toEqual([
+      path.join(WORKSPACE_ROOT, '.github', 'copilot', 'prompts', 'hello.prompt.md')
+    ]);
+  });
+
   it('writes instructions to .github/copilot/instructions/', async () => {
     const fs = new InMemoryFileSystem();
     const writer = new RepositoryScopeWriter({ fs, workspaceRoot: WORKSPACE_ROOT, commitMode: 'commit' });
@@ -75,6 +151,54 @@ describe('RepositoryScopeWriter', () => {
     const result = await writer.write(files);
 
     const expected = path.join(WORKSPACE_ROOT, '.github', 'copilot', 'instructions', 'test.md');
+    expect(result.written).toContain(expected);
+    expect(await fs.exists(expected)).toBe(true);
+  });
+
+  it('writes instructions with plural "instructions" type to .github/copilot/instructions/', async () => {
+    const fs = new InMemoryFileSystem();
+    const writer = new RepositoryScopeWriter({ fs, workspaceRoot: WORKSPACE_ROOT, commitMode: 'commit' });
+
+    const manifest = `id: test-bundle
+version: 1.0.0
+name: Test
+instructions:
+  - id: test-instruction
+    file: instructions/test.md
+    type: instructions`;
+
+    const files = new Map<string, Uint8Array>([
+      ['deployment-manifest.yml', new TextEncoder().encode(manifest)],
+      ['instructions/test.md', new TextEncoder().encode('# Test Instruction')]
+    ]);
+
+    const result = await writer.write(files);
+
+    const expected = path.join(WORKSPACE_ROOT, '.github', 'copilot', 'instructions', 'test.md');
+    expect(result.written).toContain(expected);
+    expect(await fs.exists(expected)).toBe(true);
+  });
+
+  it('writes chatmode items to .github/copilot/agents/', async () => {
+    const fs = new InMemoryFileSystem();
+    const writer = new RepositoryScopeWriter({ fs, workspaceRoot: WORKSPACE_ROOT, commitMode: 'commit' });
+
+    const manifest = `id: test-bundle
+version: 1.0.0
+name: Test
+prompts:
+  - id: review-mode
+    file: chat-modes/review.chatmode.md
+    type: chatmode`;
+
+    const files = new Map<string, Uint8Array>([
+      ['deployment-manifest.yml', new TextEncoder().encode(manifest)],
+      ['chat-modes/review.chatmode.md', new TextEncoder().encode('# Review')]
+    ]);
+
+    const result = await writer.write(files);
+
+    const expected = path.join(WORKSPACE_ROOT, '.github', 'copilot', 'agents', 'review.chatmode.md');
     expect(result.written).toContain(expected);
     expect(await fs.exists(expected)).toBe(true);
   });
@@ -171,6 +295,18 @@ describe('RepositoryScopeWriter', () => {
     expect(await fs.exists(testFile)).toBe(false);
   });
 
+  it('removes a bundle-relative prompt path from the repository output route', async () => {
+    const fs = new InMemoryFileSystem();
+    const writer = new RepositoryScopeWriter({ fs, workspaceRoot: WORKSPACE_ROOT, commitMode: 'commit' });
+
+    const testFile = path.join(WORKSPACE_ROOT, '.github', 'copilot', 'prompts', 'test.md');
+    fs.seed(testFile, '# Test');
+
+    await writer.removeBundleFile('prompts/test.md');
+
+    expect(await fs.exists(testFile)).toBe(false);
+  });
+
   it('removes files for a bundle from manifest', async () => {
     const fs = new InMemoryFileSystem();
     const writer = new RepositoryScopeWriter({ fs, workspaceRoot: WORKSPACE_ROOT, commitMode: 'commit' });
@@ -184,6 +320,20 @@ describe('RepositoryScopeWriter', () => {
     };
 
     await writer.remove('test-bundle', manifest);
+
+    expect(await fs.exists(promptFile)).toBe(false);
+  });
+
+  it('removes governed canonical items without relying on legacy projections', async () => {
+    const fs = new InMemoryFileSystem();
+    const writer = new RepositoryScopeWriter({ fs, workspaceRoot: WORKSPACE_ROOT, commitMode: 'commit' });
+    const promptFile = path.join(WORKSPACE_ROOT, '.github', 'copilot', 'prompts', 'governed.md');
+    fs.seed(promptFile, '# Governed');
+
+    await writer.remove('governed-bundle', {
+      formatVersion: 1,
+      items: [{ id: 'governed', path: 'prompts/governed.md', kind: 'prompt' }]
+    });
 
     expect(await fs.exists(promptFile)).toBe(false);
   });
@@ -437,6 +587,19 @@ describe('RepositoryScopeWriterAdapter', () => {
     fs.seed(testFile, '# Test');
 
     await adapter.remove(dummyTarget, 'copilot/prompts/test.md');
+
+    expect(await fs.exists(testFile)).toBe(false);
+  });
+
+  it('translates bundle-relative paths during pipeline removal', async () => {
+    const fs = new InMemoryFileSystem();
+    const writer = new RepositoryScopeWriter({ fs, workspaceRoot: WORKSPACE_ROOT, commitMode: 'commit' });
+    const adapter = new RepositoryScopeWriterAdapter(writer);
+
+    const testFile = path.join(WORKSPACE_ROOT, '.github', 'copilot', 'prompts', 'test.md');
+    fs.seed(testFile, '# Test');
+
+    await adapter.remove(dummyTarget, 'prompts/test.md');
 
     expect(await fs.exists(testFile)).toBe(false);
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,6 +328,9 @@ importers:
       '@ai-primitives-hub/infra':
         specifier: workspace:*
         version: link:../infra
+      '@prompt-registry/collection-scripts':
+        specifier: workspace:^
+        version: link:../../lib
       archiver:
         specifier: ^7.0.1
         version: 7.0.1


### PR DESCRIPTION
## Description

Extends the install layer so that the primitive kinds added to the collection schema (`steering`, `spec`, `command`, `rule`, `output-style`, `tool`, `power`, `knowledge`, `playbook`, `chat-mode`) are routed to the correct on-disk locations for each supported AI tool. Also adds the missing target types (`cursor`, `opencode`, `devin`, `devin-cli`, `kiro-cli`) so they can be initialised from the CLI.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧪 Test coverage improvement

## Related Issues

Relates to the schema-extension assessment in `.tmp/features/schema-extension/assessment.md`.

## Changes Made

- Added `cursor`, `opencode`, `devin`, `devin-cli`, `kiro-cli` to `TARGET_TYPES` and the `Target` union.
- Updated `default-layouts.json` with user/repository layouts and `kindRoutes` for all new primitive kinds and targets.
- Fixed `RepositoryScopeWriter` to route `instructions` (plural) and `chatmode`/`chat-mode` files into `.github/copilot/`.
- Made `FileTreeTargetWriter` select the longest matching `kindRoutes` prefix first.
- Changed `createWriterFactory` to use `FileTreeTargetWriter` for non-Copilot repository-scope installs.
- Added CLI display names and `target types` descriptions for the new targets.

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

### Manual Testing Steps

1. `pnpm -C packages/core test`
2. `pnpm -C packages/infra test`
3. `pnpm -C packages/app test`
4. `pnpm -C packages/cli test`

### Tested On

- [x] Linux
- [ ] macOS
- [ ] Windows

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Documentation

- [ ] README.md updated
- [x] No documentation changes needed

## Additional Notes

The `mcp-server` primitive (`mcp-servers/...`) is still skipped because it requires a dedicated `McpConfigWriter` that merges server definitions into each IDE's MCP config file. That is intentionally left for a follow-up PR.

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
