### PR TITLE
fix(cli): honor native repository target layouts

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,7 +22,10 @@
     "email": "opensource@amadeus.com"
   },
   "files": [
-    "dist",
+    "dist/**/*.js",
+    "dist/**/*.js.map",
+    "dist/**/*.d.ts",
+    "dist/**/*.d.ts.map",
     "bin"
   ],
   "scripts": {

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -8,7 +8,7 @@
  * Lockfile integration uses `app`'s dict-based `Lockfile` (extension-compatible
  * schema, `bundles: Record<bundleId, LockfileBundleEntry>`) rather than the
  * reference branch's array-of-entries schema. There is no per-entry `target`
- * field — repository scope always writes to `.github/` regardless of target,
+ * field — each repository target uses its own native directory layout,
  * and user-scope installs get their own lockfile file
  * (`resolveUserConfigPaths(env).userLockfile`) rather than the project-root one.
  * `SourceDispatcher`/`GitHubBundleResolver` take a shared `GitHubApi` client
@@ -19,14 +19,12 @@ import * as path from 'node:path';
 import {
   checksumFiles,
   emptyLockfile,
-  FileTreeTargetWriter,
   type Lockfile,
   type LockfileBundleEntry,
   type LockfileSourceEntry,
   readLockfile,
   resolveUserConfigPaths,
   type TargetWriter,
-  TransformerRegistry,
   upsertBundleEntry,
   upsertSource,
   writeLockfile,
@@ -46,7 +44,6 @@ import {
   ActiveHubStore,
   AwesomeCopilotBundleResolver,
   defaultTokenProvider,
-  FileSystemLayoutConfigLoader,
   GitHubApiClient,
   GitHubBundleResolver,
   HttpsBundleDownloader,
@@ -55,9 +52,6 @@ import {
   readLocalBundle,
   readTargets,
   type RepositoryCommitMode,
-  RepositoryScopeWriter,
-  RepositoryScopeWriterAdapter,
-  resolveUserConfigDir,
   SourceDispatcher,
   TargetStateStore,
   ZipBundleExtractor,
@@ -66,6 +60,7 @@ import inquirer from 'inquirer';
 import {
   Command,
   createHubManager,
+  createTargetWriter,
   failWith,
   findProjectLockfile,
   loadTargets,
@@ -410,7 +405,7 @@ async function executeInstallMode(
  * Create a writer factory that routes to the appropriate
  * writer based on target scope.
  * - user scope → FileTreeTargetWriter
- * - repository scope → RepositoryScopeWriter
+ * - repository scope → target-aware FileTreeTargetWriter
  * @param ctx CLI context.
  * @param opts Install options.
  * @returns Writer factory function.
@@ -419,36 +414,11 @@ export const createWriterFactory = (
   ctx: Context,
   opts: InstallOptions
 ): (target: Target) => TargetWriter => {
-  // Create transformer registry and hierarchical layout loader once per command.
-  const transformerRegistry = TransformerRegistry.withBuiltIns();
-  const layoutLoader = new FileSystemLayoutConfigLoader({
-    cwd: ctx.cwd(),
-    fs: ctx.fs,
-    userConfigDir: resolveUserConfigDir(ctx.env)
-  });
-
   return (target: Target): TargetWriter => {
     // Use CLI flags to override target scope if specified
     const scope = opts.scope ?? target.scope;
     const commitMode = opts.commitMode ?? target.commitMode ?? 'commit';
-    const workspaceRoot = target.rootPath ?? ctx.cwd();
-
-    if (scope === 'repository') {
-      const writer = new RepositoryScopeWriter({
-        fs: ctx.fs,
-        workspaceRoot,
-        commitMode
-      });
-      return new RepositoryScopeWriterAdapter(writer);
-    }
-    // Default to FileTreeTargetWriter for user scope
-    const transformer = transformerRegistry.getTransformer(target.type);
-    return new FileTreeTargetWriter({
-      fs: ctx.fs,
-      env: ctx.env,
-      transformer,
-      layoutLoader
-    });
+    return createTargetWriter(ctx, target, scope, commitMode);
   };
 };
 
@@ -936,12 +906,10 @@ async function performRemoteInstall(
       });
       return 0;
     }
-    const transformerRegistry = TransformerRegistry.withBuiltIns();
-    const transformer = transformerRegistry.getTransformer(target.type);
-    const writer = new FileTreeTargetWriter({ fs: ctx.fs, env: ctx.env, transformer });
-    const result = await writer.write(target, files);
     const scope = opts.scope ?? target.scope;
     const commitMode = opts.commitMode ?? target.commitMode ?? 'commit';
+    const writer = createTargetWriter(ctx, target, scope, commitMode);
+    const result = await writer.write(target, files);
     const lockPath = lockfilePathForTarget(ctx, target, commitMode);
     const existing = await readLockfile(lockPath, ctx.fs) ?? emptyLockfile('ai-primitives-hub-cli');
     const entry: LockfileBundleEntry = {

--- a/packages/cli/src/commands/uninstall.ts
+++ b/packages/cli/src/commands/uninstall.ts
@@ -17,12 +17,10 @@
 import * as path from 'node:path';
 import {
   cleanupOrphanedSource,
-  FileTreeTargetWriter,
   type LockfileBundleEntry,
   readLockfile,
   removeBundleEntry,
   type TargetWriter,
-  TransformerRegistry,
   UninstallPipeline,
   type UninstallResult,
   writeLockfile,
@@ -31,16 +29,13 @@ import type {
   Target,
 } from '@ai-primitives-hub/core';
 import {
-  FileSystemLayoutConfigLoader,
   readTargets,
   type RepositoryCommitMode,
-  RepositoryScopeWriter,
-  RepositoryScopeWriterAdapter,
-  resolveUserConfigDir,
   TargetStateStore,
 } from '@ai-primitives-hub/infra';
 import {
   Command,
+  createTargetWriter,
   failWith,
   findProjectLockfile,
   loadTargets,
@@ -219,7 +214,7 @@ export class UninstallCommand extends BaseUninstallCommand {
 /**
  * Create a writer factory that routes to the appropriate writer based on target scope.
  * - user scope → FileTreeTargetWriter
- * - repository scope → RepositoryScopeWriter
+ * - repository scope → target-aware FileTreeTargetWriter
  * @param ctx CLI context.
  * @param opts Uninstall options.
  * @returns Writer factory function.
@@ -228,39 +223,11 @@ export const createWriterFactory = (
   ctx: Context,
   opts: UninstallOptions
 ): (target: Target) => TargetWriter => {
-  // Create transformer registry with built-in transformers — must match
-  // install.ts's factory so `writer.remove()` computes the same on-disk
-  // path that `writer.write()` used (targets with a real, non-identity
-  // transformer like Kiro would otherwise resolve the wrong path).
-  const transformerRegistry = TransformerRegistry.withBuiltIns();
-  const layoutLoader = new FileSystemLayoutConfigLoader({
-    cwd: ctx.cwd(),
-    fs: ctx.fs,
-    userConfigDir: resolveUserConfigDir(ctx.env)
-  });
-
   return (target: Target): TargetWriter => {
     // Use CLI flags to override target scope if specified
     const scope = opts.scope ?? target.scope;
     const commitMode = opts.commitMode ?? target.commitMode ?? 'commit';
-    const workspaceRoot = target.rootPath ?? ctx.cwd();
-
-    if (scope === 'repository') {
-      const writer = new RepositoryScopeWriter({
-        fs: ctx.fs,
-        workspaceRoot,
-        commitMode
-      });
-      return new RepositoryScopeWriterAdapter(writer);
-    }
-    // Default to FileTreeTargetWriter for user scope
-    const transformer = transformerRegistry.getTransformer(target.type);
-    return new FileTreeTargetWriter({
-      fs: ctx.fs,
-      env: ctx.env,
-      transformer,
-      layoutLoader
-    });
+    return createTargetWriter(ctx, target, scope, commitMode);
   };
 };
 

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -12,14 +12,12 @@
 import * as path from 'node:path';
 import {
   checksumFiles,
-  FileTreeTargetWriter,
   type Lockfile,
   type LockfileBundleEntry,
   type LockfileSourceEntry,
   readLockfile,
   resolveUserConfigPaths,
   type TargetWriter,
-  TransformerRegistry,
   upsertBundleEntry,
   upsertSource,
   writeLockfile,
@@ -38,15 +36,11 @@ import {
 import {
   ActiveHubStore,
   defaultTokenProvider,
-  FileSystemLayoutConfigLoader,
   GitHubApiClient,
   HttpsBundleDownloader,
   NodeHttpClient,
   readTargets,
   type RepositoryCommitMode,
-  RepositoryScopeWriter,
-  RepositoryScopeWriterAdapter,
-  resolveUserConfigDir,
   SourceDispatcher,
   TargetStateStore,
   ZipBundleExtractor,
@@ -55,6 +49,7 @@ import inquirer from 'inquirer';
 import {
   Command,
   createHubManager,
+  createTargetWriter,
   failWith,
   findProjectLockfile,
   loadTargets,
@@ -410,21 +405,7 @@ function renderNoUpdates(ctx: Context, fmt: OutputFormat, checked: number, skipp
  * @returns A TargetWriter.
  */
 function writerFor(ctx: Context, target: Target, scope: string, commitMode: RepositoryCommitMode): TargetWriter {
-  if (scope === 'repository') {
-    const writer = new RepositoryScopeWriter({
-      fs: ctx.fs,
-      workspaceRoot: target.rootPath ?? ctx.cwd(),
-      commitMode
-    });
-    return new RepositoryScopeWriterAdapter(writer);
-  }
-  const transformer = TransformerRegistry.withBuiltIns().getTransformer(target.type);
-  const layoutLoader = new FileSystemLayoutConfigLoader({
-    cwd: ctx.cwd(),
-    fs: ctx.fs,
-    userConfigDir: resolveUserConfigDir(ctx.env)
-  });
-  return new FileTreeTargetWriter({ fs: ctx.fs, env: ctx.env, transformer, layoutLoader });
+  return createTargetWriter(ctx, target, scope as Target['scope'], commitMode);
 }
 
 async function applyUpdates(

--- a/packages/cli/src/framework/index.ts
+++ b/packages/cli/src/framework/index.ts
@@ -104,6 +104,9 @@ export {
 export {
   copyCommandPrototype,
 } from './command-class';
+export {
+  createTargetWriter,
+} from './target-writer';
 export type {
   RenderTableOptions,
   TableColumn,

--- a/packages/cli/src/framework/target-writer.ts
+++ b/packages/cli/src/framework/target-writer.ts
@@ -1,0 +1,83 @@
+/**
+ * Shared target-writer construction for install, update, and uninstall.
+ * @module framework/target-writer
+ */
+import {
+  FileTreeTargetWriter,
+  type TargetWriter,
+  TransformerRegistry,
+} from '@ai-primitives-hub/app';
+import type {
+  ExtractedFiles,
+  Target,
+  TargetWriteResult,
+} from '@ai-primitives-hub/core';
+import {
+  FileSystemLayoutConfigLoader,
+  LocalOnlyTargetWriter,
+  type RepositoryCommitMode,
+  resolveUserConfigDir,
+} from '@ai-primitives-hub/infra';
+import type {
+  Context,
+} from './context';
+
+/**
+ * Bind a writer to the target after command-line scope overrides are applied.
+ */
+class ConfiguredTargetWriter implements TargetWriter {
+  public constructor(
+    private readonly delegate: TargetWriter,
+    private readonly configuredTarget: Target
+  ) {}
+
+  public async write(_target: Target, files: ExtractedFiles): Promise<TargetWriteResult> {
+    return await this.delegate.write(this.configuredTarget, files);
+  }
+
+  public async remove(_target: Target, filePath: string): Promise<void> {
+    await this.delegate.remove(this.configuredTarget, filePath);
+  }
+}
+
+/**
+ * Create a layout-aware writer for the effective target and scope.
+ * Repository targets retain their native VS Code, Kiro, Claude Code, or
+ * Windsurf directory layout instead of being forced into `.github/copilot`.
+ * @param ctx CLI context.
+ * @param target Configured target.
+ * @param scope Effective installation scope.
+ * @param commitMode Repository commit mode.
+ * @returns A writer configured consistently for all lifecycle commands.
+ */
+export function createTargetWriter(
+  ctx: Context,
+  target: Target,
+  scope: Target['scope'],
+  commitMode: RepositoryCommitMode
+): TargetWriter {
+  const configuredTarget: Target = {
+    ...target,
+    scope,
+    commitMode: scope === 'repository' ? commitMode : undefined,
+    rootPath: scope === 'user' ? target.rootPath : (target.rootPath ?? ctx.cwd())
+  };
+  const transformer = TransformerRegistry.withBuiltIns().getTransformer(configuredTarget.type);
+  const layoutLoader = new FileSystemLayoutConfigLoader({
+    cwd: ctx.cwd(),
+    fs: ctx.fs,
+    userConfigDir: resolveUserConfigDir(ctx.env)
+  });
+  const layoutWriter = new FileTreeTargetWriter({
+    fs: ctx.fs,
+    env: ctx.env,
+    transformer,
+    layoutLoader
+  });
+  let writer: TargetWriter = new ConfiguredTargetWriter(layoutWriter, configuredTarget);
+
+  if (scope === 'repository' && commitMode === 'local-only') {
+    writer = new LocalOnlyTargetWriter(writer, ctx.fs, configuredTarget.rootPath as string);
+  }
+  return writer;
+}

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -162,6 +162,9 @@ import {
   createProductionContext,
   runCli,
 } from './framework';
+import {
+  CLI_VERSION,
+} from './version';
 
 /**
  * Main entry point.
@@ -243,7 +246,7 @@ async function main(): Promise<number> {
     commands: [],
     commandClasses,
     name: 'ai-primitives-hub',
-    version: '1.0.0',
+    version: CLI_VERSION,
     http,
     tokens,
     defaultOutput: 'text'

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -1,0 +1,2 @@
+/** Published CLI version. Keep this synchronized with package.json. */
+export const CLI_VERSION = '0.0.1-alpha.2';

--- a/packages/cli/test/commands/install.test.ts
+++ b/packages/cli/test/commands/install.test.ts
@@ -140,4 +140,75 @@ describe('install command (local --from mode)', () => {
     ]);
     expect(result.exitCode).toBe(1);
   });
+
+  it.each([
+    ['vscode', '.github/prompts/hello.prompt.md'],
+    ['kiro', '.kiro/steering/hello.prompt.md'],
+    ['claude-code', '.claude/commands/hello.prompt.md']
+  ] as const)('uses the native %s repository layout', async (targetType, expectedPath) => {
+    const repoRoot = path.join(workspace, `repo-${targetType}`);
+    const targetName = `repo-${targetType}`;
+    await mkdir(repoRoot, { recursive: true });
+    const addResult = await run([
+      'target', 'add', targetName,
+      '--type', targetType,
+      '--scope', 'repository',
+      '--workspace-root', repoRoot,
+      '-o', 'json'
+    ]);
+    expect(addResult.exitCode).toBe(0);
+
+    const installResult = await run([
+      'install', 'local-foo', '--from', bundleDir, '--target', targetName, '-o', 'json'
+    ]);
+    expect(installResult.exitCode).toBe(0);
+    expect(await readFile(path.join(repoRoot, expectedPath), 'utf8')).toContain('Hello Prompt');
+  });
+
+  it('writes every supported primitive kind for Kiro repository targets', async () => {
+    const repoRoot = path.join(workspace, 'repo-kiro-all-kinds');
+    await Promise.all([
+      mkdir(path.join(bundleDir, 'instructions'), { recursive: true }),
+      mkdir(path.join(bundleDir, 'agents'), { recursive: true }),
+      mkdir(path.join(bundleDir, 'skills', 'reviewer'), { recursive: true }),
+      mkdir(repoRoot, { recursive: true })
+    ]);
+    await Promise.all([
+      writeFile(path.join(bundleDir, 'instructions', 'rules.instructions.md'), '# Rules\n'),
+      writeFile(path.join(bundleDir, 'agents', 'reviewer.agent.md'), '# Reviewer\n'),
+      writeFile(path.join(bundleDir, 'skills', 'reviewer', 'SKILL.md'), '# Skill\n')
+    ]);
+    expect((await run([
+      'target', 'add', 'kiro-all', '--type', 'kiro', '--scope', 'repository',
+      '--workspace-root', repoRoot, '-o', 'json'
+    ])).exitCode).toBe(0);
+
+    const result = await run([
+      'install', 'local-foo', '--from', bundleDir, '--target', 'kiro-all', '-o', 'json'
+    ]);
+    expect(result.exitCode).toBe(0);
+    await expect(readFile(path.join(repoRoot, '.kiro/steering/rules.instructions.md'), 'utf8'))
+      .resolves.toContain('Rules');
+    await expect(readFile(path.join(repoRoot, '.kiro/agents/reviewer.agent.md'), 'utf8'))
+      .resolves.toContain('Reviewer');
+    await expect(readFile(path.join(repoRoot, '.kiro/skills/reviewer/SKILL.md'), 'utf8'))
+      .resolves.toContain('Skill');
+  });
+
+  it('records local-only repository paths in Git exclude', async () => {
+    const repoRoot = path.join(workspace, 'repo-local-only');
+    await mkdir(path.join(repoRoot, '.git', 'info'), { recursive: true });
+    expect((await run([
+      'target', 'add', 'kiro-local', '--type', 'kiro', '--scope', 'repository',
+      '--workspace-root', repoRoot, '-o', 'json'
+    ])).exitCode).toBe(0);
+
+    const result = await run([
+      'install', 'local-foo', '--from', bundleDir, '--target', 'kiro-local',
+      '--commit-mode', 'local-only', '-o', 'json'
+    ]);
+    expect(result.exitCode).toBe(0);
+    const exclude = await readFile(path.join(repoRoot, '.git', 'info', 'exclude'), 'utf8');
+    expect(exclude).toContain('.kiro/steering/hello.prompt.md');
+  });
 });

--- a/packages/cli/test/commands/uninstall.test.ts
+++ b/packages/cli/test/commands/uninstall.test.ts
@@ -137,6 +137,29 @@ describe('uninstall command', () => {
     await expect(readFile(installedFile(), 'utf8')).rejects.toThrow();
   });
 
+  it('removes a Kiro repository file and its local-only Git exclusion', async () => {
+    const repoRoot = path.join(workspace, 'kiro-repo');
+    await mkdir(path.join(repoRoot, '.git', 'info'), { recursive: true });
+    expect((await run([
+      'target', 'add', 'kiro-local', '--type', 'kiro', '--scope', 'repository',
+      '--workspace-root', repoRoot, '-o', 'json'
+    ])).exitCode).toBe(0);
+    expect((await run([
+      'install', 'local-foo', '--from', bundleDir, '--target', 'kiro-local',
+      '--commit-mode', 'local-only', '-o', 'json'
+    ])).exitCode).toBe(0);
+
+    const result = await run([
+      'uninstall', '--bundle', 'local-foo', '--target', 'kiro-local',
+      '--commit-mode', 'local-only', '-o', 'json'
+    ]);
+    expect(result.exitCode).toBe(0);
+    await expect(readFile(path.join(repoRoot, '.kiro/steering/hello.prompt.md'), 'utf8'))
+      .rejects.toThrow();
+    const exclude = await readFile(path.join(repoRoot, '.git', 'info', 'exclude'), 'utf8');
+    expect(exclude).not.toContain('.kiro/steering/hello.prompt.md');
+  });
+
   it('fails with exit 1 when neither --bundle, --lockfile, nor --all is given (and no lockfile is discoverable)', async () => {
     const freshWorkspace = await mkdtemp(path.join(os.tmpdir(), 'cli-uninstall-test-fresh-'));
     try {

--- a/packages/cli/test/version.test.ts
+++ b/packages/cli/test/version.test.ts
@@ -1,0 +1,20 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  CLI_VERSION,
+} from '../src/version';
+
+describe('CLI version', () => {
+  it('matches the published package version', () => {
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf8')
+    ) as { version: string };
+
+    expect(CLI_VERSION).toBe(packageJson.version);
+  });
+});

--- a/packages/core/src/ports/target-writer.ts
+++ b/packages/core/src/ports/target-writer.ts
@@ -1,8 +1,7 @@
 /**
  * TargetWriter port — writes extracted bundle files into an install
  * target (VS Code, Kiro, Windsurf, etc.). Concrete adapters live in
- * `infra`/`app`. Repository-scope installations use a specialised
- * writer that handles the `.github/` layout.
+ * `infra`/`app`; repository targets retain their target-specific layout.
  * @module ports/target-writer
  */
 import type {

--- a/packages/infra/src/writers/repo-scope-writer.ts
+++ b/packages/infra/src/writers/repo-scope-writer.ts
@@ -557,3 +557,88 @@ export class RepositoryScopeWriterAdapter implements TargetWriter {
     await this.writer.removeFile(filePath);
   }
 }
+
+/**
+ * Decorates a layout-aware writer with repository local-only bookkeeping.
+ * This keeps Kiro, Claude Code, and other target-specific layouts while still
+ * excluding installed files from Git when requested.
+ */
+/* eslint-disable @typescript-eslint/member-ordering -- public TargetWriter API precedes helpers. */
+export class LocalOnlyTargetWriter implements TargetWriter {
+  public constructor(
+    private readonly delegate: TargetWriter,
+    private readonly fs: FileSystem,
+    private readonly workspaceRoot: string
+  ) {}
+
+  public async write(target: Target, files: ExtractedFiles): Promise<TargetWriteResult> {
+    const result = await this.delegate.write(target, files);
+    await this.addToGitExclude(result.written);
+    return result;
+  }
+
+  public async remove(target: Target, filePath: string): Promise<void> {
+    await this.delegate.remove(target, filePath);
+    await this.pruneGitExclude();
+  }
+
+  private async addToGitExclude(paths: string[]): Promise<void> {
+    if (paths.length === 0) {
+      return;
+    }
+    const excludePath = path.join(this.workspaceRoot, '.git', 'info', 'exclude');
+    let lines: string[] = [];
+    try {
+      lines = (await this.fs.readFile(excludePath)).split('\n');
+    } catch {
+      await this.fs.mkdir(path.dirname(excludePath), { recursive: true });
+    }
+    if (!lines.includes(GIT_EXCLUDE_SECTION_HEADER)) {
+      lines.push(GIT_EXCLUDE_SECTION_HEADER);
+    }
+    for (const writtenPath of paths) {
+      const relativePath = toGitIgnorePath(this.workspaceRoot, writtenPath);
+      if (!lines.includes(relativePath)) {
+        lines.push(relativePath);
+      }
+    }
+    await this.fs.writeFile(excludePath, lines.join('\n'));
+  }
+
+  private async pruneGitExclude(): Promise<void> {
+    const excludePath = path.join(this.workspaceRoot, '.git', 'info', 'exclude');
+    let lines: string[];
+    try {
+      lines = (await this.fs.readFile(excludePath)).split('\n');
+    } catch {
+      return;
+    }
+
+    const headerIndex = lines.indexOf(GIT_EXCLUDE_SECTION_HEADER);
+    if (headerIndex === -1) {
+      return;
+    }
+    let sectionEnd = lines.length;
+    for (let index = headerIndex + 1; index < lines.length; index += 1) {
+      if (lines[index]?.startsWith('#') === true) {
+        sectionEnd = index;
+        break;
+      }
+    }
+
+    const before = lines.slice(0, headerIndex);
+    const entries = lines.slice(headerIndex + 1, sectionEnd);
+    const after = lines.slice(sectionEnd);
+    const retained: string[] = [];
+    for (const entry of entries) {
+      if (entry.length > 0 && await this.fs.exists(path.join(this.workspaceRoot, entry))) {
+        retained.push(entry);
+      }
+    }
+    const nextLines = retained.length === 0
+      ? [...before, ...after]
+      : [...before, GIT_EXCLUDE_SECTION_HEADER, ...retained, ...after];
+    await this.fs.writeFile(excludePath, nextLines.join('\n'));
+  }
+}
+/* eslint-enable @typescript-eslint/member-ordering */


### PR DESCRIPTION
Fixes VS Code, Kiro, and Claude repository layouts, version reporting, install/update/uninstall consistency, and oversized npm packaging.

Validation: 17 focused compatibility tests and affected-package builds passed.