### PR TITLE
fix(install): binary-safe writes with post-write integrity verification

### DIFF
--- a/apps/vscode-extension/src/services/repository-scope-service.ts
+++ b/apps/vscode-extension/src/services/repository-scope-service.ts
@@ -78,6 +78,15 @@ class NodeWriterFs implements WriterFs {
     await writeFile(p, contents, 'utf8');
   }
 
+  public async writeFileBytes(p: string, bytes: Uint8Array): Promise<void> {
+    await fs.promises.writeFile(p, bytes);
+  }
+
+  public async readFileBytes(p: string): Promise<Uint8Array> {
+    const buffer = await fs.promises.readFile(p);
+    return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+  }
+
   public async mkdir(p: string, opts?: { recursive?: boolean }): Promise<void> {
     await fs.promises.mkdir(p, opts);
   }

--- a/apps/vscode-extension/src/services/user-scope-service.ts
+++ b/apps/vscode-extension/src/services/user-scope-service.ts
@@ -439,19 +439,23 @@ export class UserScopeService implements IScopeService {
 
       // WSL: symlinks from Windows → WSL paths are broken from Windows' perspective,
       // so always copy when running in WSL. On non-WSL, prefer symlinks.
-      if (file.transformedContent !== undefined || this.isRunningInWSL()) {
-        const content = file.transformedContent ?? await readFile(file.sourcePath, 'utf8');
-        await writeFile(file.targetPath, content, 'utf8');
-        this.logger.debug(`Copied file${file.transformedContent === undefined ? ' (WSL)' : ' (transformed)'}: ${path.basename(file.targetPath)}`);
+      if (file.transformedContent !== undefined) {
+        await writeFile(file.targetPath, file.transformedContent, 'utf8');
+        this.logger.debug(`Copied file (transformed): ${path.basename(file.targetPath)}`);
+      } else if (this.isRunningInWSL()) {
+        // Binary-safe copy (issue #357): a utf8 string round-trip corrupts
+        // any non-UTF-8 payload (e.g. PPTX/zip assets), so copy raw bytes.
+        await writeFile(file.targetPath, await readFile(file.sourcePath));
+        this.logger.debug(`Copied file (WSL): ${path.basename(file.targetPath)}`);
       } else {
         try {
           await symlink(file.sourcePath, file.targetPath, 'file');
           this.logger.debug(`Created symlink: ${path.basename(file.targetPath)}`);
         } catch {
-          // Symlink failed (maybe Windows or permissions), fall back to copy
+          // Symlink failed (maybe Windows or permissions), fall back to a
+          // byte-for-byte copy (issue #357: no lossy utf8 round-trip).
           this.logger.debug('Symlink failed, copying file instead');
-          const content = await readFile(file.sourcePath, 'utf8');
-          await writeFile(file.targetPath, content, 'utf8');
+          await writeFile(file.targetPath, await readFile(file.sourcePath));
           this.logger.debug(`Copied file: ${path.basename(file.targetPath)}`);
         }
       }

--- a/docs/contributor-guide/architecture/installation-flow.md
+++ b/docs/contributor-guide/architecture/installation-flow.md
@@ -84,6 +84,15 @@ flowchart TD
     U --> AA
 ```
 
+## Binary Safety and Integrity Verification
+
+Bundle files are copied to the target byte-for-byte and verified after every write:
+
+- **Binary-safe writes** — writers use the `FileSystem` port's `readFileBytes`/`writeFileBytes` for all payloads. Text payloads (strict UTF-8) may additionally pass through a target-specific `ResourceTransformer`; binary payloads (images, archives, office documents) are never decoded as text — a lossy UTF-8 round-trip replaces invalid sequences with U+FFFD and corrupts them.
+- **Post-write verification** — after each write, the installed file is re-read and compared against the bytes the writer intended to write (`verifyWrittenBytes` in `core`'s `domain/install/integrity`). A mismatch throws `FileIntegrityError` (`BUNDLE.INTEGRITY_MISMATCH`) instead of leaving a silently corrupted artifact.
+- **Upstream layers already verified** — zip entry CRC-32 is checked during extraction, and governed (`formatVersion: 1`) deployment manifests carry per-file `size` + `sha256` validated against the extracted bytes.
+- **Lockfile checksums** — `checksumFiles` hashes the extracted (archive) bytes, not the optionally transformed on-disk result. For untransformed files those values match; for transformed files a later user-modification check that compares on-disk hashes to the lockfile will currently report a mismatch. Recording a separate `installedChecksum` in `LockfileFileEntry` is a follow-up (issue #357 Stage 2) and is not part of this binary-safety change.
+
 ## Scope Selection
 
 When a user initiates installation, a QuickPick dialog presents three options:

--- a/packages/app/src/stores/json-lockfile-store.ts
+++ b/packages/app/src/stores/json-lockfile-store.ts
@@ -59,7 +59,13 @@ export type RepositoryCommitMode = 'commit' | 'local-only';
 export interface LockfileFileEntry {
   /** Relative path from repository root. */
   path: string;
-  /** SHA256 checksum of the file contents. */
+  /**
+   * SHA256 of the extracted archive bytes for this path (not the
+   * optionally transformed on-disk result). User-modification checks
+   * compare this against the current file; transformed files will
+   * therefore look modified until an `installedChecksum` field is
+   * added (issue #357 Stage 2).
+   */
   checksum: string;
 }
 

--- a/packages/app/src/writers/file-tree-writer.ts
+++ b/packages/app/src/writers/file-tree-writer.ts
@@ -34,11 +34,13 @@ import type {
   TargetWriteResult,
 } from '@ai-primitives-hub/core';
 import {
+  decodeUtf8Strict,
   determineFileType,
   expandPath,
   getSkillName,
   getTargetFileName,
   normalizePromptId,
+  verifyWrittenBytes,
 } from '@ai-primitives-hub/core';
 import {
   defaultLayouts as builtInLayouts,
@@ -58,6 +60,14 @@ export type {
 
 export interface WriterFs {
   writeFile(p: string, contents: string): Promise<void>;
+  /**
+   * Write raw bytes verbatim. Required for binary bundle assets
+   * (images, archives, office documents): decoding them through the
+   * string `writeFile` path is lossy and corrupts them (issue #357).
+   */
+  writeFileBytes(p: string, bytes: Uint8Array): Promise<void>;
+  /** Byte-level read-back used for post-write integrity verification. */
+  readFileBytes(p: string): Promise<Uint8Array>;
   mkdir(p: string, opts?: { recursive?: boolean }): Promise<void>;
   remove(p: string): Promise<void>;
   exists(p: string): Promise<boolean>;
@@ -220,30 +230,60 @@ export class FileTreeTargetWriter implements TargetWriter {
         continue;
       }
 
-      // Decode content
-      let content = new TextDecoder().decode(bytes);
-
-      // Apply transformation if transformer is provided
-      if (this.opts.transformer !== undefined) {
-        try {
-          const result = this.opts.transformer.transform({
-            target,
-            filePath: bundlePath,
-            content
-          });
-          content = result.content;
-        } catch {
-          // Fail-safe: on transformation error, use original content
-          // In production, this would log a warning
-        }
-      }
-
       const outPath = path.join(baseDir, route.outPrefix, route.tail);
-      await this.opts.fs.mkdir(path.dirname(outPath), { recursive: true });
-      await this.opts.fs.writeFile(outPath, content);
+      await this.writeContent(target, bundlePath, bytes, outPath);
       written.push(outPath);
     }
     return { written, skipped };
+  }
+
+  /**
+   * Write one bundle file to its resolved output path, binary-safe
+   * (issue #357).
+   *
+   * Text payloads (strict UTF-8) go through the optional transformer
+   * and are written as strings; anything else is written byte-for-byte
+   * — the previous unconditional `TextDecoder` round-trip replaced
+   * invalid UTF-8 sequences with U+FFFD and corrupted binary assets
+   * such as PPTX files. Every write is verified by re-reading the file
+   * and comparing it against the intended bytes.
+   * @param target - Install target (passed to the transformer).
+   * @param bundlePath - Bundle-relative source path (transformer context).
+   * @param bytes - Raw source bytes from the extracted bundle.
+   * @param outPath - Absolute destination path.
+   */
+  private async writeContent(
+    target: Target,
+    bundlePath: string,
+    bytes: Uint8Array,
+    outPath: string
+  ): Promise<void> {
+    await this.opts.fs.mkdir(path.dirname(outPath), { recursive: true });
+
+    const text = decodeUtf8Strict(bytes);
+    if (text === null) {
+      // Binary payload: write verbatim, never transform.
+      await this.opts.fs.writeFileBytes(outPath, bytes);
+      await verifyWrittenBytes(this.opts.fs, outPath, bytes);
+      return;
+    }
+
+    let content = text;
+    if (this.opts.transformer !== undefined) {
+      try {
+        const result = this.opts.transformer.transform({
+          target,
+          filePath: bundlePath,
+          content
+        });
+        content = result.content;
+      } catch {
+        // Fail-safe: on transformation error, use original content
+        // In production, this would log a warning
+      }
+    }
+    await this.opts.fs.writeFile(outPath, content);
+    await verifyWrittenBytes(this.opts.fs, outPath, new TextEncoder().encode(content));
   }
 
   /**
@@ -305,17 +345,7 @@ export class FileTreeTargetWriter implements TargetWriter {
         continue;
       }
       const outPath = path.join(baseDir, outPrefix, getTargetFileName(item.id, type));
-      let content = new TextDecoder().decode(bytes);
-      if (this.opts.transformer !== undefined) {
-        try {
-          const result = this.opts.transformer.transform({ target, filePath: item.file, content });
-          content = result.content;
-        } catch {
-          // Fail-safe: on transformation error, use original content
-        }
-      }
-      await this.opts.fs.mkdir(path.dirname(outPath), { recursive: true });
-      await this.opts.fs.writeFile(outPath, content);
+      await this.writeContent(target, item.file, bytes, outPath);
       written.push(outPath);
     }
 
@@ -361,8 +391,11 @@ export class FileTreeTargetWriter implements TargetWriter {
       }
       const tail = bundlePath.slice(sourcePrefix.length);
       const outPath = path.join(baseDir, outPrefix, targetSkillId, tail);
+      // Skill directories carry arbitrary assets (scripts, images,
+      // office documents) — copy byte-for-byte, never transform.
       await this.opts.fs.mkdir(path.dirname(outPath), { recursive: true });
-      await this.opts.fs.writeFile(outPath, new TextDecoder().decode(bytes));
+      await this.opts.fs.writeFileBytes(outPath, bytes);
+      await verifyWrittenBytes(this.opts.fs, outPath, bytes);
       written.push(outPath);
       wroteAny = true;
     }

--- a/packages/app/test/helpers/in-memory-filesystem.ts
+++ b/packages/app/test/helpers/in-memory-filesystem.ts
@@ -16,9 +16,15 @@ import type {
 } from '@ai-primitives-hub/core';
 
 interface InMemoryEntry {
-  contents: string;
+  contents: string | Uint8Array;
   mtimeMs: number;
 }
+
+const asString = (contents: string | Uint8Array): string =>
+  typeof contents === 'string' ? contents : new TextDecoder().decode(contents);
+
+const asBytes = (contents: string | Uint8Array): Uint8Array =>
+  typeof contents === 'string' ? new TextEncoder().encode(contents) : contents;
 
 /**
  * A flat, path-keyed in-memory filesystem. Directories are implicit:
@@ -38,7 +44,7 @@ export class InMemoryFileSystem implements FileSystem {
    * @param mtimeMs - Modification time to report from `stat()`, in
    * milliseconds since the Unix epoch. Defaults to `0`.
    */
-  public seed(path: string, contents: string, mtimeMs = 0): void {
+  public seed(path: string, contents: string | Uint8Array, mtimeMs = 0): void {
     this.files.set(this.normalizePath(path), { contents, mtimeMs });
   }
 
@@ -48,11 +54,24 @@ export class InMemoryFileSystem implements FileSystem {
     if (!entry) {
       throw new Error(`ENOENT: no such file: ${normalizedPath}`);
     }
-    return entry.contents;
+    return asString(entry.contents);
   }
 
   public async writeFile(path: string, contents: string): Promise<void> {
     this.files.set(this.normalizePath(path), { contents, mtimeMs: Date.now() });
+  }
+
+  public async readFileBytes(path: string): Promise<Uint8Array> {
+    const normalizedPath = this.normalizePath(path);
+    const entry = this.files.get(normalizedPath);
+    if (!entry) {
+      throw new Error(`ENOENT: no such file: ${normalizedPath}`);
+    }
+    return asBytes(entry.contents);
+  }
+
+  public async writeFileBytes(path: string, bytes: Uint8Array): Promise<void> {
+    this.files.set(this.normalizePath(path), { contents: bytes, mtimeMs: Date.now() });
   }
 
   public async readJson<T = unknown>(path: string): Promise<T> {
@@ -112,7 +131,7 @@ export class InMemoryFileSystem implements FileSystem {
       return {
         isDirectory: false,
         isFile: true,
-        size: Buffer.byteLength(entry.contents, 'utf8'),
+        size: asBytes(entry.contents).byteLength,
         mtimeMs: entry.mtimeMs
       };
     }

--- a/packages/app/test/writers/file-tree-writer.test.ts
+++ b/packages/app/test/writers/file-tree-writer.test.ts
@@ -177,6 +177,43 @@ describe('FileTreeTargetWriter', () => {
     expect(result.skipped).toContain('prompts/test.md');
   });
 
+  it('writes binary files byte-for-byte without applying a transformer (issue #357)', async () => {
+    const fs = new InMemoryFileSystem();
+    const transformer: ResourceTransformer = {
+      transform: (ctx) => ({ content: `${ctx.content}\n<!-- transformed -->`, modified: true })
+    };
+    const writer = new FileTreeTargetWriter({ fs, env: {}, transformer });
+    // Invalid UTF-8 sequences: a lossy TextDecoder round-trip would
+    // replace them with U+FFFD and corrupt the asset.
+    const binaryBytes = new Uint8Array([0x50, 0x4B, 0x03, 0x04, 0xFF, 0xFE, 0x00, 0x9D, 0xC7, 0x80]);
+    const files = new Map<string, Uint8Array>([
+      ['skills/deck/assets/template.pptx', binaryBytes]
+    ]);
+
+    const result = await writer.write(target, files);
+
+    const installedPath = localPath('/out', 'skills', 'deck', 'assets', 'template.pptx');
+    expect(result.written).toContain(installedPath);
+    expect(await fs.readFileBytes(installedPath)).toEqual(binaryBytes);
+  });
+
+  it('writes binary skill assets byte-for-byte in writeManifestItems', async () => {
+    const fs = new InMemoryFileSystem();
+    const writer = new FileTreeTargetWriter({ fs, env: {} });
+    const binaryBytes = new Uint8Array([0x89, 0x50, 0x4E, 0x47, 0xFF, 0xD8, 0x00, 0xC0]);
+    const files = new Map<string, Uint8Array>([
+      ['skills/deck/SKILL.md', new TextEncoder().encode('# Deck')],
+      ['skills/deck/assets/logo.png', binaryBytes]
+    ]);
+    const items: ManifestPlacementItem[] = [
+      { id: 'deck', file: 'skills/deck/SKILL.md', type: 'skill' }
+    ];
+
+    await writer.writeManifestItems(target, files, items);
+
+    expect(await fs.readFileBytes(localPath('/out', 'skills', 'deck', 'assets', 'logo.png'))).toEqual(binaryBytes);
+  });
+
   it('applies a resource transformer to file content', async () => {
     const fs = new InMemoryFileSystem();
     const transformer: ResourceTransformer = {

--- a/packages/cli/src/framework/test-context.ts
+++ b/packages/cli/src/framework/test-context.ts
@@ -91,6 +91,8 @@ const rejectFsCall = (): Promise<never> =>
 const STUB_FS: FsAbstraction = {
   readFile: rejectFsCall,
   writeFile: rejectFsCall,
+  readFileBytes: rejectFsCall,
+  writeFileBytes: rejectFsCall,
   readJson: rejectFsCall,
   writeJson: rejectFsCall,
   exists: rejectFsCall,

--- a/packages/core/src/domain/index.ts
+++ b/packages/core/src/domain/index.ts
@@ -20,6 +20,7 @@ export * from './install/target';
 export * from './install/installable';
 export * from './install/copilot-file-type';
 export * from './install/layout';
+export * from './install/integrity';
 export * from './install/transform';
 export * from './registry/types';
 export * from './registry/guards';

--- a/packages/core/src/domain/install/integrity.ts
+++ b/packages/core/src/domain/install/integrity.ts
@@ -1,0 +1,108 @@
+/**
+ * Domain layer — install-time file integrity helpers (issue #357).
+ *
+ * The bundle pipeline already verifies checksums up to the in-memory
+ * `ExtractedFiles` map (zip CRC-32 during extraction; per-file SHA-256
+ * in governed deployment manifests). These helpers extend the guarantee
+ * across the last hop — writing to the install target:
+ *
+ *   - `decodeUtf8Strict` lets writers distinguish text payloads (safe
+ *     to transform and write as strings) from binary payloads (which
+ *     must be written byte-for-byte; lossy UTF-8 round-trips are what
+ *     corrupted binary assets such as PPTX files in the first place).
+ *   - `verifyWrittenBytes` re-reads an installed file and compares it
+ *     against the bytes the writer intended to write, failing loudly
+ *     instead of leaving silent corruption on disk.
+ *
+ * Pure domain logic over injected port subsets: no `node:fs`, no IO of
+ * its own.
+ * @module domain/install/integrity
+ */
+
+/**
+ * Narrow port subset needed to verify a written file. Satisfied by the
+ * full `FileSystem` port.
+ */
+export interface ByteReader {
+  readFileBytes(path: string): Promise<Uint8Array>;
+}
+
+/**
+ * Thrown when an installed file's bytes do not match what the writer
+ * intended to write (or the file cannot be read back at all).
+ */
+export class FileIntegrityError extends Error {
+  /** Stable error code for programmatic handling. */
+  public readonly code = 'BUNDLE.INTEGRITY_MISMATCH';
+
+  public constructor(
+    /** Absolute path of the file that failed verification. */
+    public readonly filePath: string,
+    detail: string
+  ) {
+    super(`integrity verification failed for "${filePath}": ${detail}`);
+    this.name = 'FileIntegrityError';
+  }
+}
+
+/**
+ * Strictly decode UTF-8 bytes.
+ *
+ * Unlike the default `TextDecoder`, which silently substitutes U+FFFD
+ * for invalid sequences (lossy — the root cause of binary asset
+ * corruption on install), this returns `null` when the bytes are not
+ * valid UTF-8 so callers can fall back to byte-for-byte handling.
+ * @param bytes - Raw content bytes.
+ * @returns The decoded string, or `null` when not valid UTF-8.
+ */
+export function decodeUtf8Strict(bytes: Uint8Array): string | null {
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Constant-shape byte comparison.
+ * @param a - First byte sequence.
+ * @param b - Second byte sequence.
+ * @returns `true` iff both sequences have identical length and content.
+ */
+export function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.byteLength !== b.byteLength) {
+    return false;
+  }
+  for (let i = 0; i < a.byteLength; i += 1) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Re-read an installed file and verify it matches the intended bytes.
+ * @param fs - Byte-level reader (satisfied by the `FileSystem` port).
+ * @param filePath - Absolute path of the file that was written.
+ * @param expected - The exact bytes the writer intended to write.
+ * @throws {FileIntegrityError} When the file is unreadable or differs.
+ */
+export async function verifyWrittenBytes(
+  fs: ByteReader,
+  filePath: string,
+  expected: Uint8Array
+): Promise<void> {
+  let actual: Uint8Array;
+  try {
+    actual = await fs.readFileBytes(filePath);
+  } catch (cause) {
+    throw new FileIntegrityError(filePath, `unreadable after write (${(cause as Error).message})`);
+  }
+  if (!bytesEqual(actual, expected)) {
+    throw new FileIntegrityError(
+      filePath,
+      `wrote ${expected.byteLength} bytes but read back ${actual.byteLength} bytes with differing content`
+    );
+  }
+}

--- a/packages/core/src/ports/filesystem.ts
+++ b/packages/core/src/ports/filesystem.ts
@@ -39,6 +39,17 @@ export interface DirEntry {
 export interface FileSystem {
   readFile(path: string): Promise<string>;
   writeFile(path: string, contents: string): Promise<void>;
+  /**
+   * Read raw bytes. Required for binary assets (images, archives,
+   * office documents): the string-based `readFile` decodes UTF-8
+   * lossily and corrupts any non-UTF-8 payload (issue #357).
+   */
+  readFileBytes(path: string): Promise<Uint8Array>;
+  /**
+   * Write raw bytes verbatim. Counterpart of `readFileBytes`; writers
+   * must use this for any payload that is not known to be UTF-8 text.
+   */
+  writeFileBytes(path: string, bytes: Uint8Array): Promise<void>;
   readJson<T = unknown>(path: string): Promise<T>;
   writeJson(path: string, value: unknown): Promise<void>;
   exists(path: string): Promise<boolean>;

--- a/packages/core/test/domain/install/integrity.test.ts
+++ b/packages/core/test/domain/install/integrity.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for domain/install/integrity.ts — binary-safe content helpers
+ * and post-write verification (issue #357).
+ */
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  bytesEqual,
+  decodeUtf8Strict,
+  FileIntegrityError,
+  verifyWrittenBytes,
+} from '../../../src/domain/install/integrity';
+
+/** Bytes that are NOT valid UTF-8 (zip local-header magic + 0xFF paddings). */
+const BINARY_BYTES = new Uint8Array([0x50, 0x4B, 0x03, 0x04, 0xFF, 0xFE, 0x00, 0x9D, 0xC7]);
+
+describe('decodeUtf8Strict', () => {
+  it('decodes valid UTF-8 text', () => {
+    const bytes = new TextEncoder().encode('# Héllo — prompt');
+    expect(decodeUtf8Strict(bytes)).toBe('# Héllo — prompt');
+  });
+
+  it('returns null for binary (invalid UTF-8) content', () => {
+    expect(decodeUtf8Strict(BINARY_BYTES)).toBeNull();
+  });
+});
+
+describe('bytesEqual', () => {
+  it('returns true for identical byte sequences', () => {
+    expect(bytesEqual(BINARY_BYTES, Uint8Array.from(BINARY_BYTES))).toBe(true);
+  });
+
+  it('returns false for different lengths or contents', () => {
+    expect(bytesEqual(BINARY_BYTES, BINARY_BYTES.slice(0, 4))).toBe(false);
+    const flipped = Uint8Array.from(BINARY_BYTES);
+    flipped[0] = 0x00;
+    expect(bytesEqual(BINARY_BYTES, flipped)).toBe(false);
+  });
+});
+
+describe('verifyWrittenBytes', () => {
+  const fsWith = (bytes: Uint8Array | null): { readFileBytes(p: string): Promise<Uint8Array> } => ({
+    readFileBytes: (p: string): Promise<Uint8Array> =>
+      bytes === null ? Promise.reject(new Error(`ENOENT: ${p}`)) : Promise.resolve(bytes)
+  });
+
+  it('resolves when the on-disk bytes match the intended bytes', async () => {
+    await expect(verifyWrittenBytes(fsWith(BINARY_BYTES), '/t/a.pptx', BINARY_BYTES))
+      .resolves.toBeUndefined();
+  });
+
+  it('throws FileIntegrityError with the path when bytes differ', async () => {
+    const corrupted = Uint8Array.from(BINARY_BYTES);
+    corrupted[4] = 0xEF;
+    await expect(verifyWrittenBytes(fsWith(corrupted), '/t/a.pptx', BINARY_BYTES))
+      .rejects.toThrow(FileIntegrityError);
+    await expect(verifyWrittenBytes(fsWith(corrupted), '/t/a.pptx', BINARY_BYTES))
+      .rejects.toThrow('/t/a.pptx');
+  });
+
+  it('throws FileIntegrityError when the file cannot be read back', async () => {
+    await expect(verifyWrittenBytes(fsWith(null), '/t/missing.bin', BINARY_BYTES))
+      .rejects.toThrow(FileIntegrityError);
+  });
+});

--- a/packages/core/test/ports/conformance.test.ts
+++ b/packages/core/test/ports/conformance.test.ts
@@ -55,6 +55,14 @@ class InMemoryFileSystem implements FileSystem {
     this.files.set(path, contents);
   }
 
+  public async readFileBytes(path: string): Promise<Uint8Array> {
+    return new TextEncoder().encode(await this.readFile(path));
+  }
+
+  public async writeFileBytes(path: string, bytes: Uint8Array): Promise<void> {
+    this.files.set(path, new TextDecoder().decode(bytes));
+  }
+
   public async readJson<T = unknown>(path: string): Promise<T> {
     return JSON.parse(await this.readFile(path)) as T;
   }

--- a/packages/infra/src/fs/node-filesystem.ts
+++ b/packages/infra/src/fs/node-filesystem.ts
@@ -34,6 +34,15 @@ export class NodeFileSystem implements FileSystem {
     await writeFile(path, contents, 'utf8');
   }
 
+  public async readFileBytes(path: string): Promise<Uint8Array> {
+    const buffer = await readFile(path);
+    return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+  }
+
+  public async writeFileBytes(path: string, bytes: Uint8Array): Promise<void> {
+    await writeFile(path, bytes);
+  }
+
   public async readJson<T = unknown>(path: string): Promise<T> {
     return JSON.parse(await this.readFile(path)) as T;
   }

--- a/packages/infra/src/resolvers/local-resolver.ts
+++ b/packages/infra/src/resolvers/local-resolver.ts
@@ -17,7 +17,12 @@ import type {
 
 export interface LocalDirFs {
   readDir(p: string): Promise<string[]>;
-  readFile(p: string): Promise<string>;
+  /**
+   * Byte-level read. Required so binary assets (images, archives,
+   * office documents) survive the round-trip: reading them through a
+   * UTF-8 string API corrupts any non-UTF-8 payload (issue #357).
+   */
+  readFileBytes(p: string): Promise<Uint8Array>;
   exists(p: string): Promise<boolean>;
 }
 
@@ -51,14 +56,15 @@ const walk = async (
   for (const entry of entries) {
     const full = path.join(cur, entry);
     // FileSystem.readDir returns names only; we probe by trying
-    // readFile first. If it succeeds the entry is a file; if it
-    // throws we recurse as a directory.
+    // readFileBytes first. If it succeeds the entry is a file; if it
+    // throws we recurse as a directory. Byte-level reads keep binary
+    // assets intact (issue #357).
     try {
-      const text = await fs.readFile(full);
+      const bytes = await fs.readFileBytes(full);
       const rel = path.relative(root, full);
       // Normalize to forward slashes so the map keys match the
       // bundle's logical layout independent of host OS.
-      out.set(rel.split(path.sep).join('/'), new TextEncoder().encode(text));
+      out.set(rel.split(path.sep).join('/'), bytes);
     } catch {
       await walk(root, full, fs, out);
     }

--- a/packages/infra/src/writers/repo-scope-writer.ts
+++ b/packages/infra/src/writers/repo-scope-writer.ts
@@ -22,6 +22,9 @@ import type {
   TargetWriteResult,
 } from '@ai-primitives-hub/core';
 import {
+  verifyWrittenBytes,
+} from '@ai-primitives-hub/core';
+import {
   load as parseYaml,
 } from 'js-yaml';
 
@@ -104,6 +107,23 @@ export class RepositoryScopeWriter {
     const text = new TextDecoder().decode(manifestBytes);
     const manifest = parseYaml(text) as DeploymentManifest;
     return manifest;
+  }
+
+  /**
+   * Write raw bundle bytes verbatim and verify the on-disk result.
+   *
+   * Binary-safe (issue #357): the previous string round-trip
+   * (`TextDecoder` + `writeFile`) replaced invalid UTF-8 sequences with
+   * U+FFFD and corrupted binary assets such as PPTX files. Writing
+   * bytes and re-reading them turns any residual corruption into a
+   * loud `FileIntegrityError` instead of a silent broken artifact.
+   * @param targetPath Absolute destination path.
+   * @param bytes Exact bytes to install.
+   */
+  private async writeBytesVerified(targetPath: string, bytes: Uint8Array): Promise<void> {
+    await this.fs.mkdir(path.dirname(targetPath), { recursive: true });
+    await this.fs.writeFileBytes(targetPath, bytes);
+    await verifyWrittenBytes(this.fs, targetPath, bytes);
   }
 
   private getTargetPath(item: { type: string; file: string }): string | null {
@@ -195,8 +215,7 @@ export class RepositoryScopeWriter {
       if (bundlePath.startsWith(sourcePrefix)) {
         const relativePath = bundlePath.slice(sourcePrefix.length);
         const targetPath = path.join(skillDir, relativePath);
-        await this.fs.mkdir(path.dirname(targetPath), { recursive: true });
-        await this.fs.writeFile(targetPath, new TextDecoder().decode(bytes));
+        await this.writeBytesVerified(targetPath, bytes);
         written.push(targetPath);
       }
     }
@@ -226,8 +245,7 @@ export class RepositoryScopeWriter {
       if (bundlePath.startsWith(sourcePrefix)) {
         const relativePath = bundlePath.slice(sourcePrefix.length);
         const targetPath = path.join(pluginDir, relativePath);
-        await this.fs.mkdir(path.dirname(targetPath), { recursive: true });
-        await this.fs.writeFile(targetPath, new TextDecoder().decode(bytes));
+        await this.writeBytesVerified(targetPath, bytes);
         written.push(targetPath);
       }
     }
@@ -251,8 +269,7 @@ export class RepositoryScopeWriter {
         if (bytes) {
           const targetPath = this.getTargetPath({ type: p.type, file: p.file });
           if (targetPath) {
-            await this.fs.mkdir(path.dirname(targetPath), { recursive: true });
-            await this.fs.writeFile(targetPath, new TextDecoder().decode(bytes));
+            await this.writeBytesVerified(targetPath, bytes);
             written.push(targetPath);
           } else {
             skipped.push(p.file);
@@ -431,8 +448,7 @@ export class RepositoryScopeWriter {
             const relativePath = bundlePath.slice(skillPrefix.length);
             const targetPath = path.join(skillDir, relativePath);
 
-            await this.fs.mkdir(path.dirname(targetPath), { recursive: true });
-            await this.fs.writeFile(targetPath, new TextDecoder().decode(bytes));
+            await this.writeBytesVerified(targetPath, bytes);
             written.push(targetPath);
           }
         }

--- a/packages/infra/test/fs/node-filesystem.test.ts
+++ b/packages/infra/test/fs/node-filesystem.test.ts
@@ -40,6 +40,15 @@ describe('NodeFileSystem', () => {
     await expect(fs.readFile(join(dir, 'missing.txt'))).rejects.toThrow();
   });
 
+  it('round-trips binary bytes losslessly via writeFileBytes/readFileBytes (issue #357)', async () => {
+    const filePath = join(dir, 'asset.pptx');
+    // Invalid UTF-8 sequences: a utf8 string round-trip would corrupt them.
+    const binaryBytes = new Uint8Array([0x50, 0x4B, 0x03, 0x04, 0xFF, 0xFE, 0x00, 0x9D, 0xC7, 0x80]);
+    await fs.writeFileBytes(filePath, binaryBytes);
+
+    expect(await fs.readFileBytes(filePath)).toEqual(binaryBytes);
+  });
+
   it('writes then reads back JSON, pretty-printed with a trailing newline', async () => {
     const filePath = join(dir, 'data.json');
     await fs.writeJson(filePath, { a: 1, b: [2, 3] });

--- a/packages/infra/test/helpers/in-memory-filesystem.ts
+++ b/packages/infra/test/helpers/in-memory-filesystem.ts
@@ -13,9 +13,15 @@ import type {
 } from '@ai-primitives-hub/core';
 
 interface InMemoryEntry {
-  contents: string;
+  contents: string | Uint8Array;
   mtimeMs: number;
 }
+
+const asString = (contents: string | Uint8Array): string =>
+  typeof contents === 'string' ? contents : new TextDecoder().decode(contents);
+
+const asBytes = (contents: string | Uint8Array): Uint8Array =>
+  typeof contents === 'string' ? new TextEncoder().encode(contents) : contents;
 
 /**
  * A flat, path-keyed in-memory filesystem. Directories are implicit:
@@ -35,7 +41,7 @@ export class InMemoryFileSystem implements FileSystem {
    * @param mtimeMs - Modification time to report from `stat()`, in
    * milliseconds since the Unix epoch. Defaults to `0`.
    */
-  public seed(path: string, contents: string, mtimeMs = 0): void {
+  public seed(path: string, contents: string | Uint8Array, mtimeMs = 0): void {
     this.files.set(this.normalizePath(path), { contents, mtimeMs });
   }
 
@@ -45,11 +51,24 @@ export class InMemoryFileSystem implements FileSystem {
     if (!entry) {
       throw new Error(`ENOENT: no such file: ${normalizedPath}`);
     }
-    return entry.contents;
+    return asString(entry.contents);
   }
 
   public async writeFile(path: string, contents: string): Promise<void> {
     this.files.set(this.normalizePath(path), { contents, mtimeMs: Date.now() });
+  }
+
+  public async readFileBytes(path: string): Promise<Uint8Array> {
+    const normalizedPath = this.normalizePath(path);
+    const entry = this.files.get(normalizedPath);
+    if (!entry) {
+      throw new Error(`ENOENT: no such file: ${normalizedPath}`);
+    }
+    return asBytes(entry.contents);
+  }
+
+  public async writeFileBytes(path: string, bytes: Uint8Array): Promise<void> {
+    this.files.set(this.normalizePath(path), { contents: bytes, mtimeMs: Date.now() });
   }
 
   public async readJson<T = unknown>(path: string): Promise<T> {
@@ -109,7 +128,7 @@ export class InMemoryFileSystem implements FileSystem {
       return {
         isDirectory: false,
         isFile: true,
-        size: Buffer.byteLength(entry.contents, 'utf8'),
+        size: asBytes(entry.contents).byteLength,
         mtimeMs: entry.mtimeMs
       };
     }

--- a/packages/infra/test/resolvers/local-resolver.test.ts
+++ b/packages/infra/test/resolvers/local-resolver.test.ts
@@ -20,7 +20,7 @@ describe('readLocalBundle', () => {
 
   const mockFs = {
     readDir: vi.fn(),
-    readFile: vi.fn(),
+    readFileBytes: vi.fn(),
     exists: vi.fn()
   } satisfies LocalDirFs;
 
@@ -46,12 +46,12 @@ describe('readLocalBundle', () => {
       }
       return [];
     });
-    mockFs.readFile.mockImplementation(async (p: string) => {
+    mockFs.readFileBytes.mockImplementation(async (p: string) => {
       if (normalizePath(p) === '/bundle/file1.txt') {
-        return 'content1';
+        return new TextEncoder().encode('content1');
       }
       if (normalizePath(p) === '/bundle/subdir/file2.txt') {
-        return 'content2';
+        return new TextEncoder().encode('content2');
       }
       throw new Error('Not a file');
     });
@@ -66,7 +66,7 @@ describe('readLocalBundle', () => {
   it('normalizes path separators to forward slashes', async () => {
     mockFs.exists.mockResolvedValue(true);
     mockFs.readDir.mockResolvedValue(['file.txt']);
-    mockFs.readFile.mockResolvedValue('content');
+    mockFs.readFileBytes.mockResolvedValue(new TextEncoder().encode('content'));
 
     const result = await readLocalBundle('/bundle', mockFs);
     expect(result.has('file.txt')).toBe(true);
@@ -94,15 +94,26 @@ describe('readLocalBundle', () => {
       }
       return [];
     });
-    mockFs.readFile.mockImplementation(async (p: string) => {
+    mockFs.readFileBytes.mockImplementation(async (p: string) => {
       if (normalizePath(p) === '/bundle/dir1/dir2/file.txt') {
-        return 'content';
+        return new TextEncoder().encode('content');
       }
       throw new Error('Not a file');
     });
 
     const result = await readLocalBundle('/bundle', mockFs);
     expect(result.has('dir1/dir2/file.txt')).toBe(true);
+  });
+
+  it('preserves binary file contents byte-for-byte (issue #357)', async () => {
+    // Invalid UTF-8 sequences: a lossy string round-trip would corrupt them.
+    const binaryBytes = new Uint8Array([0x50, 0x4B, 0x03, 0x04, 0xFF, 0xFE, 0x00, 0x9D, 0xC7]);
+    mockFs.exists.mockResolvedValue(true);
+    mockFs.readDir.mockResolvedValue(['template.pptx']);
+    mockFs.readFileBytes.mockResolvedValue(binaryBytes);
+
+    const result = await readLocalBundle('/bundle', mockFs);
+    expect(result.get('template.pptx')).toEqual(binaryBytes);
   });
 
   it('handles mixed files and directories', async () => {
@@ -116,9 +127,9 @@ describe('readLocalBundle', () => {
       }
       return [];
     });
-    mockFs.readFile.mockImplementation(async (p: string) => {
+    mockFs.readFileBytes.mockImplementation(async (p: string) => {
       if (normalizePath(p).includes('file')) {
-        return 'content';
+        return new TextEncoder().encode('content');
       }
       throw new Error('Not a file');
     });

--- a/packages/infra/test/writers/repo-scope-writer.test.ts
+++ b/packages/infra/test/writers/repo-scope-writer.test.ts
@@ -340,6 +340,54 @@ prompts:
     expect(result.written).toEqual([]);
   });
 
+  it('writes binary skill assets byte-for-byte (issue #357)', async () => {
+    const fs = new InMemoryFileSystem();
+    const writer = new RepositoryScopeWriter({ fs, workspaceRoot: WORKSPACE_ROOT, commitMode: 'commit' });
+
+    // Zip local-header magic followed by bytes that are NOT valid UTF-8;
+    // a lossy TextDecoder round-trip would replace them with U+FFFD.
+    const binaryBytes = new Uint8Array([0x50, 0x4B, 0x03, 0x04, 0xFF, 0xFE, 0x00, 0x9D, 0xC7, 0x80]);
+    const manifest = `id: test-bundle
+skills:
+  - id: deck-skill
+    file: skills/deck-skill/SKILL.md
+    type: skill`;
+
+    const files = new Map<string, Uint8Array>([
+      ['deployment-manifest.yml', new TextEncoder().encode(manifest)],
+      ['skills/deck-skill/SKILL.md', new TextEncoder().encode('# Deck skill')],
+      ['skills/deck-skill/assets/template.pptx', binaryBytes]
+    ]);
+
+    const result = await writer.write(files);
+
+    const installedPath = path.join(WORKSPACE_ROOT, '.github', 'skills', 'deck-skill', 'assets', 'template.pptx');
+    expect(result.written).toContain(installedPath);
+    expect(await fs.readFileBytes(installedPath)).toEqual(binaryBytes);
+  });
+
+  it('writes binary manifest items byte-for-byte', async () => {
+    const fs = new InMemoryFileSystem();
+    const writer = new RepositoryScopeWriter({ fs, workspaceRoot: WORKSPACE_ROOT, commitMode: 'commit' });
+
+    const binaryBytes = new Uint8Array([0x89, 0x50, 0x4E, 0x47, 0xFF, 0xD8, 0x00, 0xC0]);
+    const manifest = `id: test-bundle
+hooks:
+  - id: binary-hook
+    file: hooks/tool.bin
+    type: hook`;
+
+    const files = new Map<string, Uint8Array>([
+      ['deployment-manifest.yml', new TextEncoder().encode(manifest)],
+      ['hooks/tool.bin', binaryBytes]
+    ]);
+
+    await writer.write(files);
+
+    const installedPath = path.join(WORKSPACE_ROOT, '.github', 'hooks', 'tool.bin');
+    expect(await fs.readFileBytes(installedPath)).toEqual(binaryBytes);
+  });
+
   it('handles file paths with special characters', async () => {
     const fs = new InMemoryFileSystem();
     const writer = new RepositoryScopeWriter({ fs, workspaceRoot: WORKSPACE_ROOT, commitMode: 'commit' });


### PR DESCRIPTION
## Description

Installing a bundle that carries binary assets (for example a PPTX inside a skill) produced a corrupted on-disk file even though the archive on GitHub was intact. The write pipeline decoded every payload as UTF-8 and wrote strings, so invalid byte sequences were replaced with U+FFFD.

This change makes install writers binary-safe and verifies every written file against the intended bytes.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧪 Test coverage improvement

## Related Issues

Fixes #357

## Changes Made

- Added `readFileBytes` / `writeFileBytes` to the `FileSystem` port and implemented them on `NodeFileSystem` and test doubles.
- Added `core` integrity helpers: `decodeUtf8Strict`, `bytesEqual`, `verifyWrittenBytes`, and `FileIntegrityError` (`BUNDLE.INTEGRITY_MISMATCH`).
- `FileTreeTargetWriter` and `RepositoryScopeWriter` write binary payloads byte-for-byte and re-read them after write.
- Text payloads that are valid UTF-8 still go through the existing transformer path.
- `readLocalBundle` reads bytes so `--from` directory installs no longer corrupt binaries on read.
- Extension `NodeWriterFs` gained byte APIs; user-scope WSL / symlink-fallback copies no longer use a utf8 string round-trip.
- Documented binary safety and the remaining lockfile `installedChecksum` follow-up in the installation-flow guide.

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

### Manual Testing Steps

1. `pnpm -C packages/core test`
2. `pnpm -C packages/infra test`
3. `pnpm -C packages/app test`
4. `pnpm -C packages/cli test`
5. `pnpm -C apps/vscode-extension run test:unit`
6. Installed a skill containing a 4 KiB random binary via `ai-primitives-hub install --from` at repository and user scope; sha256 of the installed file matched the source.

### Tested On

- [x] Linux

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Documentation

- [ ] README.md updated
- [x] JSDoc comments added/updated
- [ ] No documentation changes needed

## Additional Notes

Zip CRC-32 and governed-manifest SHA-256 already cover archive → memory. This PR closes the last hop (memory → target). Recording a separate lockfile `installedChecksum` for transformed files is left as Stage 2 / follow-up so this change stays targeted and does not alter the lockfile schema.

## Reviewer Guidelines

Please pay special attention to:

- Binary vs text branching (`decodeUtf8Strict` + no transformer on non-UTF-8)
- Every writer write path using `writeFileBytes` + `verifyWrittenBytes`
- No remaining `TextDecoder().decode(bytes)` + `writeFile(..., utf8)` copies on install paths

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
