### PR TITLE
feat(hub): add shared configuration validation

### DIFF
--- a/packages/app/src/registry/index.ts
+++ b/packages/app/src/registry/index.ts
@@ -21,4 +21,5 @@ export * from './search-registry-bundles';
 export * from './uninstall-installed-bundle';
 export * from './update-registry-bundle';
 export * from './user-config-paths';
+export * from './validate-hub-config-file';
 export * from './version-consolidator';

--- a/packages/app/src/registry/validate-hub-config-file.ts
+++ b/packages/app/src/registry/validate-hub-config-file.ts
@@ -1,0 +1,752 @@
+/**
+ * Validate a hub-config YAML file from a repository working tree.
+ *
+ * The app layer coordinates file access and the infra boundary validator;
+ * parsing and policy logic remain below the delivery layer so the CLI and
+ * future authoring integrations use the same behavior.
+ * @module registry/validate-hub-config-file
+ */
+import type {
+  Bundle,
+  FileSystem,
+  HubProfileBundle,
+  RegistrySource,
+  SourceType,
+  ValidationResult,
+} from '@ai-primitives-hub/core';
+import {
+  compareVersions,
+  extractBundleIdentity,
+} from '@ai-primitives-hub/core';
+import {
+  parseHubConfigYaml,
+  validateHubConfigDocument,
+} from '@ai-primitives-hub/infra';
+import {
+  createSourceAdapter,
+  type SourceAdapterFactoryDeps,
+} from './create-source-adapter';
+
+export interface HubConfigFileValidationResult extends ValidationResult {
+  file: string;
+}
+
+export interface HubCatalogBundle {
+  id: string;
+  version: string;
+}
+
+export interface HubSourceDeepValidationResult extends ValidationResult {
+  sourceId: string;
+  sourceType: string;
+  enabled: boolean;
+  bundles: HubCatalogBundle[];
+  skipped?: boolean;
+}
+
+export interface HubProfileBundleDeepValidationResult {
+  sourceId: string;
+  bundleId: string;
+  requestedVersion: string;
+  required: boolean;
+  valid: boolean;
+  resolvedBundle?: HubCatalogBundle;
+  errors: string[];
+  warnings: string[];
+}
+
+export interface HubProfileDeepValidationResult {
+  profileId: string;
+  valid: boolean;
+  bundles: HubProfileBundleDeepValidationResult[];
+  errors: string[];
+  warnings: string[];
+}
+
+export interface DeepHubConfigValidationResult extends HubConfigFileValidationResult {
+  deep: true;
+  sources: HubSourceDeepValidationResult[];
+  profiles: HubProfileDeepValidationResult[];
+  bundlesFound: number;
+}
+
+export type HubValidationProgress =
+  | {
+    phase: 'started';
+    sourcesTotal: number;
+    profilesTotal: number;
+  }
+  | {
+    phase: 'source';
+    status: 'started' | 'completed';
+    current: number;
+    total: number;
+    sourceId: string;
+    sourceType: string;
+    enabled: boolean;
+    valid?: boolean;
+    bundlesFound?: number;
+    skipped?: boolean;
+  }
+  | {
+    phase: 'catalog';
+    status: 'started' | 'completed';
+    current: number;
+    total: number;
+    sourceId: string;
+    sourceType: string;
+    bundlesFound?: number;
+  }
+  | {
+    phase: 'profile';
+    status: 'started' | 'completed';
+    current: number;
+    total: number;
+    profileId: string;
+    bundlesTotal: number;
+    valid?: boolean;
+    errors?: number;
+    warnings?: number;
+  }
+  | {
+    phase: 'completed';
+    sourcesTotal: number;
+    profilesTotal: number;
+    bundlesFound: number;
+    valid: boolean;
+  };
+
+export interface HubConfigFileValidationOptions {
+  /** Perform source accessibility, catalog discovery, and profile resolution checks. */
+  deep?: boolean;
+  /** Dependencies used to construct the configured source adapters. */
+  sourceAdapterDeps?: SourceAdapterFactoryDeps;
+  /** Receive deterministic progress events during deep validation. */
+  onProgress?: (event: HubValidationProgress) => void;
+}
+
+const failure = (file: string, message: string): HubConfigFileValidationResult => ({
+  file,
+  valid: false,
+  errors: [message],
+  warnings: []
+});
+
+/**
+ * Read and validate one hub configuration file.
+ * @param fs Filesystem port used to read the repository file.
+ * @param filePath Absolute or repository-relative file path.
+ * @param options
+ * @returns File path and combined validation result.
+ */
+export async function validateHubConfigFile(
+  fs: FileSystem,
+  filePath: string,
+  options: HubConfigFileValidationOptions = {}
+): Promise<HubConfigFileValidationResult | DeepHubConfigValidationResult> {
+  let content: string;
+  try {
+    content = await fs.readFile(filePath);
+  } catch (error) {
+    return failure(
+      filePath,
+      `Unable to read hub configuration '${filePath}': ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+
+  let config: unknown;
+  try {
+    config = parseHubConfigYaml(content);
+  } catch (error) {
+    return failure(
+      filePath,
+      `YAML parse error in '${filePath}': ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+
+  const staticResult: HubConfigFileValidationResult = {
+    file: filePath,
+    ...validateHubConfigDocument(config)
+  };
+
+  if (!options.deep) {
+    return staticResult;
+  }
+
+  if (!options.sourceAdapterDeps) {
+    return {
+      ...staticResult,
+      deep: true,
+      sources: [],
+      profiles: [],
+      bundlesFound: 0,
+      valid: false,
+      errors: [...staticResult.errors, 'Deep validation requires source adapter dependencies.']
+    };
+  }
+
+  if (!staticResult.valid) {
+    return {
+      ...staticResult,
+      deep: true,
+      sources: [],
+      profiles: [],
+      bundlesFound: 0
+    };
+  }
+
+  return validateHubConfigDeep(config, filePath, options.sourceAdapterDeps, options.onProgress);
+}
+
+interface SourceCatalog {
+  source: RegistrySource;
+  result: HubSourceDeepValidationResult;
+  bundles: Bundle[];
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> => (
+  value !== null && typeof value === 'object' && !Array.isArray(value)
+);
+
+const asString = (value: unknown, fallback: string): string => (
+  typeof value === 'string' ? value : fallback
+);
+
+const sourceTypeFrom = (value: unknown): SourceType | undefined => {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  return value as SourceType;
+};
+
+function toRegistrySource(value: Record<string, unknown>): RegistrySource | undefined {
+  const id = typeof value.id === 'string' ? value.id : undefined;
+  const type = sourceTypeFrom(value.type);
+  const url = typeof value.url === 'string'
+    ? value.url
+    : (typeof value.repository === 'string'
+      ? `https://github.com/${value.repository}`
+      : undefined);
+
+  if (!id || !type || !url) {
+    return undefined;
+  }
+
+  const config = isRecord(value.config) ? value.config : undefined;
+  const topLevelBranch = typeof value.branch === 'string' ? value.branch : undefined;
+  const normalizedConfig = topLevelBranch === undefined || config?.branch !== undefined
+    ? config
+    : { ...config, branch: topLevelBranch };
+
+  return {
+    id,
+    name: asString(value.name, id),
+    type,
+    url,
+    enabled: value.enabled === true,
+    priority: typeof value.priority === 'number' ? value.priority : 0,
+    private: value.private === true,
+    token: typeof value.token === 'string' ? value.token : undefined,
+    metadata: isRecord(value.metadata) ? value.metadata : undefined,
+    config: normalizedConfig
+  };
+}
+
+function bundleMatchesReference(bundle: Bundle, reference: HubProfileBundle, sourceType: SourceType): boolean {
+  if (bundle.id === reference.id) {
+    return true;
+  }
+  if (sourceType !== 'github') {
+    return false;
+  }
+
+  return extractBundleIdentity(bundle.id, sourceType) === extractBundleIdentity(reference.id, sourceType);
+}
+
+function compareCatalogVersions(left: HubCatalogBundle, right: HubCatalogBundle): number {
+  try {
+    const versionOrder = compareVersions(right.version, left.version);
+    if (versionOrder !== 0) {
+      return versionOrder;
+    }
+  } catch {
+    const versionOrder = right.version.localeCompare(left.version);
+    if (versionOrder !== 0) {
+      return versionOrder;
+    }
+  }
+  return left.id.localeCompare(right.id);
+}
+
+function sortBundles(bundles: Bundle[]): Bundle[] {
+  return bundles.toSorted((left, right) => {
+    const idOrder = left.id.localeCompare(right.id);
+    if (idOrder !== 0) {
+      return idOrder;
+    }
+    return compareCatalogVersions(
+      { id: left.id, version: left.version },
+      { id: right.id, version: right.version }
+    );
+  });
+}
+
+function selectLatestBundle(bundles: Bundle[]): Bundle | undefined {
+  return bundles
+    .toSorted((left, right) => compareCatalogVersions(
+      { id: left.id, version: left.version },
+      { id: right.id, version: right.version }
+    ))[0];
+}
+
+function availableVersions(bundles: Bundle[]): string {
+  return [...new Set(bundles.map((bundle) => bundle.version))]
+    .toSorted((left, right) => {
+      try {
+        return compareVersions(left, right);
+      } catch {
+        return left.localeCompare(right);
+      }
+    })
+    .join(', ');
+}
+
+async function validateSource(
+  source: RegistrySource,
+  deps: SourceAdapterFactoryDeps,
+  onProgress: ((event: HubValidationProgress) => void) | undefined,
+  current: number,
+  total: number
+): Promise<SourceCatalog> {
+  onProgress?.({
+    phase: 'source',
+    status: 'started',
+    current,
+    total,
+    sourceId: source.id,
+    sourceType: source.type,
+    enabled: source.enabled
+  });
+
+  if (!source.enabled) {
+    onProgress?.({
+      phase: 'source',
+      status: 'completed',
+      current,
+      total,
+      sourceId: source.id,
+      sourceType: source.type,
+      enabled: false,
+      valid: true,
+      bundlesFound: 0,
+      skipped: true
+    });
+    return {
+      source,
+      bundles: [],
+      result: {
+        sourceId: source.id,
+        sourceType: source.type,
+        enabled: false,
+        valid: true,
+        errors: [],
+        warnings: ['Source is disabled; accessibility and catalog checks were skipped.'],
+        bundles: [],
+        bundlesFound: 0,
+        skipped: true
+      }
+    };
+  }
+
+  let adapter;
+  try {
+    adapter = createSourceAdapter(source, deps);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    onProgress?.({
+      phase: 'source',
+      status: 'completed',
+      current,
+      total,
+      sourceId: source.id,
+      sourceType: source.type,
+      enabled: true,
+      valid: false,
+      bundlesFound: 0
+    });
+    return {
+      source,
+      bundles: [],
+      result: {
+        sourceId: source.id,
+        sourceType: source.type,
+        enabled: true,
+        valid: false,
+        errors: [`Failed to create source adapter: ${message}`],
+        warnings: [],
+        bundles: [],
+        bundlesFound: 0
+      }
+    };
+  }
+
+  let validation: ValidationResult;
+  try {
+    validation = await adapter.validate();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    validation = {
+      valid: false,
+      errors: [`Source validation failed: ${message}`],
+      warnings: []
+    };
+  }
+
+  if (!validation.valid) {
+    onProgress?.({
+      phase: 'source',
+      status: 'completed',
+      current,
+      total,
+      sourceId: source.id,
+      sourceType: source.type,
+      enabled: true,
+      valid: false,
+      bundlesFound: 0
+    });
+    return {
+      source,
+      bundles: [],
+      result: {
+        sourceId: source.id,
+        sourceType: source.type,
+        enabled: true,
+        valid: false,
+        errors: validation.errors,
+        warnings: validation.warnings ?? [],
+        bundles: [],
+        bundlesFound: 0
+      }
+    };
+  }
+
+  onProgress?.({
+    phase: 'catalog',
+    status: 'started',
+    current,
+    total,
+    sourceId: source.id,
+    sourceType: source.type
+  });
+
+  let bundles: Bundle[];
+  try {
+    bundles = sortBundles(await adapter.fetchBundles());
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    onProgress?.({
+      phase: 'catalog',
+      status: 'completed',
+      current,
+      total,
+      sourceId: source.id,
+      sourceType: source.type,
+      bundlesFound: 0
+    });
+    onProgress?.({
+      phase: 'source',
+      status: 'completed',
+      current,
+      total,
+      sourceId: source.id,
+      sourceType: source.type,
+      enabled: true,
+      valid: false,
+      bundlesFound: 0
+    });
+    return {
+      source,
+      bundles: [],
+      result: {
+        sourceId: source.id,
+        sourceType: source.type,
+        enabled: true,
+        valid: false,
+        errors: [`Failed to discover bundles: ${message}`],
+        warnings: validation.warnings ?? [],
+        bundles: [],
+        bundlesFound: 0
+      }
+    };
+  }
+
+  const catalog = bundles.map(({ id, version }) => ({ id, version }));
+  onProgress?.({
+    phase: 'catalog',
+    status: 'completed',
+    current,
+    total,
+    sourceId: source.id,
+    sourceType: source.type,
+    bundlesFound: bundles.length
+  });
+  onProgress?.({
+    phase: 'source',
+    status: 'completed',
+    current,
+    total,
+    sourceId: source.id,
+    sourceType: source.type,
+    enabled: true,
+    valid: true,
+    bundlesFound: bundles.length
+  });
+  return {
+    source,
+    bundles,
+    result: {
+      sourceId: source.id,
+      sourceType: source.type,
+      enabled: true,
+      valid: true,
+      errors: [],
+      warnings: validation.warnings ?? [],
+      bundles: catalog,
+      bundlesFound: bundles.length
+    }
+  };
+}
+
+function resolveProfileBundle(
+  profileId: string,
+  reference: HubProfileBundle,
+  catalog: SourceCatalog | undefined
+): HubProfileBundleDeepValidationResult {
+  const base = {
+    sourceId: reference.source,
+    bundleId: reference.id,
+    requestedVersion: reference.version,
+    required: reference.required
+  };
+
+  const diagnostic = (message: string): HubProfileBundleDeepValidationResult => ({
+    ...base,
+    valid: !reference.required,
+    errors: reference.required ? [message] : [],
+    warnings: reference.required ? [] : [message]
+  });
+
+  if (!catalog) {
+    return diagnostic(`Profile '${profileId}' references unknown source '${reference.source}'.`);
+  }
+  if (!catalog.source.enabled) {
+    return diagnostic(`Profile '${profileId}' references disabled source '${reference.source}'.`);
+  }
+  if (!catalog.result.valid) {
+    return diagnostic(`Profile '${profileId}' cannot resolve bundle '${reference.id}' because source '${reference.source}' failed validation.`);
+  }
+
+  const candidates = catalog.bundles.filter((bundle) => bundleMatchesReference(bundle, reference, catalog.source.type));
+  if (candidates.length === 0) {
+    return diagnostic(
+      `Profile '${profileId}' references bundle '${reference.id}' from source '${reference.source}', `
+      + 'but no matching bundle was discovered.'
+    );
+  }
+
+  if (reference.version === 'latest') {
+    const latest = selectLatestBundle(candidates);
+    if (!latest) {
+      return diagnostic(`Profile '${profileId}' references bundle '${reference.id}' from source '${reference.source}', but no matching bundle was discovered.`);
+    }
+    return {
+      ...base,
+      valid: true,
+      resolvedBundle: { id: latest.id, version: latest.version },
+      errors: [],
+      warnings: []
+    };
+  }
+
+  const exactVersion = candidates.find((bundle) => bundle.version === reference.version);
+  if (!exactVersion) {
+    return diagnostic(
+      `Profile '${profileId}' requires bundle '${reference.id}' at version '${reference.version}' `
+      + `from source '${reference.source}', but available versions are: ${availableVersions(candidates)}.`
+    );
+  }
+
+  return {
+    ...base,
+    valid: true,
+    resolvedBundle: { id: exactVersion.id, version: exactVersion.version },
+    errors: [],
+    warnings: []
+  };
+}
+
+async function validateHubConfigDeep(
+  config: unknown,
+  filePath: string,
+  deps: SourceAdapterFactoryDeps,
+  onProgress: ((event: HubValidationProgress) => void) | undefined
+): Promise<DeepHubConfigValidationResult> {
+  const root = config as Record<string, unknown>;
+  const sourceValues = Array.isArray(root.sources) ? root.sources.filter((value) => isRecord(value)) : [];
+  const sourceEntries = sourceValues
+    .map((value, index) => ({ value, index, id: asString(value.id, `#${index + 1}`) }))
+    .toSorted((left, right) => left.id.localeCompare(right.id));
+  const profileValues = Array.isArray(root.profiles) ? root.profiles.filter((value) => isRecord(value)) : [];
+  const profileEntries = profileValues
+    .map((value, index) => ({ value, index, id: asString(value.id, `#${index + 1}`) }))
+    .toSorted((left, right) => left.id.localeCompare(right.id));
+  const catalogs = new Map<string, SourceCatalog>();
+
+  onProgress?.({
+    phase: 'started',
+    sourcesTotal: sourceEntries.length,
+    profilesTotal: profileEntries.length
+  });
+
+  for (const [sourceIndex, entry] of sourceEntries.entries()) {
+    const source = toRegistrySource(entry.value);
+    if (!source) {
+      const sourceType = asString(entry.value.type, 'unknown');
+      onProgress?.({
+        phase: 'source',
+        status: 'started',
+        current: sourceIndex + 1,
+        total: sourceEntries.length,
+        sourceId: entry.id,
+        sourceType,
+        enabled: entry.value.enabled === true
+      });
+      catalogs.set(entry.id, {
+        source: {
+          id: entry.id,
+          name: entry.id,
+          type: sourceType as SourceType,
+          url: '',
+          enabled: entry.value.enabled === true,
+          priority: typeof entry.value.priority === 'number' ? entry.value.priority : 0
+        },
+        bundles: [],
+        result: {
+          sourceId: entry.id,
+          sourceType,
+          enabled: entry.value.enabled === true,
+          valid: false,
+          errors: [`Source '${entry.id}' must define a supported type and URL for deep validation.`],
+          warnings: [],
+          bundles: [],
+          bundlesFound: 0
+        }
+      });
+      onProgress?.({
+        phase: 'source',
+        status: 'completed',
+        current: sourceIndex + 1,
+        total: sourceEntries.length,
+        sourceId: entry.id,
+        sourceType,
+        enabled: entry.value.enabled === true,
+        valid: false,
+        bundlesFound: 0
+      });
+      continue;
+    }
+
+    catalogs.set(entry.id, await validateSource(
+      source,
+      deps,
+      onProgress,
+      sourceIndex + 1,
+      sourceEntries.length
+    ));
+  }
+
+  const sourceResults = sourceEntries.map((entry) => catalogs.get(entry.id)!.result);
+
+  const profileResults = profileEntries.map((entry, profileIndex) => {
+    const rawBundles = Array.isArray(entry.value.bundles)
+      ? entry.value.bundles.filter((value) => isRecord(value))
+      : [];
+    const references = rawBundles
+      .map((value) => ({
+        id: asString(value.id, ''),
+        version: asString(value.version, ''),
+        source: asString(value.source, ''),
+        required: value.required === true
+      }))
+      .toSorted((left, right) => {
+        const sourceOrder = left.source.localeCompare(right.source);
+        if (sourceOrder !== 0) {
+          return sourceOrder;
+        }
+        const idOrder = left.id.localeCompare(right.id);
+        if (idOrder !== 0) {
+          return idOrder;
+        }
+        return left.version.localeCompare(right.version);
+      }) as HubProfileBundle[];
+    onProgress?.({
+      phase: 'profile',
+      status: 'started',
+      current: profileIndex + 1,
+      total: profileEntries.length,
+      profileId: entry.id,
+      bundlesTotal: references.length
+    });
+    const bundleResults = references.map((reference) => resolveProfileBundle(entry.id, reference, catalogs.get(reference.source)));
+    const profileResult = {
+      profileId: entry.id,
+      valid: bundleResults.every((bundle) => bundle.valid),
+      bundles: bundleResults,
+      errors: bundleResults.flatMap((bundle) => bundle.errors),
+      warnings: bundleResults.flatMap((bundle) => bundle.warnings)
+    };
+    onProgress?.({
+      phase: 'profile',
+      status: 'completed',
+      current: profileIndex + 1,
+      total: profileEntries.length,
+      profileId: entry.id,
+      bundlesTotal: references.length,
+      valid: profileResult.valid,
+      errors: profileResult.errors.length,
+      warnings: profileResult.warnings.length
+    });
+    return profileResult;
+  });
+
+  const sourceErrors = sourceResults.flatMap((source) => source.errors);
+  const profileErrors = profileResults.flatMap((profile) => profile.errors);
+  const warnings = [
+    ...sourceResults.flatMap((source) => source.warnings ?? []),
+    ...profileResults.flatMap((profile) => profile.warnings)
+  ];
+  const bundlesFound = sourceResults.reduce(
+    (total, source) => total + (source.bundlesFound ?? 0),
+    0
+  );
+  const valid = sourceErrors.length === 0 && profileErrors.length === 0;
+
+  onProgress?.({
+    phase: 'completed',
+    sourcesTotal: sourceEntries.length,
+    profilesTotal: profileEntries.length,
+    bundlesFound,
+    valid
+  });
+
+  return {
+    file: filePath,
+    deep: true,
+    valid,
+    errors: [...sourceErrors, ...profileErrors],
+    warnings,
+    sources: sourceResults,
+    profiles: profileResults,
+    bundlesFound
+  };
+}

--- a/packages/app/test/registry/validate-hub-config-file.test.ts
+++ b/packages/app/test/registry/validate-hub-config-file.test.ts
@@ -1,0 +1,265 @@
+import type {
+  Clock,
+  HttpClient,
+  ProcessRunner,
+} from '@ai-primitives-hub/core';
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import type {
+  SourceAdapterFactoryDeps,
+} from '../../src/registry/create-source-adapter';
+import {
+  validateHubConfigFile,
+} from '../../src/registry/validate-hub-config-file';
+import type {
+  HubValidationProgress,
+} from '../../src/registry/validate-hub-config-file';
+import {
+  InMemoryFileSystem,
+} from '../helpers/in-memory-filesystem';
+
+const clock: Clock = {
+  now: () => 0,
+  nowIso: () => '1970-01-01T00:00:00.000Z'
+};
+
+const httpClient: HttpClient = {
+  fetch: async () => {
+    throw new Error('HTTP should not be called for a local source');
+  }
+};
+
+const processRunner: ProcessRunner = {
+  exec: async () => {
+    throw new Error('Process execution should not be called for a local source');
+  }
+};
+
+function makeDeepDeps(fs: InMemoryFileSystem): SourceAdapterFactoryDeps {
+  return {
+    fs,
+    clock,
+    httpClient,
+    processRunner,
+    fallbackTokenProviders: []
+  };
+}
+
+function makeLocalHubYaml(bundleId: string, version: string, required = true): string {
+  return `version: 1.0.0
+metadata:
+  name: Test Hub
+  description: Test hub
+  maintainer: test
+  updatedAt: '2026-01-01T00:00:00Z'
+sources:
+  - id: local-source
+    name: Local Source
+    type: local
+    url: /registry
+    enabled: true
+    priority: 1
+profiles:
+  - id: test-profile
+    name: Test Profile
+    description: Test profile
+    bundles:
+      - id: ${bundleId}
+        version: ${version}
+        source: local-source
+        required: ${required}
+`;
+}
+
+describe('validateHubConfigFile deep validation', () => {
+  it('fails when a profile references a bundle absent from the source catalog', async () => {
+    const fs = new InMemoryFileSystem();
+    fs.seed('/registry/existing/deployment-manifest.yml', `id: existing
+name: Existing
+version: 1.0.0
+description: Existing bundle
+author: Test
+`);
+    fs.seed('/hub-config.yml', `version: 1.0.0
+metadata:
+  name: Test Hub
+  description: Test hub
+  maintainer: test
+  updatedAt: '2026-01-01T00:00:00Z'
+sources:
+  - id: local-source
+    name: Local Source
+    type: local
+    url: /registry
+    enabled: true
+    priority: 1
+profiles:
+  - id: test-profile
+    name: Test Profile
+    description: Test profile
+    bundles:
+      - id: missing
+        version: latest
+        source: local-source
+        required: true
+`);
+
+    const result = await validateHubConfigFile(fs, '/hub-config.yml', {
+      deep: true,
+      sourceAdapterDeps: makeDeepDeps(fs)
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain(
+      "Profile 'test-profile' references bundle 'missing' from source 'local-source', but no matching bundle was discovered."
+    );
+  });
+
+  it('warns instead of failing for an absent optional bundle', async () => {
+    const fs = new InMemoryFileSystem();
+    fs.seed('/registry/existing/deployment-manifest.yml', `id: existing
+name: Existing
+version: 1.0.0
+description: Existing bundle
+author: Test
+`);
+    fs.seed('/hub-config.yml', makeLocalHubYaml('missing', 'latest', false));
+
+    const result = await validateHubConfigFile(fs, '/hub-config.yml', {
+      deep: true,
+      sourceAdapterDeps: makeDeepDeps(fs)
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toContain(
+      "Profile 'test-profile' references bundle 'missing' from source 'local-source', but no matching bundle was discovered."
+    );
+  });
+
+  it('requires an exact version for a pinned profile reference', async () => {
+    const fs = new InMemoryFileSystem();
+    fs.seed('/registry/existing/deployment-manifest.yml', `id: existing
+name: Existing
+version: 2.0.0
+description: Existing bundle
+author: Test
+`);
+    fs.seed('/hub-config.yml', makeLocalHubYaml('existing', '1.0.0'));
+
+    const result = await validateHubConfigFile(fs, '/hub-config.yml', {
+      deep: true,
+      sourceAdapterDeps: makeDeepDeps(fs)
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain(
+      "Profile 'test-profile' requires bundle 'existing' at version '1.0.0' from source 'local-source', but available versions are: 2.0.0."
+    );
+  });
+
+  it('skips disabled sources and reports referenced bundles as unavailable', async () => {
+    const fs = new InMemoryFileSystem();
+    fs.seed('/hub-config.yml', makeLocalHubYaml('existing', 'latest'));
+    const disabledYaml = (await fs.readFile('/hub-config.yml')).replace('enabled: true', 'enabled: false');
+    await fs.writeFile('/hub-config.yml', disabledYaml);
+
+    const result = await validateHubConfigFile(fs, '/hub-config.yml', {
+      deep: true,
+      sourceAdapterDeps: makeDeepDeps(fs)
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.sources[0]).toMatchObject({ sourceId: 'local-source', skipped: true, bundlesFound: 0 });
+    expect(result.errors).toContain("Profile 'test-profile' references disabled source 'local-source'.");
+  });
+
+  it('reports deterministic progress for source and profile resolution', async () => {
+    const fs = new InMemoryFileSystem();
+    fs.seed('/registry/existing/deployment-manifest.yml', `id: existing
+name: Existing
+version: 1.0.0
+description: Existing bundle
+author: Test
+`);
+    fs.seed('/hub-config.yml', makeLocalHubYaml('existing', 'latest'));
+    const events: HubValidationProgress[] = [];
+
+    const result = await validateHubConfigFile(fs, '/hub-config.yml', {
+      deep: true,
+      onProgress: (event) => events.push(event),
+      sourceAdapterDeps: makeDeepDeps(fs)
+    });
+
+    expect(result.valid).toBe(true);
+    expect(events).toEqual([
+      { phase: 'started', sourcesTotal: 1, profilesTotal: 1 },
+      {
+        phase: 'source',
+        status: 'started',
+        current: 1,
+        total: 1,
+        sourceId: 'local-source',
+        sourceType: 'local',
+        enabled: true
+      },
+      {
+        phase: 'catalog',
+        status: 'started',
+        current: 1,
+        total: 1,
+        sourceId: 'local-source',
+        sourceType: 'local'
+      },
+      {
+        phase: 'catalog',
+        status: 'completed',
+        current: 1,
+        total: 1,
+        sourceId: 'local-source',
+        sourceType: 'local',
+        bundlesFound: 1
+      },
+      {
+        phase: 'source',
+        status: 'completed',
+        current: 1,
+        total: 1,
+        sourceId: 'local-source',
+        sourceType: 'local',
+        enabled: true,
+        valid: true,
+        bundlesFound: 1
+      },
+      {
+        phase: 'profile',
+        status: 'started',
+        current: 1,
+        total: 1,
+        profileId: 'test-profile',
+        bundlesTotal: 1
+      },
+      {
+        phase: 'profile',
+        status: 'completed',
+        current: 1,
+        total: 1,
+        profileId: 'test-profile',
+        bundlesTotal: 1,
+        valid: true,
+        errors: 0,
+        warnings: 0
+      },
+      {
+        phase: 'completed',
+        sourcesTotal: 1,
+        profilesTotal: 1,
+        bundlesFound: 1,
+        valid: true
+      }
+    ]);
+  });
+});

--- a/packages/cli/src/commands/hub.ts
+++ b/packages/cli/src/commands/hub.ts
@@ -8,6 +8,7 @@
  *   hub remove <id>       remove a hub
  *   hub sync [<id>]       re-fetch a hub config (default: active)
  *   hub create            scaffold a hub-config.yml skeleton
+ *   hub validate          validate a hub-config.yml offline
  *   hub refresh           sync the active hub (shorthand)
  *
  * Our `HubManager` (`@ai-primitives-hub/app`) names two methods the
@@ -18,10 +19,23 @@
  * failure `reason` string).
  */
 import * as path from 'node:path';
+import {
+  validateHubConfigFile,
+} from '@ai-primitives-hub/app';
+import type {
+  DeepHubConfigValidationResult,
+  HubConfigFileValidationResult,
+  HubValidationProgress,
+} from '@ai-primitives-hub/app';
 import type {
   HttpClient,
   TokenProvider,
 } from '@ai-primitives-hub/core';
+import {
+  defaultTokenProvider,
+  NodeHttpClient,
+  NodeProcessRunner,
+} from '@ai-primitives-hub/infra';
 import {
   Command,
   createHubManager,
@@ -385,6 +399,157 @@ export class HubCreateCommand extends BaseHubCommand {
         + `  ai-primitives-hub hub add --type local --location ${d.outDir}\n`
     });
     return 0;
+  }
+}
+
+const renderHubValidationText = (
+  result: HubConfigFileValidationResult | DeepHubConfigValidationResult
+): string => {
+  const lines = [`Validating ${result.file}`];
+  if (result.valid) {
+    const isDeep = 'deep' in result && result.deep;
+    lines.push(
+      '',
+      isDeep
+        ? '[ OK ] YAML syntax, schema, runtime, source policies, source catalogs, and profile references'
+        : '[ OK ] YAML syntax, schema, runtime checks, and source policies',
+      '',
+      isDeep
+        ? `Hub configuration valid (${result.sources.length} sources checked, ${result.bundlesFound} bundles discovered)`
+        : 'Hub configuration valid'
+    );
+  } else {
+    lines.push('', '[FAIL] Hub configuration invalid');
+    for (const error of result.errors) {
+      lines.push(`  - ${error}`);
+    }
+  }
+  return `${lines.join('\n')}\n`;
+};
+
+const renderHubValidationProgress = (ctx: Context, event: HubValidationProgress): void => {
+  switch (event.phase) {
+    case 'started': {
+      ctx.stderr.write(
+        `Deep validation: checking ${event.sourcesTotal} source(s) and ${event.profilesTotal} profile(s)\n`
+      );
+      return;
+    }
+    case 'source': {
+      const position = `[source ${event.current}/${event.total}]`;
+      if (event.status === 'started') {
+        ctx.stderr.write(`${position} Checking ${event.sourceId} (${event.sourceType})...\n`);
+        return;
+      }
+      const status = event.skipped ? 'skipped' : (event.valid ? 'ok' : 'failed');
+      ctx.stderr.write(
+        `${position} ${event.sourceId}: ${status} (${event.bundlesFound ?? 0} bundle(s))\n`
+      );
+      return;
+    }
+    case 'catalog': {
+      const position = `[source ${event.current}/${event.total}]`;
+      if (event.status === 'started') {
+        ctx.stderr.write(`${position} Discovering bundles...\n`);
+        return;
+      }
+      ctx.stderr.write(`${position} Discovered ${event.bundlesFound ?? 0} bundle(s)\n`);
+      return;
+    }
+    case 'profile': {
+      const position = `[profile ${event.current}/${event.total}]`;
+      if (event.status === 'started') {
+        ctx.stderr.write(`${position} Resolving ${event.profileId}...\n`);
+        return;
+      }
+      const status = event.valid ? 'ok' : 'failed';
+      ctx.stderr.write(
+        `${position} ${event.profileId}: ${status} (${event.bundlesTotal} reference(s))\n`
+      );
+      return;
+    }
+    case 'completed': {
+      ctx.stderr.write(
+        `Deep validation complete: ${event.valid ? 'valid' : 'invalid'} `
+        + `(${event.bundlesFound} bundle(s) discovered)\n`
+      );
+      return;
+    }
+  }
+};
+
+/**
+ * hub validate - validate a repository hub-config YAML file offline.
+ */
+export class HubValidateCommand extends BaseHubCommand {
+  public static readonly paths = [['hub', 'validate']];
+  public static readonly usage = Command.Usage({
+    description: 'Validate hub-config.yml against the schema and hub policies.',
+    category: 'Hub & Discovery',
+    details: `
+      Usage: ai-primitives-hub hub validate [options]
+
+      By default, validates YAML syntax, required fields, source/profile references,
+      source-type configuration, and GitHub bundle ID prefixes without network calls.
+      Use --check-sources to validate source accessibility, discover catalogs,
+      and resolve profile bundle references and versions.
+
+      Options:
+        --config <path>          Hub configuration file (default: hub-config.yml)
+        --check-sources          Contact/scan enabled sources and resolve profiles
+        -v, --verbose            Print deep-validation progress to stderr
+        -o, --output <format>    Output format (text, json, yaml, ndjson)
+
+      Examples:
+        ai-primitives-hub hub validate
+        ai-primitives-hub hub validate --config configs/hub-config.yml -o json
+        ai-primitives-hub hub validate --check-sources
+        ai-primitives-hub hub validate --check-sources --verbose -o json
+    `
+  });
+
+  public config = Option.String('--config');
+  public checkSources = Option.Boolean('--check-sources', false);
+  public verbose = Option.Boolean('-v,--verbose', false);
+
+  public async execute(): Promise<number> {
+    const { ctx, http, tokens } = this.commandContext;
+    const fmt = (this.output ?? 'text') as OutputFormat;
+    const configuredPath = this.config ?? 'hub-config.yml';
+    const configPath = path.isAbsolute(configuredPath)
+      ? configuredPath
+      : path.join(ctx.cwd(), configuredPath);
+    if (this.verbose && !this.checkSources) {
+      ctx.stderr.write('--verbose has no effect without --check-sources; validation remains offline.\n');
+    }
+    const result = await validateHubConfigFile(ctx.fs, configPath, this.checkSources
+      ? {
+        deep: true,
+        onProgress: this.verbose
+          ? (event) => renderHubValidationProgress(ctx, event)
+          : undefined,
+        sourceAdapterDeps: {
+          fs: ctx.fs,
+          clock: ctx.clock,
+          httpClient: http ?? new NodeHttpClient(),
+          processRunner: new NodeProcessRunner(),
+          fallbackTokenProviders: tokens === undefined
+            ? [defaultTokenProvider(ctx.env)]
+            : [tokens]
+        }
+      }
+      : undefined);
+
+    formatOutput({
+      ctx,
+      command: 'hub.validate',
+      output: fmt,
+      status: result.valid ? (result.warnings?.length ? 'warning' : 'ok') : 'error',
+      data: result,
+      warnings: result.warnings,
+      textRenderer: renderHubValidationText
+    });
+    return result.valid ? 0 : 1;
   }
 }
 

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -61,6 +61,7 @@ import {
   HubRemoveCommand,
   HubSyncCommand,
   HubUseCommand,
+  HubValidateCommand,
 } from './commands/hub';
 import {
   IndexBenchCommand,
@@ -193,6 +194,7 @@ async function main(): Promise<number> {
     HubRemoveCommand,
     HubSyncCommand,
     HubRefreshCommand,
+    HubValidateCommand,
     SourceAddCommand,
     SourceListCommand,
     SourceRemoveCommand,

--- a/packages/cli/test/commands/hub.test.ts
+++ b/packages/cli/test/commands/hub.test.ts
@@ -33,6 +33,7 @@ import {
   HubRemoveCommand,
   HubSyncCommand,
   HubUseCommand,
+  HubValidateCommand,
 } from '../../src/commands/hub';
 import {
   runCommand,
@@ -45,7 +46,8 @@ const COMMAND_CLASSES = [
   HubRefreshCommand,
   HubRemoveCommand,
   HubSyncCommand,
-  HubUseCommand
+  HubUseCommand,
+  HubValidateCommand
 ];
 
 interface JsonEnvelope<T> {
@@ -122,6 +124,282 @@ profiles: []
     it('fails with exit 1 when --name is missing', async () => {
       const result = await run(['hub', 'create', '-o', 'json']);
       expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe('hub validate', () => {
+    it('validates hub-config.yml through the CLI', async () => {
+      await writeFile(
+        hubConfigFile,
+        `version: 1.0.0
+metadata:
+  name: Test Hub
+  description: Test hub
+  maintainer: test
+  updatedAt: '2026-01-01T00:00:00Z'
+sources:
+  - id: github-source
+    type: github
+    url: https://github.com/example-org/example-repository
+    enabled: true
+    priority: 1
+profiles:
+  - id: test-profile
+    name: Test Profile
+    description: Test profile
+    bundles:
+      - id: example-org-example-repository-example-bundle
+        version: latest
+        source: github-source
+        required: true
+`
+      );
+
+      const result = await run(['hub', 'validate', '-o', 'json']);
+
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ valid: boolean; file: string; errors: string[] }>(result.stdout);
+      expect(envelope.data.valid).toBe(true);
+      expect(envelope.data.file).toContain('hub-config.yml');
+      expect(envelope.data.errors).toHaveLength(0);
+    });
+
+    it('returns source-policy errors and a failing exit code', async () => {
+      await writeFile(
+        hubConfigFile,
+        `version: 1.0.0
+metadata:
+  name: Test Hub
+  description: Test hub
+  maintainer: test
+  updatedAt: '2026-01-01T00:00:00Z'
+sources:
+  - id: github-source
+    type: github
+    url: https://github.com/example-org/example-repository
+    enabled: true
+    priority: 1
+    config:
+      branch: main
+profiles: []
+`
+      );
+
+      const result = await run(['hub', 'validate', '-o', 'json']);
+
+      expect(result.exitCode).toBe(1);
+      const envelope = parseJson<{ valid: boolean; errors: string[] }>(result.stdout);
+      expect(envelope.data.valid).toBe(false);
+      expect(envelope.data.errors).toContain(
+        "Source 'github-source' has type 'github' and must not define 'config'."
+      );
+    });
+
+    it('keeps the default validation offline', async () => {
+      await writeFile(
+        hubConfigFile,
+        `version: 1.0.0
+metadata:
+  name: Test Hub
+  description: Test hub
+  maintainer: test
+  updatedAt: '2026-01-01T00:00:00Z'
+sources:
+  - id: github-source
+    type: github
+    url: https://github.com/example-org/example-repository-that-does-not-exist
+    enabled: true
+    priority: 1
+profiles: []
+`
+      );
+
+      const result = await run(['hub', 'validate', '-o', 'json']);
+
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ valid: boolean; deep?: boolean }>(result.stdout);
+      expect(envelope.data.valid).toBe(true);
+      expect(envelope.data.deep).toBeUndefined();
+    });
+
+    it('checks local catalogs and reports a missing required profile bundle', async () => {
+      await mkdir(path.join(bundleDir, 'available'), { recursive: true });
+      await writeFile(
+        path.join(bundleDir, 'available', 'deployment-manifest.yml'),
+        `id: available
+name: Available Bundle
+version: 1.0.0
+description: Available bundle
+author: test
+`
+      );
+      await writeFile(
+        hubConfigFile,
+        `version: 1.0.0
+metadata:
+  name: Test Hub
+  description: Test hub
+  maintainer: test
+  updatedAt: '2026-01-01T00:00:00Z'
+sources:
+  - id: local-foo-src
+    name: Local Foo Source
+    type: local
+    url: ${bundleDir}
+    enabled: true
+    priority: 0
+profiles:
+  - id: test-profile
+    name: Test Profile
+    description: Test profile
+    bundles:
+      - id: missing
+        version: latest
+        source: local-foo-src
+        required: true
+`
+      );
+
+      const result = await run(['hub', 'validate', '--check-sources', '-o', 'json']);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).not.toContain('Deep validation:');
+      const envelope = parseJson<{
+        valid: boolean;
+        deep: boolean;
+        sources: { sourceId: string; bundlesFound: number }[];
+        profiles: { profileId: string; valid: boolean }[];
+        errors: string[];
+      }>(result.stdout);
+      expect(envelope.data.deep).toBe(true);
+      expect(envelope.data.valid).toBe(false);
+      expect(envelope.data.sources).toEqual([
+        expect.objectContaining({ sourceId: 'local-foo-src', bundlesFound: 1 })
+      ]);
+      expect(envelope.data.profiles).toEqual([
+        expect.objectContaining({ profileId: 'test-profile', valid: false })
+      ]);
+      expect(envelope.data.errors).toContain(
+        "Profile 'test-profile' references bundle 'missing' from source 'local-foo-src', but no matching bundle was discovered."
+      );
+    });
+
+    it('resolves latest from the discovered local catalog', async () => {
+      await mkdir(path.join(bundleDir, 'v1'), { recursive: true });
+      await mkdir(path.join(bundleDir, 'v2'), { recursive: true });
+      await writeFile(
+        path.join(bundleDir, 'v1', 'deployment-manifest.yml'),
+        `id: versioned
+name: Versioned Bundle
+version: 1.0.0
+description: Version one
+author: test
+`
+      );
+      await writeFile(
+        path.join(bundleDir, 'v2', 'deployment-manifest.yml'),
+        `id: versioned
+name: Versioned Bundle
+version: 2.0.0
+description: Version two
+author: test
+`
+      );
+      await writeFile(
+        hubConfigFile,
+        `version: 1.0.0
+metadata:
+  name: Test Hub
+  description: Test hub
+  maintainer: test
+  updatedAt: '2026-01-01T00:00:00Z'
+sources:
+  - id: local-foo-src
+    name: Local Foo Source
+    type: local
+    url: ${bundleDir}
+    enabled: true
+    priority: 0
+profiles:
+  - id: test-profile
+    name: Test Profile
+    description: Test profile
+    bundles:
+      - id: versioned
+        version: latest
+        source: local-foo-src
+        required: true
+`
+      );
+
+      const result = await run(['hub', 'validate', '--check-sources', '-o', 'json']);
+
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{
+        profiles: { bundles: { resolvedBundle?: { version: string } }[] }[];
+      }>(result.stdout);
+      expect(envelope.data.profiles[0].bundles[0].resolvedBundle?.version).toBe('2.0.0');
+    });
+
+    it('reports verbose deep progress to stderr while keeping JSON stdout parseable', async () => {
+      await mkdir(path.join(bundleDir, 'available'), { recursive: true });
+      await writeFile(
+        path.join(bundleDir, 'available', 'deployment-manifest.yml'),
+        `id: available
+name: Available Bundle
+version: 1.0.0
+description: Available bundle
+author: test
+`
+      );
+      await writeFile(
+        hubConfigFile,
+        `version: 1.0.0
+metadata:
+  name: Test Hub
+  description: Test hub
+  maintainer: test
+  updatedAt: '2026-01-01T00:00:00Z'
+sources:
+  - id: local-foo-src
+    name: Local Foo Source
+    type: local
+    url: ${bundleDir}
+    enabled: true
+    priority: 0
+profiles:
+  - id: test-profile
+    name: Test Profile
+    description: Test profile
+    bundles:
+      - id: available
+        version: latest
+        source: local-foo-src
+        required: true
+`
+      );
+
+      const result = await run([
+        'hub', 'validate', '--check-sources', '--verbose', '-o', 'json'
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ valid: boolean; deep: boolean }>(result.stdout);
+      expect(envelope.data).toMatchObject({ valid: true, deep: true });
+      expect(result.stderr).toContain('Deep validation: checking 1 source(s) and 1 profile(s)');
+      expect(result.stderr).toContain('[source 1/1] Checking local-foo-src (local)');
+      expect(result.stderr).toContain('[profile 1/1] Resolving test-profile');
+      expect(result.stderr).toContain('Deep validation complete: valid');
+    });
+
+    it('does not enable deep checks when --verbose is used without --check-sources', async () => {
+      const result = await run(['hub', 'validate', '--verbose', '-o', 'json']);
+
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ valid: boolean; deep?: boolean }>(result.stdout);
+      expect(envelope.data).toMatchObject({ valid: true });
+      expect(envelope.data.deep).toBeUndefined();
+      expect(result.stderr).toContain('--verbose has no effect without --check-sources');
     });
   });
 

--- a/packages/core/src/domain/hub/validate.ts
+++ b/packages/core/src/domain/hub/validate.ts
@@ -12,6 +12,9 @@
  * parser (Phase 3), not in `core`'s pure domain layer.
  * @module domain/hub/validate
  */
+import {
+  URL,
+} from 'node:url';
 import type {
   HubReference,
 } from './types';
@@ -28,8 +31,148 @@ export function hasPathTraversal(path: string): boolean {
   if (path.includes('..')) {
     return true;
   }
-  const decoded = decodeURIComponent(path);
-  return decoded.includes('..');
+  try {
+    const decoded = decodeURIComponent(path);
+    return decoded.includes('..');
+  } catch {
+    // A malformed escape sequence is not a valid safe path either. Treat it
+    // as traversal so callers validating untrusted configuration fail closed.
+    return true;
+  }
+}
+
+/**
+ * Derive the bundle ID prefix used by a plain GitHub source.
+ *
+ * GitHub-backed bundles are exposed as
+ * `<owner>-<repository>-<bundle-id>`. This helper deliberately accepts only
+ * repository URLs with exactly two path segments, matching the hub authoring
+ * contract rather than silently accepting a subdirectory URL.
+ * @param sourceUrl GitHub repository URL.
+ * @returns Expected bundle prefix, or `null` for an invalid repository URL.
+ */
+export function githubBundlePrefix(sourceUrl: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(sourceUrl);
+  } catch {
+    return null;
+  }
+
+  const authority = /^[A-Za-z][A-Za-z\d+.-]*:\/\/([^/?#]*)/.exec(sourceUrl)?.[1];
+  const pathParts = parsed.pathname.split('/').filter((part) => part.length > 0);
+  if (authority?.toLowerCase() !== 'github.com' || pathParts.length !== 2) {
+    return null;
+  }
+
+  const [owner, repositoryWithSuffix] = pathParts;
+  const repository = repositoryWithSuffix.endsWith('.git')
+    ? repositoryWithSuffix.slice(0, -4)
+    : repositoryWithSuffix;
+  return `${owner}-${repository}-`;
+}
+
+/**
+ * Validate source-type-specific hub policies.
+ *
+ * These are the rules previously kept in the hub repository's Python helper:
+ * `github` sources cannot carry a `config` block, `awesome-copilot` sources
+ * must carry one, and GitHub bundle references must use the repository-derived
+ * bundle ID prefix.
+ * @param config Parsed but untrusted hub configuration.
+ * @returns Human-readable policy violations.
+ */
+export function validateHubSourcePolicies(config: unknown): string[] {
+  if (config === null || typeof config !== 'object' || Array.isArray(config)) {
+    return [];
+  }
+
+  const root = config as Record<string, unknown>;
+  const sources = root.sources;
+  const profiles = root.profiles;
+  if (!Array.isArray(sources)) {
+    return [];
+  }
+
+  const errors: string[] = [];
+  const githubSources = new Map<string, Record<string, unknown>>();
+
+  sources.forEach((value, sourceIndex) => {
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+      return;
+    }
+
+    const source = value as Record<string, unknown>;
+    const sourceId = typeof source.id === 'string' ? source.id : `#${sourceIndex + 1}`;
+    const sourceType = source.type;
+    const hasConfig = Object.prototype.hasOwnProperty.call(source, 'config');
+
+    if (sourceType === 'github' && hasConfig) {
+      errors.push(`Source '${sourceId}' has type 'github' and must not define 'config'.`);
+    } else if (sourceType === 'awesome-copilot' && !hasConfig) {
+      errors.push(`Source '${sourceId}' has type 'awesome-copilot' and must define 'config'.`);
+    }
+
+    if (sourceType === 'github' && typeof source.id === 'string') {
+      githubSources.set(source.id, source);
+    }
+  });
+
+  if (!Array.isArray(profiles)) {
+    return errors;
+  }
+
+  profiles.forEach((value, profileIndex) => {
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+      return;
+    }
+
+    const profile = value as Record<string, unknown>;
+    const profileId = typeof profile.id === 'string' ? profile.id : `#${profileIndex + 1}`;
+    const bundles = profile.bundles;
+    if (!Array.isArray(bundles)) {
+      return;
+    }
+
+    bundles.forEach((bundleValue, bundleIndex) => {
+      if (bundleValue === null || typeof bundleValue !== 'object' || Array.isArray(bundleValue)) {
+        return;
+      }
+
+      const bundle = bundleValue as Record<string, unknown>;
+      const sourceId = bundle.source;
+      const source = typeof sourceId === 'string' ? githubSources.get(sourceId) : undefined;
+      if (source === undefined) {
+        return;
+      }
+
+      const sourceUrl = source.url;
+      if (typeof sourceUrl !== 'string') {
+        errors.push(
+          `GitHub source '${sourceId}' must define a valid GitHub repository URL.`
+        );
+        return;
+      }
+
+      const expectedPrefix = githubBundlePrefix(sourceUrl);
+      if (expectedPrefix === null) {
+        errors.push(
+          `GitHub source '${sourceId}' has invalid repository URL '${sourceUrl}'.`
+        );
+        return;
+      }
+
+      const bundleId = bundle.id;
+      if (typeof bundleId !== 'string' || !bundleId.startsWith(expectedPrefix)) {
+        errors.push(
+          `Profile '${profileId}' bundle #${bundleIndex + 1} must reference GitHub source `
+          + `'${sourceId}' with an ID starting '${expectedPrefix}'.`
+        );
+      }
+    });
+  });
+
+  return errors;
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,6 +33,11 @@ export { default as COLLECTION_SCHEMA } from './public/schemas/collection.schema
 export { default as DEPLOYMENT_MANIFEST_SCHEMA } from './public/schemas/deployment-manifest.schema.json';
 
 /**
+ * Hub configuration schema used by the CLI and other non-extension callers.
+ */
+export { default as HUB_CONFIG_SCHEMA } from './public/schemas/hub-config.schema.json';
+
+/**
  * Phase 1 scaffolding marker, kept until `infra`/`app`/`cli` each have real
  * code of their own to depend on instead of this placeholder re-export
  * chain (see those packages' `src/index.ts`) — removed in Phase 5 once

--- a/packages/core/src/public/schemas/hub-config.schema.json
+++ b/packages/core/src/public/schemas/hub-config.schema.json
@@ -76,7 +76,7 @@
           },
           "type": {
             "type": "string",
-            "description": "Type of the source repository (github, local, awesome-copilot, local-awesome-copilot, apm, local-apm, skills)",
+            "description": "Type of the source repository (github, local, awesome-copilot, local-awesome-copilot, apm, local-apm, skills, local-skills, azure-devops)",
             "enum": [
               "github",
               "local",
@@ -84,7 +84,9 @@
               "local-awesome-copilot",
               "apm",
               "local-apm",
-              "skills"
+              "skills",
+              "local-skills",
+              "azure-devops"
             ]
           },
           "url": {

--- a/packages/core/test/domain/hub/validate.test.ts
+++ b/packages/core/test/domain/hub/validate.test.ts
@@ -4,6 +4,7 @@ import {
   it,
 } from 'vitest';
 import {
+  githubBundlePrefix,
   hasPathTraversal,
   isValidProtocol,
   sanitizeHubId,
@@ -25,6 +26,28 @@ describe('hasPathTraversal', () => {
 
   it('returns false for an empty path', () => {
     expect(hasPathTraversal('')).toBe(false);
+  });
+
+  it('fails closed for malformed URL encoding', () => {
+    expect(hasPathTraversal('%2')).toBe(true);
+  });
+});
+
+describe('githubBundlePrefix', () => {
+  it('derives the owner and repository prefix', () => {
+    expect(githubBundlePrefix('https://github.com/example-org/example-repository'))
+      .toBe('example-org-example-repository-');
+  });
+
+  it('accepts a .git repository suffix', () => {
+    expect(githubBundlePrefix('https://github.com/example-org/example-repository.git'))
+      .toBe('example-org-example-repository-');
+  });
+
+  it('rejects non-canonical GitHub hosts and repository paths', () => {
+    expect(githubBundlePrefix('https://github.com:443/example-org/example-repository')).toBeNull();
+    expect(githubBundlePrefix('https://github.com/example-org/example-repository/tree/main')).toBeNull();
+    expect(githubBundlePrefix('https://git.example.com/example-org/example-repository')).toBeNull();
   });
 });
 

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -38,6 +38,8 @@
     "@elastic/elasticsearch": "^9.3.4",
     "@ternlight/mini": "0.1.0",
     "adm-zip": "^0.6.0",
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1",
     "archiver": "^7.0.1",
     "js-yaml": "^4.3.1"
   },

--- a/packages/infra/src/hub/validate-hub-config.ts
+++ b/packages/infra/src/hub/validate-hub-config.ts
@@ -11,52 +11,150 @@
  */
 import {
   hasPathTraversal,
+  HUB_CONFIG_SCHEMA,
+  validateHubSourcePolicies,
   type ValidationResult,
 } from '@ai-primitives-hub/core';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import * as yaml from 'js-yaml';
+
+const ajv = new Ajv({
+  allErrors: true,
+  strict: false
+});
+addFormats(ajv);
+const validateSchema = ajv.compile(HUB_CONFIG_SCHEMA);
+
+const asRecord = (value: unknown): Record<string, unknown> | undefined => {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
+};
+
+const containsPathTraversal = (value: string): boolean => {
+  try {
+    return hasPathTraversal(value);
+  } catch {
+    return true;
+  }
+};
+
+const formatSchemaErrors = (): string[] => {
+  return (validateSchema.errors ?? []).map((error) => {
+    const dataPath = error.instancePath || '$';
+    const params = error.params as Record<string, unknown>;
+
+    switch (error.keyword) {
+      case 'required': {
+        return `${dataPath}: missing required property '${String(params.missingProperty)}'`;
+      }
+      case 'pattern': {
+        return `${dataPath}: ${error.message ?? 'must match the required pattern'}`;
+      }
+      case 'enum': {
+        return `${dataPath}: ${error.message ?? 'must be an allowed value'}`;
+      }
+      case 'format': {
+        return `${dataPath}: ${error.message ?? 'must use the required format'}`;
+      }
+      case 'minLength':
+      case 'maxLength':
+      case 'minItems':
+      case 'maxItems':
+      case 'minimum':
+      case 'maximum':
+      case 'type': {
+        return `${dataPath}: ${error.message ?? 'has an invalid value'}`;
+      }
+      default: {
+        return `${dataPath}: ${error.message ?? 'validation failed'}`;
+      }
+    }
+  });
+};
+
+/**
+ * Parse a hub YAML document without applying any defaults or transformations.
+ * @param content Raw YAML content.
+ * @returns Parsed YAML value.
+ */
+export function parseHubConfigYaml(content: string): unknown {
+  return yaml.load(content);
+}
 
 /**
  * Validate an already YAML-parsed, still-untrusted hub configuration.
  * @param config - Parsed hub config candidate.
  * @returns Validation result with errors if any.
  */
-export function validateHubConfig(config: any): ValidationResult {
+export function validateHubConfig(config: unknown): ValidationResult {
   const errors: string[] = [];
 
-  if (config.version) {
-    if (!/^\d+\.\d+\.\d+$/.test(config.version)) {
+  const root = asRecord(config);
+  if (root === undefined) {
+    return {
+      valid: false,
+      errors: ['Hub configuration root must be a mapping.']
+    };
+  }
+
+  if (root.version) {
+    if (typeof root.version !== 'string' || !/^\d+\.\d+\.\d+$/.test(root.version)) {
       errors.push('version must be in semver format (e.g., 1.0.0)');
     }
   } else {
     errors.push('version is required');
   }
 
-  if (config.metadata) {
-    if (!config.metadata.name) {
+  const metadata = asRecord(root.metadata);
+  if (metadata === undefined) {
+    errors.push('metadata is required');
+  } else {
+    if (!metadata.name) {
       errors.push('metadata.name is required');
     }
-    if (!config.metadata.description) {
+    if (!metadata.description) {
       errors.push('metadata.description is required');
     }
-    if (!config.metadata.maintainer) {
+    if (!metadata.maintainer) {
       errors.push('metadata.maintainer is required');
     }
-    if (!config.metadata.updatedAt) {
+    if (!metadata.updatedAt) {
       errors.push('metadata.updatedAt is required');
     }
 
-    if (config.metadata.checksum && !/^(sha256|sha512):[a-f0-9]+$/.test(config.metadata.checksum)) {
+    if (metadata.checksum && (typeof metadata.checksum !== 'string'
+      || !/^(sha256|sha512):[a-f0-9]+$/.test(metadata.checksum))) {
       errors.push('metadata.checksum must be in format "sha256:hash" or "sha512:hash"');
     }
-  } else {
-    errors.push('metadata is required');
   }
 
-  if (config.sources) {
-    if (Array.isArray(config.sources)) {
-      config.sources.forEach((source: any, index: number) => {
+  const sources = root.sources;
+  const sourceIds = new Map<string, number>();
+  if (sources) {
+    if (Array.isArray(sources)) {
+      sources.forEach((sourceValue, index) => {
+        const source = asRecord(sourceValue);
+        if (source === undefined) {
+          errors.push(`source[${index}] must be a mapping`);
+          return;
+        }
+
         if (source.id) {
-          if (hasPathTraversal(source.id)) {
+          if (typeof source.id === 'string' && containsPathTraversal(source.id)) {
             errors.push(`source[${index}].id contains path traversal: ${source.id}`);
+          }
+          if (typeof source.id === 'string') {
+            const previousIndex = sourceIds.get(source.id);
+            if (previousIndex === undefined) {
+              sourceIds.set(source.id, index);
+            } else {
+              errors.push(
+                `Duplicate source ID '${source.id}' at source[${index}] (also at source[${previousIndex}])`
+              );
+            }
           }
         } else {
           errors.push(`source[${index}].id is required`);
@@ -72,27 +170,47 @@ export function validateHubConfig(config: any): ValidationResult {
     errors.push('sources is required');
   }
 
-  if (config.profiles) {
-    if (Array.isArray(config.profiles)) {
-      const sourceIds = new Set(
-        Array.isArray(config.sources) ? config.sources.map((s: any) => s.id) : []
-      );
+  const profiles = root.profiles;
+  if (profiles) {
+    if (Array.isArray(profiles)) {
+      const profileIds = new Map<string, number>();
+      const sourceIdSet = new Set(sourceIds.keys());
 
-      config.profiles.forEach((profile: any, pIndex: number) => {
+      profiles.forEach((profileValue, pIndex) => {
+        const profile = asRecord(profileValue);
+        if (profile === undefined) {
+          errors.push(`profile[${pIndex}] must be a mapping`);
+          return;
+        }
+
         if (!profile.id) {
           errors.push(`profile[${pIndex}].id is required`);
+        } else if (typeof profile.id === 'string') {
+          const previousIndex = profileIds.get(profile.id);
+          if (previousIndex === undefined) {
+            profileIds.set(profile.id, pIndex);
+          } else {
+            errors.push(
+              `Duplicate profile ID '${profile.id}' at profile[${pIndex}] (also at profile[${previousIndex}])`
+            );
+          }
         }
         if (!profile.name) {
           errors.push(`profile[${pIndex}].name is required`);
         }
 
         if (profile.bundles && Array.isArray(profile.bundles)) {
-          profile.bundles.forEach((bundle: any, bIndex: number) => {
-            if (bundle.id && hasPathTraversal(bundle.id)) {
+          profile.bundles.forEach((bundleValue, bIndex) => {
+            const bundle = asRecord(bundleValue);
+            if (bundle === undefined) {
+              return;
+            }
+
+            if (bundle.id && typeof bundle.id === 'string' && containsPathTraversal(bundle.id)) {
               errors.push(`profile[${pIndex}].bundle[${bIndex}].id contains path traversal: ${bundle.id}`);
             }
 
-            if (bundle.source && !sourceIds.has(bundle.source)) {
+            if (bundle.source && typeof bundle.source === 'string' && !sourceIdSet.has(bundle.source)) {
               errors.push(`profile[${pIndex}].bundle[${bIndex}] references non-existent source: ${bundle.source}`);
             }
           });
@@ -106,5 +224,29 @@ export function validateHubConfig(config: any): ValidationResult {
   return {
     valid: errors.length === 0,
     errors
+  };
+}
+
+/**
+ * Validate a parsed hub document with every offline validator used by the
+ * hub repository: runtime safety checks, JSON Schema, and source policies.
+ * @param config Parsed hub configuration.
+ * @returns Combined validation result with de-duplicated errors.
+ */
+export function validateHubConfigDocument(config: unknown): ValidationResult {
+  const runtimeResult = validateHubConfig(config);
+  const schemaValid = validateSchema(config);
+  const schemaErrors = schemaValid ? [] : formatSchemaErrors();
+  const policyErrors = validateHubSourcePolicies(config);
+  const errors = [...new Set([
+    ...runtimeResult.errors,
+    ...schemaErrors,
+    ...policyErrors
+  ])];
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings: runtimeResult.warnings ?? []
   };
 }

--- a/packages/infra/test/hub/validate-hub-config.test.ts
+++ b/packages/infra/test/hub/validate-hub-config.test.ts
@@ -8,6 +8,7 @@ import {
 } from 'vitest';
 import {
   validateHubConfig,
+  validateHubConfigDocument,
 } from '../../src/hub/validate-hub-config';
 
 function validConfig(): Record<string, unknown> {
@@ -27,6 +28,42 @@ function validConfig(): Record<string, unknown> {
         id: 'profile-1',
         name: 'Profile One',
         bundles: [{ id: 'bundle-1', source: 'src-1' }]
+      }
+    ]
+  };
+}
+
+function schemaValidConfig(): Record<string, unknown> {
+  return {
+    version: '1.0.0',
+    metadata: {
+      name: 'Test Hub',
+      description: 'A test hub',
+      maintainer: 'someone',
+      updatedAt: '2024-01-01T00:00:00.000Z'
+    },
+    sources: [
+      {
+        id: 'github-source',
+        type: 'github',
+        url: 'https://github.com/example-org/example-repository',
+        enabled: true,
+        priority: 1
+      }
+    ],
+    profiles: [
+      {
+        id: 'profile-1',
+        name: 'Profile One',
+        description: 'A test profile',
+        bundles: [
+          {
+            id: 'example-org-example-repository-example-bundle',
+            version: 'latest',
+            source: 'github-source',
+            required: true
+          }
+        ]
       }
     ]
   };
@@ -131,5 +168,81 @@ describe('validateHubConfig', () => {
     (config.profiles as Record<string, unknown>[])[0].bundles = [{ id: 'bundle-1', source: 'missing-src' }];
     const result = validateHubConfig(config);
     expect(result.errors.some((e) => e.includes('references non-existent source'))).toBe(true);
+  });
+});
+
+describe('validateHubConfigDocument', () => {
+  it('accepts a schema-valid config and the source policies', () => {
+    const result = validateHubConfigDocument(schemaValidConfig());
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('includes JSON schema errors for missing source fields', () => {
+    const config = schemaValidConfig();
+    delete (config.sources as Record<string, unknown>[])[0].enabled;
+
+    const result = validateHubConfigDocument(config);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((error) => error.includes("'enabled'") || error.includes('enabled'))).toBe(true);
+  });
+
+  it('rejects a github source that defines config', () => {
+    const config = schemaValidConfig();
+    (config.sources as Record<string, unknown>[])[0].config = { branch: 'main' };
+
+    const result = validateHubConfigDocument(config);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain(
+      "Source 'github-source' has type 'github' and must not define 'config'."
+    );
+  });
+
+  it('rejects an awesome-copilot source without config', () => {
+    const config = schemaValidConfig();
+    const source = (config.sources as Record<string, unknown>[])[0];
+    source.type = 'awesome-copilot';
+
+    const result = validateHubConfigDocument(config);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain(
+      "Source 'github-source' has type 'awesome-copilot' and must define 'config'."
+    );
+  });
+
+  it('rejects a github profile bundle with the wrong repository prefix', () => {
+    const config = schemaValidConfig();
+    const bundle = ((config.profiles as Record<string, unknown>[])[0].bundles as Record<string, unknown>[])[0];
+    bundle.id = 'another-org-another-repository-example-bundle';
+
+    const result = validateHubConfigDocument(config);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain(
+      "Profile 'profile-1' bundle #1 must reference GitHub source 'github-source' "
+      + "with an ID starting 'example-org-example-repository-'."
+    );
+  });
+
+  it('rejects duplicate source and profile IDs', () => {
+    const config = schemaValidConfig();
+    config.sources = [
+      ...(config.sources as Record<string, unknown>[]),
+      { ...(config.sources as Record<string, unknown>[])[0] }
+    ];
+    config.profiles = [
+      ...(config.profiles as Record<string, unknown>[]),
+      { ...(config.profiles as Record<string, unknown>[])[0] }
+    ];
+
+    const result = validateHubConfigDocument(config);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((error) => error.includes('Duplicate source ID'))).toBe(true);
+    expect(result.errors.some((error) => error.includes('Duplicate profile ID'))).toBe(true);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -423,6 +423,12 @@ importers:
       adm-zip:
         specifier: ^0.6.0
         version: 0.6.0
+      ajv:
+        specifier: ^8.20.0
+        version: 8.20.0
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.20.0)
       archiver:
         specifier: ^7.0.1
         version: 7.0.1


### PR DESCRIPTION
## Description

Add a shared `hub validate` command for validating `hub-config.yml` through the existing `core → infra → app → cli` layers. Static validation remains offline and deterministic by default; source-level checks are explicitly opt-in, with verbose progress separated from structured output.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test coverage improvement
- [x] 🔧 Configuration/build changes

## Related Issues

Relates to #410 

## Changes Made

- Added shared Hub schema, runtime, source-policy, and profile-reference validation across the package layers.
- Added `hub validate` with `--config`, `--check-sources`, and `--verbose` options.
- Kept normal validation network-free; deep validation checks enabled sources, discovers catalogs, and resolves profile bundle versions.
- Sent deep-validation progress to stderr while preserving text, JSON, YAML, and NDJSON result output.
- Added focused tests for core, infra, app, and CLI behavior.

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

### Manual Testing Steps

1. Built `core`, `infra`, `app`, and `cli` packages successfully.
2. Ran focused tests: core (22), infra (20), app (5), and CLI (23) passing.
3. Ran the branch-built `hub validate` against the Hub configuration; static and machine-readable JSON validation passed.

### Tested On

- [ ] macOS
- [ ] Windows
- [x] Linux

- [ ] VS Code Stable
- [ ] VS Code Insiders

## Screenshots

N/A — CLI-only change.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Documentation

- [ ] README.md updated
- [x] JSDoc comments added/updated
- [ ] No documentation changes needed

CLI usage is documented in `hub validate --help`. Consumer-repository adoption documentation is maintained separately.

## Additional Notes

- This PR delivers the shared Hub-validation foundation for #410; collection/primitive governance rules and reusable CI gates remain follow-up work.
- Deep source validation intentionally remains sequential.
- The downstream Hub configuration repository needs a release containing this CLI command before its published-package validation can use `hub validate`.
- The source level validation should not yet be added to the CI by default as we are not quite ready for the token routing allowing us to switching the organisations. It is usable only directly from the user context at this stage.

## Reviewer Guidelines

Please pay special attention to:

- The offline-by-default boundary and the behavior of `--check-sources`.
- Deterministic source/profile result ordering and error aggregation.
- Separation of progress on stderr from structured validation output on stdout.

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
