### PR TITLE
feat(auth): add source-aware GitHub App authentication

### DIFF
--- a/apps/vscode-extension/test/e2e/github-scaffold-integration.test.ts
+++ b/apps/vscode-extension/test/e2e/github-scaffold-integration.test.ts
@@ -381,7 +381,7 @@ suite('E2E: Script Execution Tests', () => {
       npmInstalled = true;
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
-      if (process.env.CI === 'true') {
+      if (process.env.CI === 'true' || process.env.CI === '1') {
         throw new Error(`Scaffold setup failed in CI: ${detail}`);
       }
       console.error(`[e2e] skipping script-execution tests - scaffold setup failed: ${detail}`);

--- a/apps/vscode-extension/test/helpers/workspace-pack-helpers.ts
+++ b/apps/vscode-extension/test/helpers/workspace-pack-helpers.ts
@@ -1,4 +1,11 @@
-/** Pack local workspace artifacts into a temporary scaffold for E2E tests. */
+/**
+ * Pack the current workspace packages into a throwaway scaffold project.
+ *
+ * Scaffold tests must exercise the packages built from this checkout rather
+ * than whatever versions happen to be published in the registry. The helper
+ * rewrites only the temporary project's manifest; the scaffold template stays
+ * suitable for real users.
+ */
 import {
   execFileSync,
 } from 'node:child_process';
@@ -11,9 +18,9 @@ import {
 
 const PACK_TIMEOUT_MS = 60_000;
 /**
- * Install budget. Generous because Windows runners are markedly slower at
- * this - NTFS plus on-access virus scanning over a `node_modules` tree -
- * and 120s proved too tight there while being ample on Linux and macOS.
+ * Windows runners can spend several minutes installing a node_modules tree
+ * because of NTFS and on-access virus scanning; 300s keeps that work from
+ * timing out on CI while remaining ample on Linux and macOS.
  */
 const DEFAULT_INSTALL_TIMEOUT_MS = 300_000;
 
@@ -150,7 +157,7 @@ export interface InstallWorkspaceBuildsOptions {
 }
 
 /**
- * Pack, install, and remove local workspace artifacts for a temporary project.
+ * Pack workspace builds, install them into a temporary project, and clean up.
  * @param options
  */
 export function installWorkspaceBuilds(options: InstallWorkspaceBuildsOptions): void {
@@ -159,8 +166,8 @@ export function installWorkspaceBuilds(options: InstallWorkspaceBuildsOptions): 
   try {
     const tarballs = packWorkspacePackages(tarballDir);
     useLocalWorkspaceBuilds(options.projectDir, tarballs);
-    // `--no-audit` and `--no-fund` drop network round-trips a test has no
-    // use for, which is both faster and one less thing to hang on.
+    // These tests do not need audit/funding requests; avoiding them reduces
+    // network traffic and removes two unrelated sources of flakiness.
     runCommand(
       'npm',
       ['install', '--prefer-offline', '--package-lock=false', '--no-audit', '--no-fund'],

--- a/docs/contributor-guide/architecture/adr/0007-source-aware-github-app-authentication.md
+++ b/docs/contributor-guide/architecture/adr/0007-source-aware-github-app-authentication.md
@@ -1,0 +1,155 @@
+# ADR-0007: Source-Aware GitHub App Authentication for CLI Workflows
+
+**Status:** Accepted
+
+## Context
+
+The CLI and primitive-index harvester access a Hub whose configured sources can
+span many GitHub organizations and repositories. The legacy source path could
+fall back to anonymous GitHub requests, while a single generic developer token
+is not an appropriate identity for every private source. Anonymous requests
+also have a small shared rate-limit budget and can make a full Hub operation
+fail late or appear stalled while retrying until a reset window.
+
+The source-aware CI path therefore needs to select credentials from evidence
+in the configured Hub, preserve repository scope across API/raw/asset hosts,
+and fail before source work when access cannot be established. The decision
+also affects `core` ports, `infra` adapters, CLI wiring, temporary credential
+configuration, caching, and operational documentation.
+
+ADR-0006 already defines the shared cache policy for reusable semantic
+artifacts. This ADR narrows the authentication-related cache boundary: source
+content and conditional-request metadata may be persisted when their
+invalidation rules are explicit, but credentials and private-key material are
+not cache artifacts.
+
+## Decision
+
+1. **Make source-aware authentication explicit and opt-in.**
+   `AI_PRIMITIVES_HUB_GH_APP_AUTH_ENABLED` enables the stricter CLI/harvest
+   path. When it is unset or false, the existing developer compatibility path
+   remains unchanged.
+
+2. **Require authenticated generic evidence before source classification.**
+   Source-aware public and visibility checks use `GH_TOKEN`, then
+   `GITHUB_TOKEN` in CI, or the local `gh auth token` provider where local
+   fallback is allowed. Anonymous source-aware access is rejected before a
+   GitHub request. Missing generic credentials, ambiguous visibility, rate
+   limits, malformed targets, and failed checks produce an `unresolved`
+   result; they do not trigger an anonymous fallback.
+
+3. **Use repository-scoped GitHub App installation tokens only for sources
+   proven to require them.**
+   A source whose authenticated generic evidence reports private or otherwise
+   requires repository-scoped access is checked with `gh app-auth token
+   --repo <host>/<owner>/<repository>`. App-authenticated requests cannot fall
+   back to a generic or personal credential. Public sources remain on the
+   generic authenticated path.
+
+4. **Carry source repository context separately from request host.**
+   `TokenProvider` receives the request host plus an optional normalized
+   `GitHubRepositoryTarget`. This allows API, raw-content, codeload, and
+   release-asset requests for one source to use the same repository-scoped App
+   decision without treating `api.github.com` or
+   `raw.githubusercontent.com` as the App repository.
+
+5. **Keep App setup separate from token lookup.**
+   `gh app-auth setup` is an explicit bootstrap operation. The CLI derives
+   organization wildcard routes from the observed App candidates, creates a
+   temporary filesystem configuration only when App bootstrap inputs are
+   explicitly supplied, and removes the temporary workspace in `finally`
+   cleanup. `TokenProvider.getToken()` only validates context, mints, caches,
+   or reuses a token; it does not discover installations or perform setup.
+
+6. **Use safe in-memory App token caching.**
+   Installation tokens are cached by exact canonical repository plus App/config
+   identity, with single-flight refresh and a conservative lifetime below the
+   one-hour GitHub token lifetime. Tokens are process-local and are never
+   persisted in files, GitHub Actions caches, progress logs, snapshots,
+   lockfiles, telemetry, or diagnostics.
+
+7. **Persist only safe source content metadata where it improves repeat runs.**
+   The existing content-addressed Git `BlobCache` and ETag store may be reused
+   by trusted workflows. A GitHub Actions cache may carry `blobs/` and
+   `etags.json` when the cache key includes a format namespace, runtime/dependency
+   family, and verified source revision. It must not carry App tokens, PEMs, or
+   unreviewed derived state by default. Cache restore is an optimization, not
+   an authentication or authorization decision.
+
+8. **Keep source decisions immutable and observable for one operation.**
+   Each requested source receives a deterministic category, target, checked
+   operations, optional verified revision, credential mode, and stable error
+   code. Any unresolved source fails the requested operation and is exposed in
+   the sanitized preflight report. A mutable shared client must not switch
+   repository scope between requests.
+
+9. **Limit the first implementation to CLI/CI and harvesting.**
+   VS Code authentication and automatic hidden App setup in unrelated commands
+   are out of scope for this decision. Install/update integrations may reuse
+   the source-aware providers, but any future bootstrap convenience must retain
+   the same explicit credentials, cleanup, and fail-closed rules.
+
+## Alternatives considered
+
+- **Anonymous-first with authenticated fallback:** rejected because it spends
+  the unauthenticated budget before knowing whether authentication is needed,
+  can stall on rate-limit reset sleeps, and violates the source-aware
+  no-anonymous policy.
+- **One generic/personal token for every source:** rejected because it does
+  not provide repository-scoped access across all configured organizations and
+  makes credential ownership/permission failures ambiguous.
+- **App provider first with generic fallback:** rejected because it can use a
+  credential for a source category that has not been established and can hide
+  missing generic visibility evidence.
+- **Persist installation tokens in the shared/Actions cache:** rejected due
+  to expiry, revocation, secret-at-rest, cross-job, and cache-poisoning risks.
+- **Central proxy or a single long-lived service credential:** deferred; it
+  changes the trust boundary and operational ownership beyond this CLI
+  feature. The repository-scoped App remains the smallest available change.
+- **Apply the feature to the VS Code extension immediately:** deferred to
+  avoid coupling an extension session/account-selection UX to CI bootstrap and
+  to keep the first rollout limited to the CLI/harvester boundary.
+
+## Consequences
+
+- **Positive:** public sources use authenticated access from the first request,
+  private sources receive least-scope App credentials, and source failures are
+  reported before partial work is performed.
+- **Positive:** API and download hosts retain the correct source repository
+  scope; App token reuse reduces repeated child processes within one CLI
+  invocation.
+- **Positive:** content-addressed blob reuse and conditional requests can make
+  repeated trusted harvests cheaper without persisting credentials.
+- **Negative:** source-aware preflight adds metadata, commit, tree, collection,
+  and release requests before normal operations. GitHub primary and secondary
+  limits must be treated as shared operational capacity, with canaries,
+  serialization, telemetry, and backoff/circuit-breaker behavior.
+- **Negative:** CI must provision a supported `gh-app-auth` extension, App
+  permissions/repository selection, generic credential, App selector, and
+  private key. The full original Hub scope can remain unresolved until external
+  App installation configuration is corrected.
+- **Negative:** a separate CLI process cannot warm the process-local App token
+  cache. Safe content/ETag caches may cross processes, but derived state needs
+  explicit freshness and compatibility rules.
+- **Unaffected:** the legacy non-opt-in developer path, VS Code account
+  selection, repository lockfile semantics, and existing client-owned storage
+  decisions remain governed by their existing contracts.
+
+## Implementation implications
+
+1. Keep the repository target and authentication category in the source-bound
+   construction path from `app` through `infra` adapters and CLI commands.
+2. Test missing generic credentials, anonymous rejection, category isolation,
+   repository/host mismatch, route/installation failures, timeout/output
+   validation, cache expiry, and concurrent single-flight calls.
+3. Retain sanitized structured preflight reports in CLI JSON envelopes and
+   fail closed when any requested source is unresolved.
+4. Treat GitHub Actions cache as a trusted-run optimization. Use a rolling
+   source-revision key, avoid pull-request cache exposure for private content,
+   serialize jobs sharing a credential or installation, and gate expensive
+   runs with real endpoint quota canaries.
+5. Measure request counts and response-limit headers by authentication category
+   before adding broad concurrency or cross-process content-cache policies.
+6. Revisit the decision if App setup becomes a supported user-facing VS Code
+   feature, if a central proxy changes the trust model, or if persistent
+   derived-index state is made portable with explicit compatibility metadata.

--- a/docs/contributor-guide/architecture/adr/adr-index.md
+++ b/docs/contributor-guide/architecture/adr/adr-index.md
@@ -13,6 +13,7 @@ focused on one decision.
 | [0004](./0004-cli-only-rebrand-keep-lockfile-and-extension-identity-stable.md) | CLI-Only Rebrand — Keep Lockfile and Extension Identity Stable | Accepted |
 | [0005](./0005-universal-xdg-based-app-storage.md) | Universal, XDG-Based Application Storage Port | Accepted |
 | [0006](./0006-shared-semantic-cache-and-client-owned-state.md) | Shared Semantic Cache and Client-Owned State | Accepted |
+| [0007](./0007-source-aware-github-app-authentication.md) | Source-Aware GitHub App Authentication for CLI Workflows | Accepted |
 
 ## When to add a new ADR
 

--- a/docs/contributor-guide/architecture/authentication.md
+++ b/docs/contributor-guide/architecture/authentication.md
@@ -22,6 +22,10 @@ The order is:
 2. Fallback providers supplied by the delivery layer, in their supplied order
 3. Anonymous access when no provider returns a token
 
+This legacy chain applies only when source-aware App mode is disabled. The
+source-aware path below requires a generic credential before its first GitHub
+request and never uses this anonymous fallback.
+
 For the VS Code extension, the fallback providers are:
 
 1. The selected VS Code GitHub authentication session
@@ -52,6 +56,193 @@ GitHub API requests use the token format implemented by
 Basic-auth PAT encoding in `azure-devops-api-client.ts`. Bundle downloaders
 may use a different authorization scheme required by their endpoint; use the
 relevant client implementation as the authority.
+
+## CLI Source-Aware Authentication
+
+The CLI and primitive-index harvester have an explicit, opt-in source-aware
+mode for CI workflows that need repository-scoped GitHub App installation
+tokens. The switch is `AI_PRIMITIVES_HUB_GH_APP_AUTH_ENABLED`; when it is
+unset or false, the existing developer token chain remains unchanged and the
+App CLI is never invoked.
+
+When enabled, the runtime parses the configured GitHub sources and performs
+the required source-type operations with a generic GitHub credential before
+selecting any repository-scoped App credential. Anonymous GitHub traffic is
+disabled in this mode. Each source receives one of these evidence-based
+categories:
+
+| Category | Runtime behavior |
+|---|---|
+| `public-generic` | Use `GH_TOKEN`, then `GITHUB_TOKEN` in CI, or local `gh auth token`; no anonymous fallback is permitted. |
+| `app-authenticated` | Invoke `gh app-auth token` with the source repository as `--repo`; no generic or personal fallback is allowed. |
+| `unresolved` | Fail the requested operation before source work; do not omit or silently reclassify the source. Missing generic credentials, ambiguous visibility, inaccessible repositories, and failed source operations are unresolved. |
+
+`AI_PRIMITIVES_HUB_GH_PUBLIC_AUTH_MODE` selects the public policy:
+`auto` (default) or `generic`. Both modes require an authenticated generic
+credential. The legacy value `anonymous` is rejected with
+`GH_PUBLIC_ANONYMOUS_DISABLED`. The App selector and isolated configuration
+are supplied through the
+`AI_PRIMITIVES_HUB_GH_APP_AUTH_APP_ID` or
+`AI_PRIMITIVES_HUB_GH_APP_AUTH_CLIENT_ID`, together with
+`AI_PRIMITIVES_HUB_GH_APP_AUTH_CONFIG`. The implementation passes the
+repository target separately from the request host, so API, raw-content, and
+asset requests for one repository receive the same repository-scoped token.
+
+For machine-readable consumers, source-aware validation returns the sanitized
+preflight report as `data.sourcePreflight`. Source-aware harvest failures use
+`GH_SOURCE_PREFLIGHT_FAILED` internally and expose the same report under
+`errors[0].context.sourcePreflight`; the report contains repository targets,
+categories, checked operations, and stable error codes, but no credentials.
+
+App setup is a separate bootstrap operation. `gh app-auth setup` receives
+wildcard routes derived from the sources that actually require
+authentication; runtime token lookup never performs setup or discovers
+installations. For the CLI's explicit bootstrap flow, `hub validate --check-sources`
+and `index harvest` accept an App ID, a PEM path, and a local hub YAML path.
+They create a private temporary filesystem config, derive the
+routes after generic preflight, run setup, reuse the resulting runtime, and
+remove the temporary config in `finally` cleanup. Setup is therefore automatic
+only when the caller explicitly supplies bootstrap inputs; it is never a
+hidden side effect of `TokenProvider.getToken()`.
+
+Keep private keys in the CI secret store or a restrictive temporary mount, and
+use placeholders in documentation and automation examples. Installation
+tokens are held in memory, cached per exact repository with a conservative
+lifetime, and never written to logs or persistent cache. Source-aware
+preflight fails promptly with `GH_PUBLIC_GENERIC_RATE_LIMIT_UNSAFE` when the
+authenticated generic path is rate limited; it never wait-retries through an
+anonymous tier or silently falls back to one. Private or ambiguous metadata
+still follows the App or unresolved path.
+
+The cache lifetime is command-scoped. Lockfile installs and profile activation
+reuse one source-aware runtime across bundle references, so multiple bundles
+from the same repository share one preflight and one cached App token. Harvest
+also reuses the verified default-branch revision from preflight instead of
+issuing a second commit lookup. Token values remain process-local; a separate
+warm-up command cannot populate a later process and tokens are never persisted.
+
+## GitHub API quota and CI design limits
+
+Source-aware authentication must be budgeted as an API workload, not just as a
+token-minting feature. GitHub has several independent constraints:
+
+- A personal access token normally has a 5,000-request-per-hour primary REST
+  limit.
+- A GitHub App *installation access token* for an installation on GitHub
+  Enterprise Cloud can have a 15,000-request-per-hour primary limit. That is
+  an installation-level bucket, not 15,000 requests for every repository or
+  every token minted by the installation.
+- The generic credential and App credential are both used by the current
+  source-aware design: generic authentication establishes visibility and
+  serves public sources; repository-scoped App tokens serve sources requiring
+  authentication. A healthy App bucket therefore does not prove that the
+  generic 5,000-request bucket is healthy. GitHub also documents that some
+  higher-limit App/OAuth requests made on a user's behalf can reduce the
+  lower-limit user budget, so the actual response headers must be treated as
+  authoritative for the selected token type.
+- Primary limits are not the only limit. GitHub's secondary controls include
+  a maximum of 100 concurrent requests across REST and GraphQL, endpoint
+  point-rate limits, CPU-time limits, and limits on token requests. Secondary
+  limits can be reached before the primary hourly counter is exhausted.
+
+The `GET /rate_limit` endpoint reports primary buckets and does not consume
+primary quota, but it is not a complete health check: GitHub states that there
+is no endpoint for querying secondary-limit state. Check the
+`x-ratelimit-*` headers on real API responses and stop on a `403`/`429` rather
+than polling through the failure. In one 2026-08-23 observation,
+`/rate_limit` reported thousands of primary requests remaining for the EMU
+credential while ordinary authenticated endpoints returned `403` with
+`x-ratelimit-remaining: 0` and a future reset time. The exact dynamic throttle
+could not be identified from public headers, so CI must classify this as
+*quota unavailable* rather than assume that primary quota is still usable.
+
+### Measured request shape
+
+The optimized clean-hub instrumentation used 47 sources (46 App-bound and one
+generic-public) and 60 lifecycle bundle references. It measured HTTP request
+attempts, not token values, as follows:
+
+| Flow | Developer credential | CI-simulated App | App-mode delta |
+|---|---:|---:|---:|
+| `hub validate --check-sources` | 562 | 754 | +192 |
+| `index harvest` | 1,038 | 1,183 | +145 |
+| `install --lockfile` | 159 | 298 | +139 |
+| `update --lockfile --dry-run` | 109 | 248 | +139 |
+| **All four flows** | **1,868** | **2,483** | **+615** |
+
+These are aggregate counts across credential categories; they must not be
+read as 2,483 requests against the App bucket or 1,868 requests against the
+personal bucket. Per-category counters are required before setting a precise
+per-token budget. They do show that repeating the complete matrix several
+times in one rolling hour is unsafe, especially when the same EMU identity is
+also used by other jobs or interactive tooling.
+
+For a source-aware preflight, a useful planning estimate is:
+
+$$
+Q_p \approx 3S + A + D + R
+$$
+
+where $Q_p$ is the preflight request count, $S$ is the number of sources, and
+$A$ is the number that require the App
+metadata check after generic visibility fails, $D$ is the number of
+collection/plugin directory checks, and $R$ is the number of release metadata
+checks. The three $S$ terms are generic visibility metadata, branch commit,
+and recursive tree. For the clean validation scope this predicted
+$3(47)+46+5=192$ preflight requests. The lifecycle scope had 28 sources,
+27 App-bound sources, four collection checks, and 24 release checks, yielding
+$3(28)+27+4+24=139$. The estimate excludes retries and operation requests;
+source-specific fallback paths can add requests.
+
+The cost scales with more than source count. A changed source revision causes
+tree and content/blob reads, and each uncached primitive candidate can add a
+raw-content request. The content-addressed blob cache reduces warm harvest
+cost, but only if CI preserves a safe cache between jobs. App tokens must not
+be placed in that cache.
+
+### CI operating policy
+
+Until per-category request telemetry is available, use conservative scheduling
+and budgets:
+
+1. Do not run validation, harvest, install, and update as four independent
+  checks on every push. Run static/offline validation on pull requests; run
+  one source-aware harvest on a controlled schedule; reserve lifecycle
+  install/update checks for release or scheduled jobs.
+2. Serialize jobs that use the same generic identity or App installation.
+  Use CI concurrency cancellation so an obsolete full-hub run cannot consume
+  the budget while a newer run starts.
+3. Treat the observed clean-hub counts as minimum planning baselines. A first
+  guardrail of roughly 1,000 attempts for full validation, 1,500 for harvest,
+  400 for install, and 350 for update includes modest headroom over the
+  measured run; these are engineering budgets, not GitHub guarantees. A
+  complete matrix should be budgeted at roughly 3,100 aggregate attempts
+  before it is allowed to start, with additional reserve for retries and
+  concurrent consumers.
+4. Perform a generic-credential canary against a representative repository
+  and inspect its response headers before starting a large job. Use
+  `/rate_limit` for primary accounting, but do not use it as the only canary
+  because it cannot reveal secondary throttling. If either canary is
+  throttled, abort the job and wait for the provider's reset guidance.
+5. Record, without secrets, request count and attempts by authentication
+  category, status-code counts, `304` counts, token-mint process counts,
+  `x-ratelimit-limit`, `x-ratelimit-remaining`, `x-ratelimit-used`, and
+  `x-ratelimit-reset`. This is necessary to distinguish primary exhaustion,
+  secondary throttling, App installation limits, and generic-user limits.
+6. Keep the repository/blob/ETag cache warm across CI jobs where the security
+  model permits it. Key it by hub/source revision and invalidate it when the
+  source or authentication category changes. Never persist installation
+  tokens or private keys.
+
+The implementation now trips a fail-closed preflight circuit after the first
+generic rate-limit response: remaining sources are marked
+`GH_PUBLIC_GENERIC_RATE_LIMIT_UNSAFE` without further probes. This avoids
+turning one quota outage into dozens of identical requests. It does not remove
+the need for CI-level serialization, canary checks, or budget accounting.
+
+Official references: [REST API rate limits](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api),
+[REST API best practices](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api),
+and [REST API rate-limit endpoints](https://docs.github.com/en/rest/rate-limit/rate-limit).
 
 ## First-Run GitHub Account Selection
 

--- a/packages/app/src/registry/create-source-adapter.ts
+++ b/packages/app/src/registry/create-source-adapter.ts
@@ -25,6 +25,8 @@ import type {
   Clock,
   FileSystem,
   GitHubApi,
+  GitHubRepositoryTarget,
+  GitHubSourceAuthCategory,
   HttpClient,
   ProcessRunner,
   RegistrySource,
@@ -43,6 +45,7 @@ import {
   LocalApmAdapter,
   LocalAwesomeCopilotAdapter,
   LocalSkillsAdapter,
+  parseGitHubRepositoryTarget,
   SkillsAdapter,
   StaticTokenProvider,
 } from '@ai-primitives-hub/infra';
@@ -59,9 +62,31 @@ export interface SourceAdapterFactoryDeps {
    * the CLI itself.
    */
   fallbackTokenProviders: readonly TokenProvider[];
+  /** Optional preflight authentication decisions, keyed by source id. */
+  sourceAuthentication?: ReadonlyMap<string, SourceAuthenticationContext>;
+}
+
+export interface SourceAuthenticationContext {
+  category: GitHubSourceAuthCategory;
+  target: GitHubRepositoryTarget;
+  /** Exactly one provider for `public-generic` or `app-authenticated`. */
+  tokenProvider?: TokenProvider;
 }
 
 function buildSourceTokenProvider(source: RegistrySource, deps: SourceAdapterFactoryDeps): TokenProvider {
+  const authentication = deps.sourceAuthentication?.get(source.id);
+  if (authentication !== undefined) {
+    if (authentication.category === 'unresolved') {
+      throw new Error(`Source ${source.id} has unresolved GitHub authentication.`);
+    }
+    if (authentication.category === 'public-anonymous') {
+      return new StaticTokenProvider('');
+    }
+    if (authentication.tokenProvider === undefined) {
+      throw new Error(`Source ${source.id} has no provider for ${authentication.category} authentication.`);
+    }
+    return authentication.tokenProvider;
+  }
   const providers: TokenProvider[] = [];
   if (source.token) {
     providers.push(new StaticTokenProvider(source.token));
@@ -70,8 +95,26 @@ function buildSourceTokenProvider(source: RegistrySource, deps: SourceAdapterFac
   return new CompositeTokenProvider(providers);
 }
 
-function buildGitHubApi(tokenProvider: TokenProvider, deps: SourceAdapterFactoryDeps): GitHubApi {
-  return new GitHubApiClient(deps.httpClient, { tokenProvider });
+function buildGitHubApi(
+  source: RegistrySource,
+  tokenProvider: TokenProvider,
+  deps: SourceAdapterFactoryDeps,
+  authentication?: SourceAuthenticationContext
+): GitHubApi {
+  const repositoryTarget = authentication?.target ?? parseGitHubRepositoryTarget(source.url);
+  if (authentication !== undefined) {
+    const configuredTarget = parseGitHubRepositoryTarget(source.url);
+    if (configuredTarget.host !== repositoryTarget.host
+      || configuredTarget.owner !== repositoryTarget.owner
+      || configuredTarget.repository !== repositoryTarget.repository) {
+      throw new Error(`Source ${source.id} authentication target does not match the configured source.`);
+    }
+  }
+  return new GitHubApiClient(deps.httpClient, {
+    tokenProvider,
+    repositoryTarget,
+    authenticationCategory: authentication?.category
+  });
 }
 
 function buildAzureDevOpsApi(tokenProvider: TokenProvider, deps: SourceAdapterFactoryDeps): AzureDevOpsApi {
@@ -84,6 +127,7 @@ function buildAzureDevOpsApi(tokenProvider: TokenProvider, deps: SourceAdapterFa
  * @param deps - Shared, delivery-context-specific dependencies (Node port implementations + auth fallback chain).
  */
 export function createSourceAdapter(source: RegistrySource, deps: SourceAdapterFactoryDeps): SourceAdapter {
+  const authentication = deps.sourceAuthentication?.get(source.id);
   switch (source.type) {
     case 'local': {
       return new LocalAdapter(source, deps.fs);
@@ -98,17 +142,17 @@ export function createSourceAdapter(source: RegistrySource, deps: SourceAdapterF
       return new LocalSkillsAdapter(source, deps.fs, deps.clock);
     }
     case 'github': {
-      return new GitHubAdapter(source, buildGitHubApi(buildSourceTokenProvider(source, deps), deps));
+      return new GitHubAdapter(source, buildGitHubApi(source, buildSourceTokenProvider(source, deps), deps, authentication));
     }
     case 'skills': {
-      return new SkillsAdapter(source, buildGitHubApi(buildSourceTokenProvider(source, deps), deps), deps.clock);
+      return new SkillsAdapter(source, buildGitHubApi(source, buildSourceTokenProvider(source, deps), deps, authentication), deps.clock);
     }
     case 'awesome-copilot': {
-      return new AwesomeCopilotAdapter(source, buildGitHubApi(buildSourceTokenProvider(source, deps), deps), deps.clock);
+      return new AwesomeCopilotAdapter(source, buildGitHubApi(source, buildSourceTokenProvider(source, deps), deps, authentication), deps.clock);
     }
     case 'apm': {
       const tokenProvider = buildSourceTokenProvider(source, deps);
-      return new ApmAdapter(source, buildGitHubApi(tokenProvider, deps), deps.processRunner, deps.fs, deps.clock, tokenProvider);
+      return new ApmAdapter(source, buildGitHubApi(source, tokenProvider, deps, authentication), deps.processRunner, deps.fs, deps.clock, tokenProvider);
     }
     case 'azure-devops': {
       return new AzureDevOpsAdapter(

--- a/packages/app/test/registry/create-source-adapter.test.ts
+++ b/packages/app/test/registry/create-source-adapter.test.ts
@@ -1,5 +1,7 @@
 import type {
   Clock,
+  GitHubRepositoryTarget,
+  GitHubSourceAuthCategory,
   HttpClient,
   HttpRequest,
   HttpResponse,
@@ -58,6 +60,33 @@ class StubTokenProvider implements TokenProvider {
 
   public async getToken(): Promise<string | undefined> {
     return this.token;
+  }
+}
+
+class RecordingTargetTokenProvider implements TokenProvider {
+  public readonly targets: (GitHubRepositoryTarget | undefined)[] = [];
+
+  public async getToken(_host: string, target?: GitHubRepositoryTarget): Promise<string | undefined> {
+    this.targets.push(target);
+    return undefined;
+  }
+}
+
+class CountingTokenProvider implements TokenProvider {
+  public calls = 0;
+
+  public async getToken(): Promise<string | undefined> {
+    this.calls += 1;
+    return 'fallback-token';
+  }
+}
+
+class RecordingTokenProvider implements TokenProvider {
+  public readonly targets: (GitHubRepositoryTarget | undefined)[] = [];
+
+  public async getToken(_host: string, target?: GitHubRepositoryTarget): Promise<string | undefined> {
+    this.targets.push(target);
+    return 'category-token';
   }
 }
 
@@ -146,6 +175,114 @@ describe('createSourceAdapter', () => {
       for (const request of httpClient.requests) {
         expect(request.headers?.Authorization).toBeUndefined();
       }
+    });
+
+    it('binds GitHub API calls to the source repository target', async () => {
+      const httpClient = new RecordingHttpClient();
+      const tokenProvider = new RecordingTargetTokenProvider();
+      const adapter = createSourceAdapter(
+        makeSource({ type: 'github', url: 'https://github.com/owner/repo' }),
+        makeDeps({ httpClient, fallbackTokenProviders: [tokenProvider] })
+      );
+
+      await adapter.validate();
+
+      expect(tokenProvider.targets.length).toBeGreaterThan(0);
+      expect(tokenProvider.targets.every((target) => target !== undefined)).toBe(true);
+      expect(tokenProvider.targets[0]).toEqual({
+        host: 'github.com',
+        owner: 'owner',
+        repository: 'repo'
+      });
+    });
+
+    it('does not invoke credentials for a public-anonymous source', async () => {
+      const httpClient = new RecordingHttpClient();
+      const fallback = new CountingTokenProvider();
+      const source = makeSource({ type: 'github', url: 'https://github.com/owner/repo' });
+      const auth: { category: GitHubSourceAuthCategory; target: GitHubRepositoryTarget } = {
+        category: 'public-anonymous',
+        target: { host: 'github.com', owner: 'owner', repository: 'repo' }
+      };
+      const adapter = createSourceAdapter(
+        source,
+        makeDeps({
+          httpClient,
+          fallbackTokenProviders: [fallback],
+          sourceAuthentication: new Map([[source.id, auth]])
+        })
+      );
+
+      await adapter.validate();
+
+      expect(fallback.calls).toBe(0);
+      expect(httpClient.requests.length).toBeGreaterThan(0);
+      for (const request of httpClient.requests) {
+        expect(request.headers?.Authorization).toBeUndefined();
+      }
+    });
+
+    it('uses only the preflight provider for a public-generic source', async () => {
+      const httpClient = new RecordingHttpClient();
+      const fallback = new CountingTokenProvider();
+      const categoryProvider = new RecordingTokenProvider();
+      const source = makeSource({ type: 'github', url: 'https://github.com/owner/repo' });
+      const adapter = createSourceAdapter(
+        source,
+        makeDeps({
+          httpClient,
+          fallbackTokenProviders: [fallback],
+          sourceAuthentication: new Map([[
+            source.id,
+            {
+              category: 'public-generic',
+              target: { host: 'github.com', owner: 'owner', repository: 'repo' },
+              tokenProvider: categoryProvider
+            }
+          ]])
+        })
+      );
+
+      await adapter.validate();
+
+      expect(fallback.calls).toBe(0);
+      expect(categoryProvider.targets.length).toBeGreaterThan(0);
+      expect(httpClient.requests.every((request) => request.headers?.Authorization === 'token category-token')).toBe(true);
+    });
+
+    it('rejects an unresolved preflight source before constructing its adapter', () => {
+      const source = makeSource({ type: 'github', url: 'https://github.com/owner/repo' });
+
+      expect(() => createSourceAdapter(
+        source,
+        makeDeps({
+          sourceAuthentication: new Map([[
+            source.id,
+            {
+              category: 'unresolved',
+              target: { host: 'github.com', owner: 'owner', repository: 'repo' }
+            }
+          ]])
+        })
+      )).toThrow('unresolved GitHub authentication');
+    });
+
+    it('rejects a preflight target that does not match the configured source', () => {
+      const source = makeSource({ type: 'github', url: 'https://github.com/owner/repo' });
+
+      expect(() => createSourceAdapter(
+        source,
+        makeDeps({
+          sourceAuthentication: new Map([[
+            source.id,
+            {
+              category: 'app-authenticated',
+              target: { host: 'github.com', owner: 'other-owner', repository: 'repo' },
+              tokenProvider: new RecordingTokenProvider()
+            }
+          ]])
+        })
+      )).toThrow('does not match the configured source');
     });
   });
 });

--- a/packages/cli/src/commands/hub.ts
+++ b/packages/cli/src/commands/hub.ts
@@ -26,15 +26,30 @@ import type {
   DeepHubConfigValidationResult,
   HubConfigFileValidationResult,
   HubValidationProgress,
+  SourceAuthenticationContext,
 } from '@ai-primitives-hub/app';
 import type {
+  GitHubSourceAuthCategory,
   HttpClient,
   TokenProvider,
 } from '@ai-primitives-hub/core';
 import {
+  createGitHubSourceAuthRuntime,
+  createGitHubSourceAuthSession,
   defaultTokenProvider,
+  GITHUB_APP_AUTH_KEY_FILE,
+  GITHUB_APP_CLIENT_ID,
+  GITHUB_APP_ID,
+  GITHUB_APP_INSTALLATION_ID,
+  isGitHubAppAuthEnabled,
   NodeHttpClient,
   NodeProcessRunner,
+  parseHubConfig,
+} from '@ai-primitives-hub/infra';
+import type {
+  GitHubSourceAuthRuntime,
+  GitHubSourceAuthSession,
+  GitHubSourcePreflightReport,
 } from '@ai-primitives-hub/infra';
 import {
   Command,
@@ -478,6 +493,58 @@ const renderHubValidationProgress = (ctx: Context, event: HubValidationProgress)
   }
 };
 
+interface HubSourceAuthenticationPreparation {
+  sourceAuthentication?: ReadonlyMap<string, SourceAuthenticationContext>;
+  report?: GitHubSourcePreflightReport;
+  errors: string[];
+}
+
+async function prepareHubSourceAuthentication(
+  ctx: Context,
+  configPath: string,
+  verbose: boolean,
+  runtime: GitHubSourceAuthRuntime
+): Promise<HubSourceAuthenticationPreparation> {
+  try {
+    const specs = parseHubConfig(await ctx.fs.readFile(configPath), { strict: true });
+    const report = await runtime.preflight(specs, {
+      onLog: verbose ? (message) => ctx.stderr.write(`[github preflight] ${message}\n`) : undefined
+    });
+    if (!report.valid) {
+      return {
+        report,
+        errors: report.results
+          .filter((result) => result.category === 'unresolved')
+          .map((result) => {
+            const operation = result.operations.at(-1);
+            return `GitHub source preflight failed for ${result.sourceId}: ${result.errorCode ?? 'GH_SOURCE_PREFLIGHT_UNRESOLVED'}`
+              + (operation === undefined ? '' : ` (operation: ${operation})`);
+          })
+      };
+    }
+    return {
+      report,
+      sourceAuthentication: new Map(
+        report.results.map((result) => [result.sourceId, {
+          category: result.category,
+          target: result.target!,
+          tokenProvider: result.category === 'public-anonymous'
+            ? undefined
+            : runtime.tokenProviderFor(result.category as Exclude<GitHubSourceAuthCategory, 'unresolved'>)
+        }])
+      ),
+      errors: []
+    };
+  } catch (error) {
+    const code = typeof (error as { code?: unknown } | undefined)?.code === 'string'
+      ? (error as { code: string }).code
+      : undefined;
+    return {
+      errors: [`GitHub source preflight could not run: ${code === undefined ? '' : `${code}: `}${error instanceof Error ? error.message : String(error)}`]
+    };
+  }
+}
+
 /**
  * hub validate - validate a repository hub-config YAML file offline.
  */
@@ -497,6 +564,9 @@ export class HubValidateCommand extends BaseHubCommand {
       Options:
         --config <path>          Hub configuration file (default: hub-config.yml)
         --check-sources          Contact/scan enabled sources and resolve profiles
+        --github-app-id <id>     App ID for automatic source-aware setup
+        --github-app-key-file <path>
+                                 PEM path for automatic source-aware setup
         -v, --verbose            Print deep-validation progress to stderr
         -o, --output <format>    Output format (text, json, yaml, ndjson)
 
@@ -510,6 +580,11 @@ export class HubValidateCommand extends BaseHubCommand {
 
   public config = Option.String('--config');
   public checkSources = Option.Boolean('--check-sources', false);
+  public githubAppId = Option.String('--github-app-id');
+  public githubAppClientId = Option.String('--github-app-client-id');
+  public githubAppKeyFile = Option.String('--github-app-key-file');
+  public githubAppInstallationId = Option.String('--github-app-installation-id');
+  public githubAppSetupTimeoutMs = Option.String('--github-app-setup-timeout-ms');
   public verbose = Option.Boolean('-v,--verbose', false);
 
   public async execute(): Promise<number> {
@@ -522,34 +597,113 @@ export class HubValidateCommand extends BaseHubCommand {
     if (this.verbose && !this.checkSources) {
       ctx.stderr.write('--verbose has no effect without --check-sources; validation remains offline.\n');
     }
-    const result = await validateHubConfigFile(ctx.fs, configPath, this.checkSources
-      ? {
-        deep: true,
-        onProgress: this.verbose
-          ? (event) => renderHubValidationProgress(ctx, event)
-          : undefined,
-        sourceAdapterDeps: {
-          fs: ctx.fs,
-          clock: ctx.clock,
-          httpClient: http ?? new NodeHttpClient(),
-          processRunner: new NodeProcessRunner(),
-          fallbackTokenProviders: tokens === undefined
-            ? [defaultTokenProvider(ctx.env)]
-            : [tokens]
+    const appBootstrapRequested = this.githubAppId !== undefined
+      || this.githubAppClientId !== undefined
+      || this.githubAppKeyFile !== undefined
+      || ctx.env[GITHUB_APP_AUTH_KEY_FILE] !== undefined;
+    let appSession: GitHubSourceAuthSession | undefined;
+    try {
+      let sourceAuthentication: ReadonlyMap<string, SourceAuthenticationContext> | undefined;
+      let sourcePreflight: GitHubSourcePreflightReport | undefined;
+      if (this.checkSources && (isGitHubAppAuthEnabled(ctx.env) || appBootstrapRequested)) {
+        const staticResult = await validateHubConfigFile(ctx.fs, configPath);
+        if (!staticResult.valid) {
+          formatOutput({
+            ctx,
+            command: 'hub.validate',
+            output: fmt,
+            status: 'error',
+            data: staticResult,
+            warnings: staticResult.warnings,
+            textRenderer: renderHubValidationText
+          });
+          return 1;
         }
+        let runtime: GitHubSourceAuthRuntime;
+        if (appBootstrapRequested) {
+          appSession = await createGitHubSourceAuthSession({
+            env: ctx.env,
+            http: http ?? new NodeHttpClient(),
+            appId: this.githubAppId ?? ctx.env[GITHUB_APP_ID],
+            clientId: this.githubAppClientId ?? ctx.env[GITHUB_APP_CLIENT_ID],
+            keyFile: this.githubAppKeyFile ?? ctx.env[GITHUB_APP_AUTH_KEY_FILE] ?? '',
+            installationId: this.githubAppInstallationId ?? ctx.env[GITHUB_APP_INSTALLATION_ID],
+            setupTimeoutMs: this.githubAppSetupTimeoutMs === undefined
+              ? undefined
+              : Number.parseInt(this.githubAppSetupTimeoutMs, 10)
+          });
+          runtime = appSession;
+        } else {
+          runtime = createGitHubSourceAuthRuntime({
+            env: ctx.env,
+            http: http ?? new NodeHttpClient()
+          });
+        }
+        const prepared = await prepareHubSourceAuthentication(
+          ctx,
+          configPath,
+          this.verbose,
+          runtime
+        );
+        sourcePreflight = prepared.report;
+        if (prepared.errors.length > 0) {
+          const preflightResult: HubConfigFileValidationResult = {
+            file: configPath,
+            valid: false,
+            errors: prepared.errors,
+            warnings: []
+          };
+          formatOutput({
+            ctx,
+            command: 'hub.validate',
+            output: fmt,
+            status: 'error',
+            data: {
+              ...preflightResult,
+              sourcePreflight
+            },
+            warnings: preflightResult.warnings,
+            textRenderer: renderHubValidationText
+          });
+          return 1;
+        }
+        sourceAuthentication = prepared.sourceAuthentication;
       }
-      : undefined);
+      const result = await validateHubConfigFile(ctx.fs, configPath, this.checkSources
+        ? {
+          deep: true,
+          onProgress: this.verbose
+            ? (event) => renderHubValidationProgress(ctx, event)
+            : undefined,
+          sourceAdapterDeps: {
+            fs: ctx.fs,
+            clock: ctx.clock,
+            httpClient: http ?? new NodeHttpClient(),
+            processRunner: new NodeProcessRunner(),
+            fallbackTokenProviders: tokens === undefined
+              ? [defaultTokenProvider(ctx.env)]
+              : [tokens],
+            sourceAuthentication
+          }
+        }
+        : undefined);
+      const validationData = sourcePreflight === undefined
+        ? result
+        : { ...result, sourcePreflight };
 
-    formatOutput({
-      ctx,
-      command: 'hub.validate',
-      output: fmt,
-      status: result.valid ? (result.warnings?.length ? 'warning' : 'ok') : 'error',
-      data: result,
-      warnings: result.warnings,
-      textRenderer: renderHubValidationText
-    });
-    return result.valid ? 0 : 1;
+      formatOutput({
+        ctx,
+        command: 'hub.validate',
+        output: fmt,
+        status: result.valid ? (result.warnings?.length ? 'warning' : 'ok') : 'error',
+        data: validationData,
+        warnings: result.warnings,
+        textRenderer: renderHubValidationText
+      });
+      return result.valid ? 0 : 1;
+    } finally {
+      await appSession?.cleanup();
+    }
   }
 }
 

--- a/packages/cli/src/commands/index-harvest.ts
+++ b/packages/cli/src/commands/index-harvest.ts
@@ -18,6 +18,7 @@ import {
   ActiveHubStore,
   AppStoragePrimitiveIndexStore,
   harvestHub as defaultHarvestHub,
+  GitHubSourcePreflightError,
   type HubHarvestPipelineOptions,
   type HubHarvestPipelineResult,
   HubStore,
@@ -104,11 +105,20 @@ function applyHubRef(
   cmd.hubConfigFile = hubConfigFile;
 }
 
-const buildHarvestError = (cause: unknown): RegistryError => new RegistryError({
-  code: 'INDEX.HARVEST_FAILED',
-  message: `index harvest failed: ${cause instanceof Error ? cause.message : String(cause)}`,
-  cause: cause instanceof Error ? cause : undefined
-});
+const buildHarvestError = (cause: unknown): RegistryError => {
+  const message = cause instanceof Error ? cause.message : String(cause);
+  const stableCode = typeof (cause as { code?: unknown } | undefined)?.code === 'string'
+    ? (cause as { code: string }).code
+    : undefined;
+  return new RegistryError({
+    code: 'INDEX.HARVEST_FAILED',
+    message: `index harvest failed: ${stableCode === undefined ? '' : `${stableCode}: `}${message}`,
+    cause: cause instanceof Error ? cause : undefined,
+    context: cause instanceof GitHubSourcePreflightError
+      ? { sourcePreflight: cause.report }
+      : undefined
+  });
+};
 
 const isHubRefMissing = (noHubConfig: boolean, hubConfigFile: string | undefined, hubRepo: string | undefined): boolean =>
   !noHubConfig && !hubConfigFile && (!hubRepo || hubRepo.length === 0);
@@ -129,6 +139,9 @@ export class IndexHarvestCommand extends Command {
       Options:
         --embed              Embed primitive text using the local ternlight model
         --embed-strategy     Embedding strategy: single (default) or dual
+        --github-app-id      GitHub App ID for automatic source-aware setup
+        --github-app-key-file
+                             PEM path for automatic source-aware setup
 
       Examples:
         ai-primitives-hub index harvest --hub-repo OWNER/REPO
@@ -156,6 +169,11 @@ export class IndexHarvestCommand extends Command {
   public dryRun = Option.Boolean('--dry-run');
   public embed = Option.Boolean('--embed', false);
   public embedStrategy = Option.String('--embed-strategy');
+  public githubAppId = Option.String('--github-app-id');
+  public githubAppClientId = Option.String('--github-app-client-id');
+  public githubAppKeyFile = Option.String('--github-app-key-file');
+  public githubAppInstallationId = Option.String('--github-app-installation-id');
+  public githubAppSetupTimeoutMs = Option.String('--github-app-setup-timeout-ms');
   public verbose = Option.Boolean('--verbose');
   public output = Option.String('-o,--output');
   public commandContext!: { ctx: Context };
@@ -215,7 +233,14 @@ export class IndexHarvestCommand extends Command {
       embeddingStrategy: this.embedStrategy as 'single' | 'dual' | undefined,
       searchProfileId: this.embed
         ? (this.embedStrategy === 'dual' ? 'ternlight-dual-v1' : 'ternlight-single-v1')
-        : 'bm25-v1'
+        : 'bm25-v1',
+      githubAppId: this.githubAppId,
+      githubAppClientId: this.githubAppClientId,
+      githubAppKeyFile: this.githubAppKeyFile,
+      githubAppInstallationId: this.githubAppInstallationId,
+      githubAppSetupTimeoutMs: this.githubAppSetupTimeoutMs === undefined
+        ? undefined
+        : Number.parseInt(this.githubAppSetupTimeoutMs, 10)
     };
 
     const runner = defaultHarvestHub;

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -34,7 +34,11 @@ import {
 } from '@ai-primitives-hub/app';
 import type {
   BundleResolver,
+  GitHubApi,
+  GitHubRepositoryTarget,
+  GitHubSourceAuthCategory,
   HttpClient,
+  HubSourceSpec,
   RegistrySource,
   Target,
   TokenProvider,
@@ -47,13 +51,17 @@ import {
 import {
   ActiveHubStore,
   AwesomeCopilotBundleResolver,
+  createGitHubSourceAuthRuntime,
   defaultTokenProvider,
   FileSystemLayoutConfigLoader,
   GitHubApiClient,
   GitHubBundleResolver,
+  type GitHubSourceAuthRuntime,
   HttpsBundleDownloader,
   HubStore,
+  isGitHubAppAuthEnabled,
   NodeHttpClient,
+  parseGitHubRepositoryTarget,
   readLocalBundle,
   readTargets,
   type RepositoryCommitMode,
@@ -61,6 +69,7 @@ import {
   RepositoryScopeWriterAdapter,
   resolveUserConfigDir,
   SourceDispatcher,
+  StaticTokenProvider,
   TargetStateStore,
   ZipBundleExtractor,
 } from '@ai-primitives-hub/infra';
@@ -101,15 +110,142 @@ function extractRepoSlug(url: string): string {
   return url;
 }
 
+export interface SourceAwareInstallDependencies {
+  githubApi: GitHubApi;
+  downloadTokens: TokenProvider;
+  repositoryTarget: GitHubRepositoryTarget;
+  authenticationCategory: Exclude<GitHubSourceAuthCategory, 'unresolved'>;
+}
+
+export interface SourceAwareInstallDependencyCache {
+  get(repoSlug: string, sourceConfig?: RegistrySource): Promise<SourceAwareInstallDependencies>;
+}
+
+function sourceSpecForInstall(
+  repoSlug: string,
+  sourceConfig: RegistrySource | undefined,
+  target: GitHubRepositoryTarget
+): HubSourceSpec {
+  const sourceType = sourceConfig?.type === 'awesome-copilot' ? 'awesome-copilot' : 'github';
+  const config = sourceConfig?.config ?? {};
+  return {
+    id: sourceConfig?.id ?? repoSlug,
+    name: sourceConfig?.name ?? repoSlug,
+    type: sourceType,
+    url: sourceConfig?.url ?? `https://${target.host}/${target.owner}/${target.repository}`,
+    owner: target.owner,
+    repo: target.repository,
+    branch: typeof config.branch === 'string' ? config.branch : 'main',
+    ...(sourceType === 'awesome-copilot'
+      ? { collectionsPath: typeof config.collectionsPath === 'string' ? config.collectionsPath : 'collections' }
+      : {}),
+    rawConfig: config
+  };
+}
+
+async function sourceAwareInstallDependencies(
+  repoSlug: string,
+  sourceConfig: RegistrySource | undefined,
+  http: HttpClient,
+  ctx: Context,
+  runtime: GitHubSourceAuthRuntime = createGitHubSourceAuthRuntime({ env: ctx.env, http })
+): Promise<SourceAwareInstallDependencies> {
+  const sourceUrl = sourceConfig?.url ?? `https://github.com/${repoSlug}`;
+  const repositoryTarget = parseGitHubRepositoryTarget(sourceUrl);
+  const sourceSpec = sourceSpecForInstall(repoSlug, sourceConfig, repositoryTarget);
+  const report = await runtime.preflight([sourceSpec], {
+    includeReleases: sourceConfig === undefined || sourceConfig.type === 'github',
+    onLog: (message) => ctx.stderr.write(`[github preflight] ${message}\n`)
+  });
+  const decision = report.results[0];
+  if (!report.valid || decision === undefined || decision.category === 'unresolved' || decision.target === undefined) {
+    const code = decision?.errorCode ?? 'GH_SOURCE_PREFLIGHT_UNRESOLVED';
+    throw new Error(`GitHub source preflight failed for ${sourceSpec.id}: ${code}`);
+  }
+  const downloadTokens = runtime.tokenProviderFor(decision.category) ?? new StaticTokenProvider('');
+  return {
+    githubApi: runtime.clientFor(decision.target, decision.category),
+    downloadTokens,
+    repositoryTarget: decision.target,
+    authenticationCategory: decision.category
+  };
+}
+
+function sourceAwareInstallDependencyKey(
+  repoSlug: string,
+  sourceConfig: RegistrySource | undefined
+): string {
+  const sourceUrl = sourceConfig?.url ?? `https://github.com/${repoSlug}`;
+  const target = parseGitHubRepositoryTarget(sourceUrl);
+  const config = sourceConfig?.config ?? {};
+  return [
+    target.host.toLowerCase(),
+    target.owner.toLowerCase(),
+    target.repository.toLowerCase(),
+    sourceConfig?.type ?? 'github',
+    typeof config.branch === 'string' ? config.branch : 'main',
+    typeof config.collectionsPath === 'string' ? config.collectionsPath : 'collections'
+  ].join('\u0000');
+}
+
+/**
+ * Create a command-scoped cache for source-aware install dependencies.
+ *
+ * The App token cache is owned by the runtime's shared provider. Keeping the
+ * runtime and preflight promises at command scope prevents every bundle in a
+ * lockfile from repeating the same repository checks and minting a fresh
+ * token for an already-seen source.
+ * @param http HTTP client used by source preflight and resolvers.
+ * @param ctx CLI context.
+ * @param runtime Optional runtime seam for tests or advanced callers.
+ */
+export function createSourceAwareInstallDependencyCache(
+  http: HttpClient,
+  ctx: Context,
+  runtime?: GitHubSourceAuthRuntime
+): SourceAwareInstallDependencyCache {
+  const sharedRuntime = runtime ?? createGitHubSourceAuthRuntime({ env: ctx.env, http });
+  const entries = new Map<string, Promise<SourceAwareInstallDependencies>>();
+  return {
+    get: (repoSlug, sourceConfig) => {
+      const key = sourceAwareInstallDependencyKey(repoSlug, sourceConfig);
+      const existing = entries.get(key);
+      if (existing !== undefined) {
+        return existing;
+      }
+      const dependency = sourceAwareInstallDependencies(
+        repoSlug,
+        sourceConfig,
+        http,
+        ctx,
+        sharedRuntime
+      );
+      entries.set(key, dependency);
+      return dependency;
+    }
+  };
+}
+
 /**
  * Build a `GitHubApi` client shared by every GitHub-backed resolver in
  * a single command invocation.
  * @param http HTTP client.
  * @param tokens Token provider.
+ * @param repositoryTarget
+ * @param authenticationCategory
  * @returns GitHubApiClient instance.
  */
-export function githubApiFor(http: HttpClient, tokens: TokenProvider): GitHubApiClient {
-  return new GitHubApiClient(http, { tokenProvider: tokens });
+export function githubApiFor(
+  http: HttpClient,
+  tokens: TokenProvider,
+  repositoryTarget?: GitHubRepositoryTarget,
+  authenticationCategory?: GitHubSourceAuthCategory
+): GitHubApiClient {
+  return new GitHubApiClient(http, {
+    tokenProvider: tokens,
+    repositoryTarget,
+    authenticationCategory
+  });
 }
 
 /**
@@ -175,6 +311,8 @@ export interface InstallOptions {
    * If provided, SourceDispatcher will select the appropriate resolver.
    */
   sourceConfig?: RegistrySource;
+  /** Reuse source-aware preflight and token providers across bundle requests. */
+  sourceAwareDependencyCache?: SourceAwareInstallDependencyCache;
   /**
    * Verbose mode: show detailed progress and error messages.
    */
@@ -655,13 +793,22 @@ async function installSelectedBundles(
   fmt: OutputFormat
 ): Promise<number> {
   let installedCount = 0;
+  const sourceAwareDependencyCache = isGitHubAppAuthEnabled(ctx.env)
+    ? createSourceAwareInstallDependencyCache(opts.http ?? new NodeHttpClient(), ctx)
+    : undefined;
   for (const bundle of bundles) {
     const source = sourceMap.get(bundle.source);
     if (!source) {
       ctx.stderr.write(`Failed to install ${bundle.id}@${bundle.version}: source "${bundle.source}" not found in hub\n`);
       continue;
     }
-    const bundleOpts = { ...opts, bundle: bundle.id, source: source.url, sourceConfig: source };
+    const bundleOpts = {
+      ...opts,
+      bundle: bundle.id,
+      source: source.url,
+      sourceConfig: source,
+      sourceAwareDependencyCache
+    };
     try {
       const result = await performRemoteInstall(bundleOpts, target, ctx, fmt);
       if (result === 0) {
@@ -820,6 +967,9 @@ async function performLockfileInstall(
   const tokens = opts.tokens ?? defaultTokenProvider(ctx.env);
   const writerFactory = createWriterFactory(ctx, opts);
   const writer = writerFactory(effectiveTarget);
+  const sourceAwareDependencyCache = isGitHubAppAuthEnabled(ctx.env)
+    ? createSourceAwareInstallDependencyCache(http, ctx)
+    : undefined;
 
   const { replayed, failures } = await replayLockfileEntries({
     bundleIds,
@@ -829,7 +979,8 @@ async function performLockfileInstall(
     writer,
     target: effectiveTarget,
     ctx,
-    verbose: opts.verbose ?? false
+    verbose: opts.verbose ?? false,
+    sourceAwareDependencyCache
   });
 
   if (replayed.length > 0) {
@@ -898,7 +1049,22 @@ async function performRemoteInstall(
     }
     const http = opts.http ?? new NodeHttpClient();
     const tokens = opts.tokens ?? defaultTokenProvider(ctx.env);
-    const githubApi = githubApiFor(http, tokens);
+    let githubApi: GitHubApi;
+    let downloadTokens: TokenProvider;
+    let repositoryTarget: GitHubRepositoryTarget | undefined;
+    let authenticationCategory: Exclude<GitHubSourceAuthCategory, 'unresolved'> | undefined;
+    if (isGitHubAppAuthEnabled(ctx.env)) {
+      const dependencies = opts.sourceAwareDependencyCache === undefined
+        ? await sourceAwareInstallDependencies(repoSlug, opts.sourceConfig, http, ctx)
+        : await opts.sourceAwareDependencyCache.get(repoSlug, opts.sourceConfig);
+      githubApi = dependencies.githubApi;
+      downloadTokens = dependencies.downloadTokens;
+      repositoryTarget = dependencies.repositoryTarget;
+      authenticationCategory = dependencies.authenticationCategory;
+    } else {
+      githubApi = githubApiFor(http, tokens);
+      downloadTokens = tokens;
+    }
 
     // Use SourceDispatcher to select the appropriate resolver based on source config
     let resolver: BundleResolver;
@@ -911,7 +1077,7 @@ async function performRemoteInstall(
       resolver = new GitHubBundleResolver({ repoSlug, githubApi });
     }
 
-    const downloader = new HttpsBundleDownloader(http, tokens);
+    const downloader = new HttpsBundleDownloader(http, downloadTokens, repositoryTarget, authenticationCategory);
     const extractor = new ZipBundleExtractor();
 
     const installable = await resolver.resolve(spec);
@@ -971,7 +1137,7 @@ async function performRemoteInstall(
     let nextLock = upsertBundleEntry(existing, manifest.id, entry);
     const collectionsPath = opts.sourceConfig?.config?.collectionsPath;
     nextLock = upsertSource(nextLock, installable.ref.sourceId, {
-      type: 'github',
+      type: opts.sourceConfig?.type ?? 'github',
       url: `https://github.com/${repoSlug}`,
       ...(collectionsPath ? { collectionsPath } : {})
     });
@@ -1173,12 +1339,23 @@ interface ReplayLockfileEntriesOptions {
   target: Target;
   ctx: Context;
   verbose: boolean;
+  sourceAwareDependencyCache?: SourceAwareInstallDependencyCache;
 }
 
 async function replayLockfileEntries(
   opts: ReplayLockfileEntriesOptions
 ): Promise<{ replayed: string[]; failures: { bundleId: string; reason: string }[] }> {
-  const { bundleIds, lock, http, tokens, writer, target, ctx, verbose } = opts;
+  const {
+    bundleIds,
+    lock,
+    http,
+    tokens,
+    writer,
+    target,
+    ctx,
+    verbose,
+    sourceAwareDependencyCache
+  } = opts;
   const replayed: string[] = [];
   const failures: { bundleId: string; reason: string }[] = [];
 
@@ -1197,7 +1374,8 @@ async function replayLockfileEntries(
       writer,
       target,
       ctx,
-      verbose
+      verbose,
+      sourceAwareDependencyCache
     });
     if (result.success) {
       replayed.push(bundleId);
@@ -1219,19 +1397,40 @@ interface ReplaySingleEntryOptions {
   target: Target;
   ctx: Context;
   verbose: boolean;
+  sourceAwareDependencyCache?: SourceAwareInstallDependencyCache;
 }
 
 async function replaySingleEntry(
   opts: ReplaySingleEntryOptions
 ): Promise<{ success: boolean; reason: string }> {
-  const { bundleId, entry, sources, http, tokens, writer, target, ctx, verbose } = opts;
+  const {
+    bundleId,
+    entry,
+    sources,
+    http,
+    tokens,
+    writer,
+    target,
+    ctx,
+    verbose,
+    sourceAwareDependencyCache
+  } = opts;
   const src = sources[entry.sourceId];
   if (src === undefined) {
     return handleMissingSource(bundleId, entry, verbose, ctx);
   }
 
   try {
-    const files = await fetchFilesForSource(src, bundleId, entry, http, tokens, ctx, verbose);
+    const files = await fetchFilesForSource(
+      src,
+      bundleId,
+      entry,
+      http,
+      tokens,
+      ctx,
+      verbose,
+      sourceAwareDependencyCache
+    );
     if (files === null) {
       return handleFetchFailure(bundleId, src, verbose, ctx);
     }
@@ -1313,6 +1512,7 @@ function handleInstallError(
  * @param tokens Token provider.
  * @param ctx CLI context.
  * @param verbose Whether to write `[verbose]` progress lines to stdout.
+ * @param sourceAwareDependencyCache Optional command-scoped source-aware cache.
  * @returns The extracted files, or `null` if the bundle couldn't be resolved/fetched.
  */
 export async function fetchFilesForSource(
@@ -1322,7 +1522,8 @@ export async function fetchFilesForSource(
   http: HttpClient,
   tokens: TokenProvider,
   ctx: Context,
-  verbose: boolean
+  verbose: boolean,
+  sourceAwareDependencyCache?: SourceAwareInstallDependencyCache
 ): Promise<Map<string, Uint8Array> | null> {
   if (src.type === 'local') {
     if (verbose) {
@@ -1331,11 +1532,39 @@ export async function fetchFilesForSource(
     const files = await readLocalBundle(src.url, ctx.fs);
     return new Map(files);
   }
-  if (src.type === 'github') {
-    const githubApi = githubApiFor(http, tokens);
+  if (src.type === 'github' || src.type === 'skills' || src.type === 'awesome-copilot') {
     // Check if this is an awesome-copilot source (detected by sourceId prefix)
-    const isAwesomeCopilot = bundleId.startsWith('awesome-copilot-') || entry.sourceId.startsWith('awesome-copilot-');
-    const repoSlug = src.url.replace(/^https?:\/\/github\.com\//, '');
+    const isAwesomeCopilot = src.type === 'awesome-copilot'
+      || bundleId.startsWith('awesome-copilot-')
+      || entry.sourceId.startsWith('awesome-copilot-');
+    const sourceConfig: RegistrySource = {
+      id: entry.sourceId,
+      name: entry.sourceId,
+      type: isAwesomeCopilot ? 'awesome-copilot' : (src.type === 'skills' ? 'skills' : 'github'),
+      url: src.url,
+      enabled: true,
+      priority: 0,
+      config: {
+        branch: src.branch,
+        collectionsPath: src.collectionsPath
+      }
+    };
+    const repoSlug = extractRepoSlug(src.url);
+    let githubApi: GitHubApi;
+    let downloadTokens = tokens;
+    let repositoryTarget: GitHubRepositoryTarget | undefined;
+    let authenticationCategory: Exclude<GitHubSourceAuthCategory, 'unresolved'> | undefined;
+    if (isGitHubAppAuthEnabled(ctx.env)) {
+      const dependencies = sourceAwareDependencyCache === undefined
+        ? await sourceAwareInstallDependencies(repoSlug, sourceConfig, http, ctx)
+        : await sourceAwareDependencyCache.get(repoSlug, sourceConfig);
+      githubApi = dependencies.githubApi;
+      downloadTokens = dependencies.downloadTokens;
+      repositoryTarget = dependencies.repositoryTarget;
+      authenticationCategory = dependencies.authenticationCategory;
+    } else {
+      githubApi = githubApiFor(http, tokens);
+    }
     if (verbose) {
       ctx.stdout.write(`[verbose] Resolving ${bundleId}@${entry.version} from ${repoSlug} (${isAwesomeCopilot ? 'awesome-copilot' : 'github'})\n`);
     }
@@ -1362,7 +1591,7 @@ export async function fetchFilesForSource(
 
     // Use GitHub resolver for regular github sources
     const resolver = new GitHubBundleResolver({ repoSlug, githubApi });
-    const downloader = new HttpsBundleDownloader(http, tokens);
+    const downloader = new HttpsBundleDownloader(http, downloadTokens, repositoryTarget, authenticationCategory);
     const installable = await resolver.resolve({ bundleId, bundleVersion: entry.version });
     if (installable === null) {
       if (verbose) {

--- a/packages/cli/src/commands/profile.ts
+++ b/packages/cli/src/commands/profile.ts
@@ -52,6 +52,7 @@ import {
   validateManifest,
 } from '@ai-primitives-hub/core';
 import {
+  isGitHubAppAuthEnabled,
   ProfileActivationStore,
 } from '@ai-primitives-hub/infra';
 import * as yaml from 'js-yaml';
@@ -73,8 +74,10 @@ import {
   RegistryError,
 } from '../framework';
 import {
+  createSourceAwareInstallDependencyCache,
   createWriterFactory,
   fetchFilesForSource,
+  type SourceAwareInstallDependencyCache,
 } from './install';
 import {
   createWriterFactory as createUninstallWriterFactory,
@@ -351,6 +354,7 @@ type ActivateBundleOutcome =
  * @param http HTTP client.
  * @param tokens Token provider.
  * @param ctx CLI context.
+ * @param sourceAwareDependencyCache
  * @returns The written files and lockfile entries on success, or a failure reason.
  */
 async function activateBundleForTarget(
@@ -360,7 +364,8 @@ async function activateBundleForTarget(
   writer: TargetWriter,
   http: HttpClient,
   tokens: TokenProvider,
-  ctx: Context
+  ctx: Context,
+  sourceAwareDependencyCache?: SourceAwareInstallDependencyCache
 ): Promise<ActivateBundleOutcome> {
   const src = sources[bundleRef.source];
   if (!src) {
@@ -383,7 +388,16 @@ async function activateBundleForTarget(
     files: []
   };
   try {
-    const files = await fetchFilesForSource(sourceEntry, bundleRef.id, probeEntry, http, tokens, ctx, false);
+    const files = await fetchFilesForSource(
+      sourceEntry,
+      bundleRef.id,
+      probeEntry,
+      http,
+      tokens,
+      ctx,
+      false,
+      sourceAwareDependencyCache
+    );
     if (files === null) {
       return { ok: false, reason: 'failed to fetch bundle files' };
     }
@@ -502,6 +516,9 @@ export async function runProfileActivation(
   const syncedBundleVersions: Record<string, string> = {};
   const failures: { bundleId: string; target: string; reason: string }[] = [];
   const writtenByTarget: Record<string, string[]> = {};
+  const sourceAwareDependencyCache = isGitHubAppAuthEnabled(ctx.env)
+    ? createSourceAwareInstallDependencyCache(built.http, ctx)
+    : undefined;
 
   for (const target of effectiveTargets) {
     const writer = createWriterFactory(ctx, {})(target);
@@ -510,7 +527,16 @@ export async function runProfileActivation(
     let lock: Lockfile = await readLockfile(lockPath, ctx.fs) ?? emptyLockfile('ai-primitives-hub-cli');
 
     for (const bundleRef of profile.bundles) {
-      const outcome = await activateBundleForTarget(bundleRef, sources, target, writer, built.http, built.tokens, ctx);
+      const outcome = await activateBundleForTarget(
+        bundleRef,
+        sources,
+        target,
+        writer,
+        built.http,
+        built.tokens,
+        ctx,
+        sourceAwareDependencyCache
+      );
       if (!outcome.ok) {
         failures.push({ bundleId: bundleRef.id, target: target.name, reason: outcome.reason });
         continue;

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -26,7 +26,11 @@ import {
   writeTargetSafely,
 } from '@ai-primitives-hub/app';
 import type {
+  GitHubApi,
+  GitHubRepositoryTarget,
+  GitHubSourceAuthCategory,
   HttpClient,
+  HubSourceSpec,
   Installable,
   RegistrySource,
   SourceType,
@@ -39,17 +43,21 @@ import {
 } from '@ai-primitives-hub/core';
 import {
   ActiveHubStore,
+  createGitHubSourceAuthRuntime,
   defaultTokenProvider,
   FileSystemLayoutConfigLoader,
   GitHubApiClient,
   HttpsBundleDownloader,
+  isGitHubAppAuthEnabled,
   NodeHttpClient,
+  parseGitHubRepositoryTarget,
   readTargets,
   type RepositoryCommitMode,
   RepositoryScopeWriter,
   RepositoryScopeWriterAdapter,
   resolveUserConfigDir,
   SourceDispatcher,
+  StaticTokenProvider,
   TargetStateStore,
   ZipBundleExtractor,
 } from '@ai-primitives-hub/infra';
@@ -105,6 +113,9 @@ interface UpdateCandidate {
   from: string;
   to: string;
   installable: Installable;
+  repositoryTarget?: GitHubRepositoryTarget;
+  authenticationCategory?: Exclude<GitHubSourceAuthCategory, 'unresolved'>;
+  downloadTokens?: TokenProvider;
 }
 
 interface UpdateContext {
@@ -320,6 +331,57 @@ function toRegistrySource(sourceId: string, src: LockfileSourceEntry): RegistryS
   };
 }
 
+function toHarvestSourceSpec(sourceId: string, src: LockfileSourceEntry): HubSourceSpec {
+  const target = parseGitHubRepositoryTarget(src.url);
+  const type = src.type === 'awesome-copilot' ? 'awesome-copilot' : 'github';
+  return {
+    id: sourceId,
+    name: sourceId,
+    type,
+    url: src.url,
+    owner: target.owner,
+    repo: target.repository,
+    branch: src.branch ?? 'main',
+    ...(type === 'awesome-copilot'
+      ? { collectionsPath: src.collectionsPath ?? 'collections' }
+      : {}),
+    rawConfig: {
+      branch: src.branch,
+      collectionsPath: src.collectionsPath
+    }
+  };
+}
+
+interface SourceAwareUpdateDependencies {
+  githubApi: GitHubApi;
+  repositoryTarget: GitHubRepositoryTarget;
+  authenticationCategory: Exclude<GitHubSourceAuthCategory, 'unresolved'>;
+  downloadTokens: TokenProvider;
+}
+
+async function sourceAwareUpdateDependencies(
+  sourceId: string,
+  src: LockfileSourceEntry,
+  ctx: Context,
+  http: HttpClient
+): Promise<SourceAwareUpdateDependencies> {
+  const runtime = createGitHubSourceAuthRuntime({ env: ctx.env, http });
+  const report = await runtime.preflight([toHarvestSourceSpec(sourceId, src)], {
+    includeReleases: src.type === 'github',
+    onLog: (message) => ctx.stderr.write(`[github preflight] ${message}\n`)
+  });
+  const decision = report.results[0];
+  if (!report.valid || decision === undefined || decision.category === 'unresolved' || decision.target === undefined) {
+    throw new Error(`GitHub source preflight failed for ${sourceId}: ${decision?.errorCode ?? 'GH_SOURCE_PREFLIGHT_UNRESOLVED'}`);
+  }
+  return {
+    githubApi: runtime.clientFor(decision.target, decision.category),
+    repositoryTarget: decision.target,
+    authenticationCategory: decision.category,
+    downloadTokens: runtime.tokenProviderFor(decision.category) ?? new StaticTokenProvider('')
+  };
+}
+
 async function findUpdateCandidates(
   bundleIds: string[],
   lock: Lockfile,
@@ -329,14 +391,26 @@ async function findUpdateCandidates(
 ): Promise<{ candidates: UpdateCandidate[]; skipped: string[] }> {
   const candidates: UpdateCandidate[] = [];
   const skipped: string[] = [];
+  const sourceAware = isGitHubAppAuthEnabled(ctx.env);
   const githubApi = new GitHubApiClient(http, { tokenProvider: tokens });
   const dispatcher = new SourceDispatcher({ githubApi, fs: ctx.fs });
+  const sourceDependencies = new Map<string, SourceAwareUpdateDependencies>();
 
   for (const bundleId of bundleIds) {
     const entry = lock.bundles[bundleId];
     const src = lock.sources[entry.sourceId];
     try {
-      const resolver = dispatcher.resolverFor(toRegistrySource(entry.sourceId, src));
+      let resolverDispatcher = dispatcher;
+      let dependencies: SourceAwareUpdateDependencies | undefined;
+      if (sourceAware) {
+        dependencies = sourceDependencies.get(entry.sourceId);
+        if (dependencies === undefined) {
+          dependencies = await sourceAwareUpdateDependencies(entry.sourceId, src, ctx, http);
+          sourceDependencies.set(entry.sourceId, dependencies);
+        }
+        resolverDispatcher = new SourceDispatcher({ githubApi: dependencies.githubApi, fs: ctx.fs });
+      }
+      const resolver = resolverDispatcher.resolverFor(toRegistrySource(entry.sourceId, src));
       if (resolver === null) {
         skipped.push(bundleId);
         continue;
@@ -348,9 +422,22 @@ async function findUpdateCandidates(
       }
       const latestVersion = installable.ref.bundleVersion;
       if (isNewerVersion(latestVersion, entry.version)) {
-        candidates.push({ bundleId, entry, source: src, from: entry.version, to: latestVersion, installable });
+        candidates.push({
+          bundleId,
+          entry,
+          source: src,
+          from: entry.version,
+          to: latestVersion,
+          installable,
+          repositoryTarget: dependencies?.repositoryTarget,
+          authenticationCategory: dependencies?.authenticationCategory,
+          downloadTokens: dependencies?.downloadTokens
+        });
       }
-    } catch {
+    } catch (error) {
+      if (sourceAware && error instanceof Error && error.message.startsWith('GitHub source preflight failed')) {
+        throw error;
+      }
       skipped.push(bundleId);
     }
   }
@@ -487,7 +574,12 @@ async function applyUpdate(
   http: HttpClient,
   tokens: TokenProvider
 ): Promise<void> {
-  const downloader = new HttpsBundleDownloader(http, tokens);
+  const downloader = new HttpsBundleDownloader(
+    http,
+    candidate.downloadTokens ?? tokens,
+    candidate.repositoryTarget,
+    candidate.authenticationCategory
+  );
   const extractor = new ZipBundleExtractor();
 
   const dl = await downloader.download(candidate.installable);

--- a/packages/cli/src/framework/hub-manager.ts
+++ b/packages/cli/src/framework/hub-manager.ts
@@ -27,10 +27,12 @@ import type {
 import {
   ActiveHubStore,
   CompositeHubResolver,
+  createGitHubSourceAuthRuntime,
   EnvTokenProvider,
   FavoritesStore,
   GitHubHubResolver,
   HubStore,
+  isGitHubAppAuthEnabled,
   LocalHubResolver,
   NodeHttpClient,
   UrlHubResolver,
@@ -72,8 +74,18 @@ export const createHubManager = (opts: CreateHubManagerOptions): HubManager => {
   const { ctx, http, tokens } = opts;
   const paths = resolveUserConfigPaths(ctx.env);
   const [httpClient, tokenProvider] = createHttpClientAndTokens(http, ctx, tokens);
+  const sourceAuth = isGitHubAppAuthEnabled(ctx.env)
+    ? createGitHubSourceAuthRuntime({ env: ctx.env, http: httpClient })
+    : undefined;
   const resolver = new CompositeHubResolver(
-    new GitHubHubResolver(httpClient, tokenProvider),
+    new GitHubHubResolver(httpClient, tokenProvider, sourceAuth === undefined
+      ? undefined
+      : {
+        sourceAware: {
+          genericTokenProvider: sourceAuth.genericTokenProvider,
+          appTokenProvider: sourceAuth.appTokenProvider
+        }
+      }),
     new LocalHubResolver(ctx.fs),
     new UrlHubResolver(httpClient, tokenProvider)
   );

--- a/packages/cli/test/commands/hub.test.ts
+++ b/packages/cli/test/commands/hub.test.ts
@@ -15,6 +15,11 @@ import {
 } from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import type {
+  HttpClient,
+  HttpRequest,
+  HttpResponse,
+} from '@ai-primitives-hub/core';
 import {
   NodeFileSystem,
 } from '@ai-primitives-hub/infra';
@@ -36,6 +41,8 @@ import {
   HubValidateCommand,
 } from '../../src/commands/hub';
 import {
+  createTestContext,
+  runCli,
   runCommand,
 } from '../../src/framework';
 
@@ -73,6 +80,31 @@ describe('hub commands', () => {
       }
     }
   });
+
+  const runWithHttp = async (argv: string[], http: HttpClient, env: Record<string, string>): Promise<{
+    exitCode: number;
+    stdout: string;
+    stderr: string;
+  }> => {
+    const ctx = createTestContext({
+      cwd: workspace,
+      fs: new NodeFileSystem(),
+      env
+    });
+    const exitCode = await runCli(argv, {
+      ctx,
+      commandClasses: COMMAND_CLASSES,
+      commands: [],
+      name: 'ai-primitives-hub',
+      version: '0.0.0-test',
+      http
+    });
+    return {
+      exitCode,
+      stdout: ctx.stdout.captured(),
+      stderr: ctx.stderr.captured()
+    };
+  };
 
   const parseJson = <T>(stdout: string): JsonEnvelope<T> => JSON.parse(stdout) as JsonEnvelope<T>;
 
@@ -400,6 +432,76 @@ profiles:
       expect(envelope.data).toMatchObject({ valid: true });
       expect(envelope.data.deep).toBeUndefined();
       expect(result.stderr).toContain('--verbose has no effect without --check-sources');
+    });
+
+    it('returns the complete source preflight report when source-aware validation fails', async () => {
+      await writeFile(
+        hubConfigFile,
+        `version: 1.0.0
+metadata:
+  name: Test Hub
+  description: Test hub
+  maintainer: test
+  updatedAt: '2026-01-01T00:00:00Z'
+sources:
+  - id: private-source
+    name: Private Source
+    type: github
+    url: https://github.com/example-org/example-repository
+    enabled: true
+    priority: 1
+profiles: []
+`
+      );
+      const http: HttpClient = {
+        fetch: async (request: HttpRequest): Promise<HttpResponse> => ({
+          statusCode: 404,
+          body: new TextEncoder().encode('{}'),
+          finalUrl: request.url,
+          headers: {}
+        })
+      };
+
+      const result = await runWithHttp(
+        ['hub', 'validate', '--config', 'hub-config.yml', '--check-sources', '-o', 'json'],
+        http,
+        {
+          AI_PRIMITIVES_HUB_GH_APP_AUTH_ENABLED: 'true',
+          GH_TOKEN: 'test-generic-token'
+        }
+      );
+
+      expect(result.exitCode).toBe(1);
+      const envelope = parseJson<{
+        valid: boolean;
+        sourcePreflight: {
+          valid: boolean;
+          appRoutes: string[];
+          results: {
+            sourceId: string;
+            category: string;
+            errorCode?: string;
+            operations: string[];
+          }[];
+        };
+      }>(result.stdout);
+      expect(envelope.data.valid).toBe(false);
+      expect(envelope.data.sourcePreflight).toEqual({
+        valid: false,
+        appRoutes: ['github.com/example-org/*'],
+        results: [{
+          sourceId: 'private-source',
+          target: {
+            host: 'github.com',
+            owner: 'example-org',
+            repository: 'example-repository'
+          },
+          category: 'unresolved',
+          operations: ['repository metadata'],
+          credentialMode: 'none',
+          errorCode: 'GH_APP_AUTH_CONFIG_MISSING'
+        }]
+      });
     });
   });
 

--- a/packages/cli/test/commands/index.test.ts
+++ b/packages/cli/test/commands/index.test.ts
@@ -430,5 +430,20 @@ describe('index commands', () => {
       const envelope = parseJson<{ totals: { done: number; error: number } }>(result.stdout);
       expect(envelope.data.totals).toMatchObject({ done: 0, error: 0 });
     });
+
+    it('accepts App bootstrap inputs for an empty offline scope', async () => {
+      const result = await run([
+        'index', 'harvest', '--no-hub-config',
+        '--github-app-id', '123',
+        '--github-app-key-file', '/tmp/app-key.pem',
+        '--out-file', path.join(workspace, 'app-harvest-index.json'),
+        '--progress-file', path.join(workspace, 'app-harvest-progress.jsonl'),
+        '--cache-dir', path.join(workspace, 'app-harvest-cache'),
+        '-o', 'json'
+      ]);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ tokenSource: string }>(result.stdout);
+      expect(envelope.data.tokenSource).toBe('source-aware');
+    });
   });
 });

--- a/packages/cli/test/commands/install.test.ts
+++ b/packages/cli/test/commands/install.test.ts
@@ -30,8 +30,10 @@ import {
   describe,
   expect,
   it,
+  vi,
 } from 'vitest';
 import {
+  createSourceAwareInstallDependencyCache,
   installBundleWithSource,
   InstallCommand,
 } from '../../src/commands/install';
@@ -78,6 +80,46 @@ describe('install command (local --from mode)', () => {
   });
 
   const parseJson = <T>(stdout: string): JsonEnvelope<T> => JSON.parse(stdout) as JsonEnvelope<T>;
+
+  it('shares source-aware dependencies for repeated bundle requests', async () => {
+    const target = { host: 'github.com', owner: 'owner', repository: 'repo' };
+    const preflight = vi.fn(async () => ({
+      valid: true,
+      results: [{
+        sourceId: 'source',
+        target,
+        category: 'public-generic' as const,
+        operations: ['repository metadata'],
+        credentialMode: 'generic' as const
+      }],
+      appRoutes: []
+    }));
+    const clientFor = vi.fn(() => ({}) as import('@ai-primitives-hub/core').GitHubApi);
+    const tokenProviderFor = vi.fn(() => ({ getToken: async () => 'generic-token' }));
+    const runtime = {
+      preflight,
+      clientFor,
+      tokenProviderFor
+    } as unknown as import('@ai-primitives-hub/infra').GitHubSourceAuthRuntime;
+    const ctx = createTestContext({ cwd: workspace });
+    const sourceConfig: RegistrySource = {
+      id: 'source',
+      name: 'Source',
+      type: 'github',
+      url: 'https://github.com/owner/repo',
+      enabled: true,
+      priority: 0
+    };
+    const cache = createSourceAwareInstallDependencyCache({} as HttpClient, ctx, runtime);
+
+    const first = await cache.get('owner/repo', sourceConfig);
+    const second = await cache.get('owner/repo', sourceConfig);
+
+    expect(first).toBe(second);
+    expect(preflight).toHaveBeenCalledTimes(1);
+    expect(clientFor).toHaveBeenCalledTimes(1);
+    expect(tokenProviderFor).toHaveBeenCalledTimes(1);
+  });
 
   beforeEach(async () => {
     workspace = await mkdtemp(path.join(os.tmpdir(), 'cli-install-test-'));
@@ -406,5 +448,90 @@ describe('install command (local --from mode)', () => {
     ).resolves.toContain('Hello Prompt');
     await expect(readFile(path.join(workspace, '.github', 'README.md'), 'utf8')).rejects.toThrow();
     await expect(readFile(path.join(workspace, '.github', 'LICENSE'), 'utf8')).rejects.toThrow();
+  });
+
+  it('preflights a remote source before an opt-in authenticated install', async () => {
+    const zipBytes = buildZip([
+      {
+        path: 'deployment-manifest.yml',
+        bytes: new TextEncoder().encode(
+          'id: remote-preflight\nversion: 1.0.0\nname: Remote Preflight\nprompts:\n'
+          + '  - id: hello\n    file: prompts/hello.prompt.md\n    type: prompt\n'
+        )
+      },
+      {
+        path: 'prompts/hello.prompt.md',
+        bytes: new TextEncoder().encode('# Hello from a preflighted bundle\n')
+      }
+    ]);
+    const http: HttpClient = {
+      fetch: async (request: HttpRequest): Promise<HttpResponse> => {
+        if (request.url === 'https://api.github.com/repos/owner/repo') {
+          return { statusCode: 200, body: new TextEncoder().encode('{"private":false}'), finalUrl: request.url, headers: {} };
+        }
+        if (request.url === 'https://api.github.com/repos/owner/repo/commits/main') {
+          return { statusCode: 200, body: new TextEncoder().encode('{"sha":"preflight-sha"}'), finalUrl: request.url, headers: {} };
+        }
+        if (request.url === 'https://api.github.com/repos/owner/repo/git/trees/main?recursive=1') {
+          return { statusCode: 200, body: new TextEncoder().encode('{"tree":[],"truncated":false}'), finalUrl: request.url, headers: {} };
+        }
+        if (request.url === 'https://api.github.com/repos/owner/repo/releases') {
+          return {
+            statusCode: 200,
+            body: new TextEncoder().encode(JSON.stringify([{
+              tag_name: 'remote-preflight-v1.0.0',
+              assets: [{ name: 'bundle.zip', url: 'https://api.github.com/assets/remote-preflight' }]
+            }])),
+            finalUrl: request.url,
+            headers: {}
+          };
+        }
+        if (request.url === 'https://api.github.com/assets/remote-preflight') {
+          return { statusCode: 200, body: zipBytes, finalUrl: request.url, headers: {} };
+        }
+        throw new Error(`Unexpected request: ${request.url}`);
+      }
+    };
+    const source: RegistrySource = {
+      id: 'github-source',
+      name: 'GitHub source',
+      type: 'github',
+      url: 'https://github.com/owner/repo',
+      enabled: true,
+      priority: 0
+    };
+    const target: Target = {
+      name: 'repository-copilot',
+      type: 'copilot-cli',
+      scope: 'repository',
+      rootPath: workspace
+    };
+    const ctx = createTestContext({
+      cwd: workspace,
+      fs: new NodeFileSystem(),
+      env: {
+        HOME: workspace,
+        USERPROFILE: workspace,
+        XDG_CONFIG_HOME: path.join(workspace, 'xdg-config'),
+        XDG_CACHE_HOME: path.join(workspace, 'xdg-cache'),
+        AI_PRIMITIVES_HUB_GH_APP_AUTH_ENABLED: 'true',
+        GH_TOKEN: 'generic-token'
+      }
+    });
+
+    const result = await installBundleWithSource(
+      'remote-preflight',
+      source,
+      target,
+      ctx,
+      http,
+      { getToken: async () => 'must-not-be-used' },
+      'json'
+    );
+
+    expect(result).toBe(0);
+    await expect(
+      readFile(path.join(workspace, '.github', 'copilot', 'prompts', 'hello.prompt.md'), 'utf8')
+    ).resolves.toContain('preflighted bundle');
   });
 });

--- a/packages/cli/test/framework/hub-manager.test.ts
+++ b/packages/cli/test/framework/hub-manager.test.ts
@@ -57,6 +57,48 @@ describe('createHubManager', () => {
     const mgr = createHubManager({ ctx, http, tokens });
     expect(mgr).toBeDefined();
   });
+
+  it('uses the source-aware generic credential instead of the injected legacy token', async () => {
+    let tokenCalls = 0;
+    const http = {
+      fetch: async (request: { url: string; headers?: Record<string, string> }) => {
+        expect(request.headers?.Authorization).toBe('token generic-token');
+        return {
+          statusCode: 200,
+          body: new TextEncoder().encode(`version: 1.0.0
+metadata:
+  name: Test Hub
+  description: Test
+  maintainer: Test
+  updatedAt: '2026-01-01T00:00:00Z'
+sources: []
+profiles: []
+`),
+          finalUrl: request.url,
+          headers: {}
+        };
+      }
+    } as unknown as import('@ai-primitives-hub/core').HttpClient;
+    const tokens = {
+      getToken: async () => {
+        tokenCalls += 1;
+        return 'must-not-be-used';
+      }
+    } as unknown as import('@ai-primitives-hub/core').TokenProvider;
+    const ctx = createTestContext({
+      fs: new NodeFileSystem(),
+      env: {
+        XDG_CONFIG_HOME: path.join(workspace, '.config'),
+        AI_PRIMITIVES_HUB_GH_APP_AUTH_ENABLED: 'true',
+        GH_TOKEN: 'generic-token'
+      }
+    });
+    const mgr = createHubManager({ ctx, http, tokens });
+
+    await mgr.importHub({ type: 'github', location: 'owner/repo' }, 'public-hub');
+
+    expect(tokenCalls).toBe(0);
+  });
 });
 
 describe('createHttpClientAndTokens', () => {

--- a/packages/core/src/domain/hub/types.ts
+++ b/packages/core/src/domain/hub/types.ts
@@ -237,7 +237,7 @@ export interface PluginManifest {
  * shape (extends `RegistrySource`, tracks `enabled`/`priority` for the
  * extension's registry sync). `HubSourceSpec` is the *harvester's* own
  * narrower, GitHub-specific shape — owner/repo already split out, a
- * closed `type` union of only the three source kinds the harvester
+ * closed `type` union of the remote source kinds the harvester/preflight
  * walks. The two are populated from the same `hub-config.yml`, by two
  * different parsers, for two different consumers.
  */
@@ -246,8 +246,8 @@ export interface HubSourceSpec {
   id: string;
   /** Human-readable name; defaults to the config `id` or the repo segment. */
   name: string;
-  /** Source type tag; only the three listed types are wired today. */
-  type: 'github' | 'awesome-copilot' | 'awesome-copilot-plugin';
+  /** Source type tag for a supported remote GitHub-backed source family. */
+  type: 'github' | 'awesome-copilot' | 'awesome-copilot-plugin' | 'skills' | 'apm';
   /** Original config URL string (used for diagnostics / display). */
   url: string;
   /** GitHub owner segment derived from `url`. */

--- a/packages/core/src/domain/index.ts
+++ b/packages/core/src/domain/index.ts
@@ -14,6 +14,8 @@ export * from './discovery/types';
 export * from './errors';
 export * from './registry-error';
 export * from './source/types';
+export * from './source/github-repository-target';
+export * from './source/github-source-authentication';
 export * from './source-id';
 export * from './install/types';
 export * from './install/target';

--- a/packages/core/src/domain/source/github-repository-target.ts
+++ b/packages/core/src/domain/source/github-repository-target.ts
@@ -1,0 +1,15 @@
+/**
+ * Canonical repository context for a GitHub-backed source.
+ *
+ * The request host and repository host are intentionally separate: a request
+ * can target `api.github.com` or `raw.githubusercontent.com` while a
+ * repository-scoped credential must still be minted for `github.com/owner/repository`.
+ */
+export interface GitHubRepositoryTarget {
+  /** Host used when addressing the repository for authentication purposes. */
+  host: string;
+  /** Repository owner or organization. */
+  owner: string;
+  /** Repository name. */
+  repository: string;
+}

--- a/packages/core/src/domain/source/github-source-authentication.ts
+++ b/packages/core/src/domain/source/github-source-authentication.ts
@@ -1,0 +1,9 @@
+/**
+ * Source-level authentication outcomes produced by GitHub preflight.
+ * @module domain/source/github-source-authentication
+ */
+export type GitHubSourceAuthCategory =
+  | 'public-anonymous'
+  | 'public-generic'
+  | 'app-authenticated'
+  | 'unresolved';

--- a/packages/core/src/ports/http.ts
+++ b/packages/core/src/ports/http.ts
@@ -7,6 +7,9 @@
  * (`@ai-primitives-hub/infra`, Phase 3) wraps the real HTTP client.
  * @module ports/http
  */
+import type {
+  GitHubRepositoryTarget,
+} from '../domain/source/github-repository-target';
 
 export interface HttpResponse {
   /** Status code after redirect handling. */
@@ -57,5 +60,5 @@ export interface HttpClient {
  * needing its own retry-on-401 logic.
  */
 export interface TokenProvider {
-  getToken(host: string): Promise<string | undefined>;
+  getToken(host: string, repositoryTarget?: GitHubRepositoryTarget): Promise<string | undefined>;
 }

--- a/packages/core/src/ports/index.ts
+++ b/packages/core/src/ports/index.ts
@@ -12,6 +12,7 @@ export * from './http';
 export * from './github-api';
 export * from './azure-devops-api';
 export * from './process-runner';
+export * from './process-executor';
 export * from './bundle-extractor';
 export * from './target-writer';
 export * from './layout-config-loader';

--- a/packages/core/src/ports/process-executor.ts
+++ b/packages/core/src/ports/process-executor.ts
@@ -1,0 +1,20 @@
+/**
+ * Argv-safe process-execution port for external CLI integrations.
+ *
+ * Unlike `ProcessRunner`, this port never accepts a shell command string.
+ * Callers provide the executable and arguments separately so values such as
+ * repository names cannot be interpreted as shell syntax.
+ * @module ports/process-executor
+ */
+import type {
+  ProcessResult,
+  ProcessRunOptions,
+} from './process-runner';
+
+export interface ProcessExecutor {
+  execFile(
+    file: string,
+    args: readonly string[],
+    options?: ProcessRunOptions
+  ): Promise<ProcessResult>;
+}

--- a/packages/core/test/ports/http.test.ts
+++ b/packages/core/test/ports/http.test.ts
@@ -1,0 +1,33 @@
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import type {
+  GitHubRepositoryTarget,
+  TokenProvider,
+} from '../../src';
+
+describe('TokenProvider repository context', () => {
+  it('accepts an optional repository target without changing the request host', async () => {
+    const target: GitHubRepositoryTarget = {
+      host: 'github.com',
+      owner: 'owner',
+      repository: 'repo'
+    };
+    let receivedHost: string | undefined;
+    let receivedTarget: GitHubRepositoryTarget | undefined;
+    const provider: TokenProvider = {
+      getToken: async (host, repositoryTarget) => {
+        receivedHost = host;
+        receivedTarget = repositoryTarget;
+        return undefined;
+      }
+    };
+
+    await provider.getToken('raw.githubusercontent.com', target);
+
+    expect(receivedHost).toBe('raw.githubusercontent.com');
+    expect(receivedTarget).toEqual(target);
+  });
+});

--- a/packages/infra/src/adapters/apm-adapter.ts
+++ b/packages/infra/src/adapters/apm-adapter.ts
@@ -51,6 +51,7 @@ import type {
   Clock,
   FileSystem,
   GitHubApi,
+  GitHubRepositoryTarget,
   ProcessRunner,
   RegistrySource,
   SourceMetadata,
@@ -425,7 +426,13 @@ export class ApmAdapter extends BaseSourceAdapter {
 
     const status = await this.getRuntimeStatus();
     const commandPrefix = status.installed ? 'apm' : 'uvx apm';
-    const token = await this.tokenProvider?.getToken('github.com');
+    const { owner, repo } = this.parseGitHubUrl();
+    const repositoryTarget: GitHubRepositoryTarget = {
+      host: 'github.com',
+      owner,
+      repository: repo
+    };
+    const token = await this.tokenProvider?.getToken('github.com', repositoryTarget);
 
     try {
       await this.processRunner.exec(`${commandPrefix} install`, {

--- a/packages/infra/src/auth/composite-token-provider.ts
+++ b/packages/infra/src/auth/composite-token-provider.ts
@@ -18,15 +18,16 @@
  * @module auth/composite-token-provider
  */
 import type {
+  GitHubRepositoryTarget,
   TokenProvider,
 } from '@ai-primitives-hub/core';
 
 export class CompositeTokenProvider implements TokenProvider {
   public constructor(private readonly providers: readonly TokenProvider[]) {}
 
-  public async getToken(host: string): Promise<string | undefined> {
+  public async getToken(host: string, target?: GitHubRepositoryTarget): Promise<string | undefined> {
     for (const provider of this.providers) {
-      const token = await provider.getToken(host);
+      const token = await provider.getToken(host, target);
       if (token !== undefined) {
         return token;
       }

--- a/packages/infra/src/auth/generic-public-token-provider.ts
+++ b/packages/infra/src/auth/generic-public-token-provider.ts
@@ -1,0 +1,78 @@
+/**
+ * Generic public-read credentials for sources already proven public by
+ * preflight.
+ *
+ * This provider is intentionally separate from the repository-scoped App
+ * provider. It prefers CI credentials (`GH_TOKEN`, then `GITHUB_TOKEN`) and
+ * may use the local personal `gh auth token` lookup only outside CI.
+ * @module auth/generic-public-token-provider
+ */
+import type {
+  TokenProvider,
+} from '@ai-primitives-hub/core';
+import {
+  isGitHubHost,
+} from '../http/github-host';
+import {
+  GhCliTokenProvider,
+} from './gh-cli-token-provider';
+
+export interface GenericPublicTokenProviderOptions {
+  env: Readonly<Record<string, string | undefined>>;
+  /** Injectable local `gh auth token` provider. */
+  ghCli?: TokenProvider;
+  /** Override automatic CI detection for controlled callers/tests. */
+  allowGhCli?: boolean;
+}
+
+const isCi = (env: Readonly<Record<string, string | undefined>>): boolean =>
+  env.CI === 'true' || env.CI === '1';
+
+export class GenericPublicTokenProvider implements TokenProvider {
+  private readonly ghCli: TokenProvider;
+  private readonly allowGhCli: boolean;
+  private readonly cachedTokens = new Map<string, string | undefined>();
+  private readonly inFlight = new Map<string, Promise<string | undefined>>();
+
+  public constructor(private readonly options: GenericPublicTokenProviderOptions) {
+    this.ghCli = options.ghCli ?? new GhCliTokenProvider();
+    this.allowGhCli = options.allowGhCli ?? !isCi(options.env);
+  }
+
+  public async getToken(host: string): Promise<string | undefined> {
+    const normalizedHost = host.toLowerCase();
+    if (!isGitHubHost(normalizedHost)) {
+      return undefined;
+    }
+    const fromGhToken = this.options.env.GH_TOKEN;
+    if (fromGhToken !== undefined && fromGhToken.length > 0) {
+      return fromGhToken;
+    }
+    const fromGitHubToken = this.options.env.GITHUB_TOKEN;
+    if (fromGitHubToken !== undefined && fromGitHubToken.length > 0) {
+      return fromGitHubToken;
+    }
+    if (!this.allowGhCli) {
+      return undefined;
+    }
+    if (this.cachedTokens.has(normalizedHost)) {
+      return this.cachedTokens.get(normalizedHost);
+    }
+    const existing = this.inFlight.get(normalizedHost);
+    if (existing !== undefined) {
+      return existing;
+    }
+    const lookup = this.ghCli.getToken(normalizedHost).then((token) => {
+      this.cachedTokens.set(normalizedHost, token);
+      return token;
+    });
+    this.inFlight.set(normalizedHost, lookup);
+    try {
+      return await lookup;
+    } finally {
+      if (this.inFlight.get(normalizedHost) === lookup) {
+        this.inFlight.delete(normalizedHost);
+      }
+    }
+  }
+}

--- a/packages/infra/src/auth/gh-app-auth-setup-manager.ts
+++ b/packages/infra/src/auth/gh-app-auth-setup-manager.ts
@@ -1,0 +1,162 @@
+/**
+ * Explicit bootstrap boundary for `gh app-auth setup`.
+ *
+ * Runtime token lookup never calls this manager. A caller must deliberately
+ * provide routes and the private-key input before invoking setup.
+ * @module auth/gh-app-auth-setup-manager
+ */
+import type {
+  ProcessExecutor,
+} from '@ai-primitives-hub/core';
+import {
+  NodeProcessExecutor,
+} from '../process/node-process-executor';
+
+export type GhAppAuthSetupErrorCode =
+  | 'GH_APP_AUTH_SETUP_SELECTOR_INVALID'
+  | 'GH_APP_AUTH_SETUP_CONFIG_MISSING'
+  | 'GH_APP_AUTH_SETUP_ROUTES_MISSING'
+  | 'GH_APP_AUTH_SETUP_KEY_MISSING'
+  | 'GH_APP_AUTH_SETUP_FAILED'
+  | 'GH_APP_AUTH_SETUP_TIMEOUT';
+
+export class GhAppAuthSetupError extends Error {
+  public constructor(
+    public readonly code: GhAppAuthSetupErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = 'GhAppAuthSetupError';
+  }
+}
+
+export interface GhAppAuthSetupManagerOptions {
+  appId?: string | number;
+  clientId?: string;
+  keyFile?: string;
+  configPath: string;
+  routes: readonly string[];
+  installationId?: string | number;
+  processExecutor?: ProcessExecutor;
+  executable?: string;
+  timeoutMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 120_000;
+const MAX_TIMEOUT_MS = 10 * 60 * 1000;
+const hasControlCharacters = (input: string): boolean => {
+  for (const character of input) {
+    const code = character.codePointAt(0) ?? 0;
+    if (code < 0x20 || code === 0x7F) {
+      return true;
+    }
+  }
+  return false;
+};
+
+function validateSelector(options: GhAppAuthSetupManagerOptions): { flag: '--app-id' | '--client-id'; value: string } {
+  const hasAppId = options.appId !== undefined;
+  const hasClientId = options.clientId !== undefined && options.clientId.length > 0;
+  if (hasAppId === hasClientId) {
+    throw new GhAppAuthSetupError(
+      'GH_APP_AUTH_SETUP_SELECTOR_INVALID',
+      'Exactly one of GitHub App ID or Client ID is required for setup.'
+    );
+  }
+  if (hasAppId) {
+    const appIdValue = String(options.appId);
+    if (!/^\d+$/u.test(appIdValue) || Number(appIdValue) <= 0 || !Number.isSafeInteger(Number(appIdValue))) {
+      throw new GhAppAuthSetupError('GH_APP_AUTH_SETUP_SELECTOR_INVALID', 'GitHub App ID must be a positive integer.');
+    }
+    return { flag: '--app-id', value: appIdValue };
+  }
+  const clientIdValue = options.clientId!;
+  if (clientIdValue.trim() !== clientIdValue || hasControlCharacters(clientIdValue)) {
+    throw new GhAppAuthSetupError('GH_APP_AUTH_SETUP_SELECTOR_INVALID', 'GitHub App Client ID is invalid.');
+  }
+  return { flag: '--client-id', value: clientIdValue };
+}
+
+function validateNonEmpty(input: string, code: GhAppAuthSetupErrorCode, message: string): string {
+  if (input.length === 0 || input.trim() !== input || hasControlCharacters(input)) {
+    throw new GhAppAuthSetupError(code, message);
+  }
+  return input;
+}
+
+function validatePositive(value: string | number | undefined): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const normalized = String(value);
+  if (!/^\d+$/u.test(normalized) || Number(normalized) <= 0 || !Number.isSafeInteger(Number(normalized))) {
+    throw new GhAppAuthSetupError('GH_APP_AUTH_SETUP_SELECTOR_INVALID', 'Installation ID must be a positive integer.');
+  }
+  return normalized;
+}
+
+function validateTimeout(value: number | undefined): number {
+  const timeout = value ?? DEFAULT_TIMEOUT_MS;
+  if (!Number.isSafeInteger(timeout) || timeout <= 0 || timeout > MAX_TIMEOUT_MS) {
+    throw new GhAppAuthSetupError('GH_APP_AUTH_SETUP_SELECTOR_INVALID', 'Setup timeout is invalid.');
+  }
+  return timeout;
+}
+
+export class GhAppAuthSetupManager {
+  private readonly options: GhAppAuthSetupManagerOptions;
+
+  public constructor(options: GhAppAuthSetupManagerOptions) {
+    this.options = options;
+  }
+
+  public async setup(): Promise<void> {
+    const selector = validateSelector(this.options);
+    const configPath = validateNonEmpty(
+      this.options.configPath,
+      'GH_APP_AUTH_SETUP_CONFIG_MISSING',
+      'An isolated GitHub App auth config path is required for setup.'
+    );
+    if (this.options.routes.length === 0) {
+      throw new GhAppAuthSetupError(
+        'GH_APP_AUTH_SETUP_ROUTES_MISSING',
+        'At least one GitHub App route is required for setup.'
+      );
+    }
+    const routes = this.options.routes.map((route) => validateNonEmpty(
+      route,
+      'GH_APP_AUTH_SETUP_ROUTES_MISSING',
+      'GitHub App routes must be non-empty.'
+    )).toSorted((left, right) => left.toLowerCase().localeCompare(right.toLowerCase()));
+    const keyFile = validateNonEmpty(
+      this.options.keyFile ?? '',
+      'GH_APP_AUTH_SETUP_KEY_MISSING',
+      'A private-key file is required for explicit GitHub App setup.'
+    );
+    const installationId = validatePositive(this.options.installationId);
+    const timeoutMs = validateTimeout(this.options.timeoutMs);
+    const args = [
+      'app-auth', 'setup',
+      selector.flag, selector.value,
+      '--key-file', keyFile,
+      '--patterns', routes.join(','),
+      '--use-filesystem'
+    ];
+    if (installationId !== undefined) {
+      args.push('--installation-id', installationId);
+    }
+    try {
+      await (this.options.processExecutor ?? new NodeProcessExecutor()).execFile(
+        this.options.executable ?? 'gh',
+        args,
+        { env: { GH_APP_AUTH_CONFIG: configPath }, timeoutMs }
+      );
+    } catch (error) {
+      const candidate = error as { code?: unknown; message?: unknown; signal?: unknown };
+      const code = candidate.code === 'ETIMEDOUT' || candidate.signal === 'SIGTERM'
+        ? 'GH_APP_AUTH_SETUP_TIMEOUT'
+        : 'GH_APP_AUTH_SETUP_FAILED';
+      throw new GhAppAuthSetupError(code, 'GitHub App setup failed.');
+    }
+  }
+}

--- a/packages/infra/src/auth/gh-app-token-provider.ts
+++ b/packages/infra/src/auth/gh-app-token-provider.ts
@@ -1,0 +1,323 @@
+/**
+ * Repository-scoped GitHub App installation-token provider.
+ *
+ * The provider delegates JWT/configuration work to the installed
+ * `gh app-auth token` extension. It deliberately accepts the request host
+ * separately from the repository target because GitHub API, raw-content,
+ * and codeload requests use different hosts for the same repository.
+ * @module auth/gh-app-token-provider
+ */
+import type {
+  GitHubRepositoryTarget,
+  ProcessExecutor,
+  TokenProvider,
+} from '@ai-primitives-hub/core';
+import {
+  isGitHubHost,
+} from '../http/github-host';
+import {
+  canonicalizeGitHubRepositoryTarget as canonicalizeRepositoryTarget,
+} from '../http/github-repository-target';
+import {
+  NodeProcessExecutor,
+} from '../process/node-process-executor';
+
+export type GhAppAuthErrorCode =
+  | 'GH_APP_AUTH_SELECTOR_INVALID'
+  | 'GH_APP_AUTH_CONFIG_MISSING'
+  | 'GH_APP_AUTH_REPOSITORY_CONTEXT_MISSING'
+  | 'GH_APP_AUTH_REPOSITORY_INVALID'
+  | 'GH_APP_AUTH_CLI_UNAVAILABLE'
+  | 'GH_APP_AUTH_TIMEOUT'
+  | 'GH_APP_AUTH_ROUTE_MISMATCH'
+  | 'GH_APP_AUTH_INSTALLATION_MISSING'
+  | 'GH_APP_AUTH_MINT_FAILED'
+  | 'GH_APP_AUTH_OUTPUT_INVALID';
+
+/** Error with a stable, log-safe code for App-authentication failures. */
+export class GhAppAuthError extends Error {
+  public constructor(
+    public readonly code: GhAppAuthErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = 'GhAppAuthError';
+  }
+}
+
+export interface GhAppTokenProviderOptions {
+  /** Positive numeric GitHub App ID. Mutually exclusive with `clientId`. */
+  appId?: string | number;
+  /** GitHub App Client ID. Mutually exclusive with `appId`. */
+  clientId?: string;
+  /** Isolated `gh-app-auth` configuration path. */
+  configPath?: string;
+  /** Optional repository installation ID override. */
+  installationId?: string | number;
+  /** Injectable argv-safe process executor. */
+  processExecutor?: ProcessExecutor;
+  /** Executable name, primarily useful for controlled tests. Defaults to `gh`. */
+  executable?: string;
+  /** Maximum token-command duration. Defaults to 10 seconds. */
+  timeoutMs?: number;
+  /** Local cache lifetime. Defaults to 50 minutes. */
+  cacheTtlMs?: number;
+  /** Injectable clock returning epoch milliseconds. */
+  now?: () => number;
+}
+
+interface NormalizedOptions {
+  selectorFlag: '--app-id' | '--client-id';
+  selectorValue: string;
+  configPath: string;
+  installationId: string | undefined;
+  processExecutor: ProcessExecutor;
+  executable: string;
+  timeoutMs: number;
+  cacheTtlMs: number;
+  now: () => number;
+}
+
+interface CachedToken {
+  token: string;
+  expiresAt: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_CACHE_TTL_MS = 50 * 60 * 1000;
+const MAX_TIMEOUT_MS = 120_000;
+const MAX_CACHE_TTL_MS = 60 * 60 * 1000;
+const hasControlCharacters = (input: string): boolean => {
+  for (const character of input) {
+    const code = character.codePointAt(0) ?? 0;
+    if (code < 0x20 || code === 0x7F) {
+      return true;
+    }
+  }
+  return false;
+};
+
+function positiveInteger(value: string | number | undefined, field: string): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const stringValue = String(value);
+  if (!/^\d+$/u.test(stringValue) || Number(stringValue) <= 0 || !Number.isSafeInteger(Number(stringValue))) {
+    throw new GhAppAuthError(
+      'GH_APP_AUTH_SELECTOR_INVALID',
+      `GitHub App ${field} must be a positive integer.`
+    );
+  }
+  return stringValue;
+}
+
+function validateDuration(value: number | undefined, fallback: number, field: string, maximum: number): number {
+  const resolved = value ?? fallback;
+  if (!Number.isSafeInteger(resolved) || resolved <= 0 || resolved > maximum) {
+    throw new GhAppAuthError(
+      'GH_APP_AUTH_SELECTOR_INVALID',
+      `GitHub App ${field} must be a positive integer no greater than ${String(maximum)}.`
+    );
+  }
+  return resolved;
+}
+
+function validateConfigPath(configPath: string | undefined): string {
+  if (configPath === undefined || configPath.length === 0 || configPath.trim() !== configPath || hasControlCharacters(configPath)) {
+    throw new GhAppAuthError(
+      'GH_APP_AUTH_CONFIG_MISSING',
+      'An isolated GitHub App auth config path is required.'
+    );
+  }
+  return configPath;
+}
+
+function validateClientId(clientId: string | undefined): string | undefined {
+  if (clientId === undefined) {
+    return undefined;
+  }
+  if (clientId.length === 0 || clientId.trim() !== clientId || hasControlCharacters(clientId)) {
+    throw new GhAppAuthError(
+      'GH_APP_AUTH_SELECTOR_INVALID',
+      'GitHub App Client ID is invalid.'
+    );
+  }
+  return clientId;
+}
+
+function normalizeOptions(options: GhAppTokenProviderOptions): NormalizedOptions {
+  const appId = positiveInteger(options.appId, 'App ID');
+  const clientId = validateClientId(options.clientId);
+  if ((appId === undefined) === (clientId === undefined)) {
+    throw new GhAppAuthError(
+      'GH_APP_AUTH_SELECTOR_INVALID',
+      'Exactly one of GitHub App ID or Client ID is required.'
+    );
+  }
+  const executable = options.executable ?? 'gh';
+  if (executable.length === 0 || executable.trim() !== executable || hasControlCharacters(executable)) {
+    throw new GhAppAuthError(
+      'GH_APP_AUTH_SELECTOR_INVALID',
+      'GitHub App auth executable is invalid.'
+    );
+  }
+  return {
+    selectorFlag: appId === undefined ? '--client-id' : '--app-id',
+    selectorValue: appId ?? clientId!,
+    configPath: validateConfigPath(options.configPath),
+    installationId: positiveInteger(options.installationId, 'installation ID'),
+    processExecutor: options.processExecutor ?? createDefaultProcessExecutor(),
+    executable,
+    timeoutMs: validateDuration(options.timeoutMs, DEFAULT_TIMEOUT_MS, 'timeout', MAX_TIMEOUT_MS),
+    cacheTtlMs: validateDuration(options.cacheTtlMs, DEFAULT_CACHE_TTL_MS, 'cache TTL', MAX_CACHE_TTL_MS),
+    now: options.now ?? Date.now
+  };
+}
+
+function createDefaultProcessExecutor(): ProcessExecutor {
+  return new NodeProcessExecutor();
+}
+
+function isTimeoutError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+  const candidate = error as { code?: unknown; killed?: unknown; signal?: unknown; message?: unknown };
+  return candidate.code === 'ETIMEDOUT'
+    || candidate.killed === true
+    || candidate.signal === 'SIGTERM'
+    || (typeof candidate.message === 'string' && /timed? ?out|timeout/i.test(candidate.message));
+}
+
+function classifyProcessFailure(error: unknown): GhAppAuthErrorCode {
+  if (isTimeoutError(error)) {
+    return 'GH_APP_AUTH_TIMEOUT';
+  }
+  if (typeof error !== 'object' || error === null) {
+    return 'GH_APP_AUTH_MINT_FAILED';
+  }
+  const candidate = error as { code?: unknown; message?: unknown };
+  if (candidate.code === 'ENOENT') {
+    return 'GH_APP_AUTH_CLI_UNAVAILABLE';
+  }
+  const message = typeof candidate.message === 'string' ? candidate.message.toLowerCase() : '';
+  if (message.includes('route')) {
+    return 'GH_APP_AUTH_ROUTE_MISMATCH';
+  }
+  if (message.includes('installation')) {
+    return 'GH_APP_AUTH_INSTALLATION_MISSING';
+  }
+  if (message.includes('not found') && message.includes('gh')) {
+    return 'GH_APP_AUTH_CLI_UNAVAILABLE';
+  }
+  return 'GH_APP_AUTH_MINT_FAILED';
+}
+
+function parseTokenOutput(stdout: string): string {
+  if (stdout.includes('\r')) {
+    throw new GhAppAuthError(
+      'GH_APP_AUTH_OUTPUT_INVALID',
+      'GitHub App auth command returned invalid token output.'
+    );
+  }
+  const withoutTrailingNewline = stdout.endsWith('\n') ? stdout.slice(0, -1) : stdout;
+  const token = withoutTrailingNewline.trim();
+  if (token.length === 0 || withoutTrailingNewline.includes('\n') || hasControlCharacters(withoutTrailingNewline)) {
+    throw new GhAppAuthError(
+      'GH_APP_AUTH_OUTPUT_INVALID',
+      'GitHub App auth command returned invalid token output.'
+    );
+  }
+  return token;
+}
+
+/* eslint-disable @typescript-eslint/member-ordering -- public API first */
+export class GhAppTokenProvider implements TokenProvider {
+  private readonly options: NormalizedOptions;
+  private readonly cache = new Map<string, CachedToken>();
+  private readonly inFlight = new Map<string, Promise<string>>();
+
+  public constructor(options: GhAppTokenProviderOptions) {
+    this.options = normalizeOptions(options);
+  }
+
+  public async getToken(host: string, target?: GitHubRepositoryTarget): Promise<string | undefined> {
+    if (!isGitHubHost(host.toLowerCase())) {
+      return undefined;
+    }
+    if (target === undefined) {
+      throw new GhAppAuthError(
+        'GH_APP_AUTH_REPOSITORY_CONTEXT_MISSING',
+        'A repository target is required for GitHub App authentication.'
+      );
+    }
+    let repositoryTarget: string;
+    try {
+      repositoryTarget = canonicalizeRepositoryTarget(target);
+    } catch (error) {
+      if (error instanceof GhAppAuthError) {
+        throw error;
+      }
+      throw new GhAppAuthError(
+        'GH_APP_AUTH_REPOSITORY_INVALID',
+        'GitHub App repository target is invalid.'
+      );
+    }
+
+    const cacheKey = `${this.options.selectorFlag}=${this.options.selectorValue}|config=${this.options.configPath}|installation=${this.options.installationId ?? ''}|repo=${repositoryTarget}`;
+    const cached = this.cache.get(cacheKey);
+    if (cached !== undefined && cached.expiresAt > this.options.now()) {
+      return cached.token;
+    }
+
+    const existing = this.inFlight.get(cacheKey);
+    if (existing !== undefined) {
+      return existing;
+    }
+
+    const refresh = this.mintToken(repositoryTarget, cacheKey);
+    this.inFlight.set(cacheKey, refresh);
+    try {
+      return await refresh;
+    } finally {
+      if (this.inFlight.get(cacheKey) === refresh) {
+        this.inFlight.delete(cacheKey);
+      }
+    }
+  }
+
+  /** Clear in-memory installation-token state. */
+  public clearCache(): void {
+    this.cache.clear();
+  }
+
+  private async mintToken(repositoryTarget: string, cacheKey: string): Promise<string> {
+    const args = [
+      'app-auth', 'token',
+      this.options.selectorFlag, this.options.selectorValue,
+      '--repo', repositoryTarget
+    ];
+    if (this.options.installationId !== undefined) {
+      args.push('--installation-id', this.options.installationId);
+    }
+
+    let result;
+    try {
+      result = await this.options.processExecutor.execFile(this.options.executable, args, {
+        env: { GH_APP_AUTH_CONFIG: this.options.configPath },
+        timeoutMs: this.options.timeoutMs
+      });
+    } catch (error) {
+      const code = classifyProcessFailure(error);
+      throw new GhAppAuthError(code, `GitHub App token command failed for ${repositoryTarget}.`);
+    }
+
+    const token = parseTokenOutput(result.stdout);
+    this.cache.set(cacheKey, {
+      token,
+      expiresAt: this.options.now() + this.options.cacheTtlMs
+    });
+    return token;
+  }
+}
+/* eslint-enable @typescript-eslint/member-ordering */

--- a/packages/infra/src/auth/index.ts
+++ b/packages/infra/src/auth/index.ts
@@ -6,4 +6,7 @@ export * from './composite-token-provider';
 export * from './default-token-provider';
 export * from './env-token-provider';
 export * from './gh-cli-token-provider';
+export * from './gh-app-token-provider';
+export * from './gh-app-auth-setup-manager';
+export * from './generic-public-token-provider';
 export * from './static-token-provider';

--- a/packages/infra/src/downloaders/https-bundle-downloader.ts
+++ b/packages/infra/src/downloaders/https-bundle-downloader.ts
@@ -3,8 +3,9 @@
  *
  * Downloads bundle bytes over HTTP(S) via the injected `HttpClient`,
  * attaching a bearer token (from `TokenProvider`, keyed by the download
- * URL's hostname) when one is available — release assets on private
- * repositories need it, public ones ignore it. When `Installable`
+ * URL's hostname and optional originating repository target) when one is
+ * available — release assets on private repositories need it, public ones
+ * may omit it. When `Installable`
  * already carries `inlineBytes` (synthesized bundles — awesome-copilot,
  * skills), the network call is skipped entirely and the digest is
  * computed directly over those bytes.
@@ -16,6 +17,8 @@ import {
 import type {
   BundleDownloader,
   DownloadResult,
+  GitHubRepositoryTarget,
+  GitHubSourceAuthCategory,
   HttpClient,
   Installable,
   TokenProvider,
@@ -27,7 +30,9 @@ const sha256Hex = (bytes: Uint8Array): string =>
 export class HttpsBundleDownloader implements BundleDownloader {
   public constructor(
     private readonly http: HttpClient,
-    private readonly tokens: TokenProvider
+    private readonly tokens: TokenProvider,
+    private readonly repositoryTarget?: GitHubRepositoryTarget,
+    private readonly authenticationCategory?: GitHubSourceAuthCategory
   ) {}
 
   public async download(installable: Installable): Promise<DownloadResult> {
@@ -39,10 +44,24 @@ export class HttpsBundleDownloader implements BundleDownloader {
     }
 
     const host = new URL(installable.downloadUrl).hostname;
-    const token = await this.tokens.getToken(host);
     const headers: Record<string, string> = { Accept: 'application/octet-stream' };
-    if (token !== undefined) {
-      headers.Authorization = `Bearer ${token}`;
+    if (this.authenticationCategory !== 'public-anonymous') {
+      const token = await this.tokens.getToken(host, this.repositoryTarget);
+      if (token === undefined && this.authenticationCategory === 'public-generic') {
+        throw authenticationRequiredError(
+          'GH_PUBLIC_GENERIC_TOKEN_UNAVAILABLE',
+          'A generic GitHub token is required for public source downloads.'
+        );
+      }
+      if (token === undefined && this.authenticationCategory === 'app-authenticated') {
+        throw authenticationRequiredError(
+          'GH_APP_AUTH_TOKEN_UNAVAILABLE',
+          'A repository-scoped GitHub App token is required for source downloads.'
+        );
+      }
+      if (token !== undefined) {
+        headers.Authorization = `Bearer ${token}`;
+      }
     }
 
     const response = await this.http.fetch({ url: installable.downloadUrl, headers });
@@ -55,4 +74,8 @@ export class HttpsBundleDownloader implements BundleDownloader {
       sha256: sha256Hex(response.body)
     };
   }
+}
+
+function authenticationRequiredError(code: string, message: string): Error & { code: string } {
+  return Object.assign(new Error(message), { code });
 }

--- a/packages/infra/src/harvest/github-source-auth-runtime.ts
+++ b/packages/infra/src/harvest/github-source-auth-runtime.ts
@@ -1,0 +1,309 @@
+/**
+ * Runtime wiring for the opt-in GitHub source authentication model.
+ *
+ * This module owns environment parsing, category-specific client
+ * construction, and the explicit ephemeral setup session. It never combines
+ * App tokens with generic or personal fallback credentials.
+ * @module harvest/github-source-auth-runtime
+ */
+import {
+  mkdtemp,
+  rm,
+} from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type {
+  GitHubApi,
+  GitHubRepositoryTarget,
+  GitHubSourceAuthCategory,
+  HttpClient,
+  ProcessExecutor,
+  TokenProvider,
+} from '@ai-primitives-hub/core';
+import {
+  GenericPublicTokenProvider,
+  GhAppAuthSetupManager,
+  GhAppTokenProvider,
+  type GhAppTokenProviderOptions,
+} from '../auth';
+import {
+  GitHubApiClient,
+  type GitHubApiClientOptions,
+} from '../http';
+import {
+  type GitHubPublicAuthMode,
+  GitHubSourceAuthPolicyError,
+  type GitHubSourcePreflightOptions,
+  type GitHubSourcePreflightReport,
+  preflightGitHubSources,
+} from './github-source-preflight';
+
+export const GITHUB_APP_AUTH_ENABLED = 'AI_PRIMITIVES_HUB_GH_APP_AUTH_ENABLED';
+export const GITHUB_PUBLIC_AUTH_MODE = 'AI_PRIMITIVES_HUB_GH_PUBLIC_AUTH_MODE';
+export const GITHUB_APP_ID = 'AI_PRIMITIVES_HUB_GH_APP_AUTH_APP_ID';
+export const GITHUB_APP_CLIENT_ID = 'AI_PRIMITIVES_HUB_GH_APP_AUTH_CLIENT_ID';
+export const GITHUB_APP_CONFIG = 'AI_PRIMITIVES_HUB_GH_APP_AUTH_CONFIG';
+export const GITHUB_APP_AUTH_KEY_FILE = 'AI_PRIMITIVES_HUB_GH_APP_AUTH_KEY_FILE';
+export const GITHUB_APP_INSTALLATION_ID = 'AI_PRIMITIVES_HUB_GH_APP_AUTH_INSTALLATION_ID';
+export const GITHUB_APP_TIMEOUT_MS = 'AI_PRIMITIVES_HUB_GH_APP_AUTH_TIMEOUT_MS';
+export const GITHUB_APP_CACHE_TTL_MS = 'AI_PRIMITIVES_HUB_GH_APP_AUTH_TOKEN_CACHE_TTL_MS';
+
+export interface GitHubSourceAuthRuntimeOptions {
+  env: Readonly<Record<string, string | undefined>>;
+  http: HttpClient;
+  processExecutor?: ProcessExecutor;
+  now?: () => number;
+  appTokenProvider?: TokenProvider;
+  genericTokenProvider?: TokenProvider;
+  publicAuthMode?: GitHubPublicAuthMode;
+  /** Retry count for preflight-only clients. Defaults to zero to fail promptly. */
+  preflightMaxRetries?: number;
+}
+
+export interface GitHubSourceAuthRuntime {
+  readonly genericTokenProvider: TokenProvider;
+  readonly appTokenProvider: TokenProvider | undefined;
+  tokenProviderFor(category: Exclude<GitHubSourceAuthCategory, 'unresolved'>): TokenProvider | undefined;
+  clientFor(target: GitHubRepositoryTarget, category: GitHubSourceAuthCategory): GitHubApi;
+  preflight(
+    sources: Parameters<typeof preflightGitHubSources>[0],
+    overrides?: Partial<Omit<GitHubSourcePreflightOptions, 'clientFactory' | 'genericTokenProvider' | 'appTokenProvider' | 'publicAuthMode'>>
+  ): Promise<GitHubSourcePreflightReport>;
+}
+
+export interface GitHubSourceAuthSessionOptions extends Omit<GitHubSourceAuthRuntimeOptions, 'appTokenProvider'> {
+  /** GitHub App numeric ID. Mutually exclusive with `clientId`. */
+  appId?: string | number;
+  /** GitHub App Client ID. Mutually exclusive with `appId`. */
+  clientId?: string;
+  /** Private-key PEM path used only by the explicit setup step. */
+  keyFile: string;
+  /** Optional installation ID forwarded to setup and token minting. */
+  installationId?: string | number;
+  /** Optional root directory for the ephemeral setup workspace. */
+  tempRoot?: string;
+  /** Timeout for the explicit setup process. */
+  setupTimeoutMs?: number;
+}
+
+export interface GitHubSourceAuthSession extends GitHubSourceAuthRuntime {
+  /** Ephemeral filesystem config used by `gh app-auth setup` and `token`. */
+  readonly configPath: string;
+  /** Remove the ephemeral setup workspace. Safe to call more than once. */
+  cleanup(): Promise<void>;
+}
+
+/**
+ * Parse the explicit source-aware GitHub authentication switch.
+ * @param env
+ */
+export function parseGitHubAppAuthEnabled(env: Readonly<Record<string, string | undefined>>): boolean {
+  const value = env[GITHUB_APP_AUTH_ENABLED];
+  if (value === undefined || value.length === 0 || value === '0' || value.toLowerCase() === 'false' || value.toLowerCase() === 'no') {
+    return false;
+  }
+  if (value === '1' || value.toLowerCase() === 'true' || value.toLowerCase() === 'yes') {
+    return true;
+  }
+  throw new Error(`Invalid ${GITHUB_APP_AUTH_ENABLED}: expected 1, true, yes, 0, false, or no.`);
+}
+
+/**
+ * Return whether source-aware GitHub authentication is explicitly enabled.
+ * @param env
+ */
+export function isGitHubAppAuthEnabled(env: Readonly<Record<string, string | undefined>>): boolean {
+  return parseGitHubAppAuthEnabled(env);
+}
+
+function publicAuthModeFromEnv(
+  env: Readonly<Record<string, string | undefined>>,
+  override: GitHubPublicAuthMode | undefined
+): GitHubPublicAuthMode {
+  const value = override ?? env[GITHUB_PUBLIC_AUTH_MODE] ?? 'generic';
+  if (value !== 'auto' && value !== 'anonymous' && value !== 'generic') {
+    throw new Error(`Invalid ${GITHUB_PUBLIC_AUTH_MODE}: expected auto, anonymous, or generic.`);
+  }
+  if (value === 'anonymous') {
+    throw new GitHubSourceAuthPolicyError();
+  }
+  return value;
+}
+
+function positiveEnvNumber(
+  env: Readonly<Record<string, string | undefined>>,
+  name: string
+): number | undefined {
+  const value = env[name];
+  if (value === undefined || value.length === 0) {
+    return undefined;
+  }
+  if (!/^\d+$/u.test(value) || Number(value) <= 0 || !Number.isSafeInteger(Number(value))) {
+    throw new Error(`Invalid ${name}: expected a positive integer.`);
+  }
+  return Number(value);
+}
+
+function buildAppTokenProvider(
+  options: GitHubSourceAuthRuntimeOptions
+): TokenProvider | undefined {
+  const appId = options.env[GITHUB_APP_ID];
+  const clientId = options.env[GITHUB_APP_CLIENT_ID];
+  const configPath = options.env[GITHUB_APP_CONFIG];
+  // App settings are conditional: a fully public requested scope must not
+  // fail merely because a caller supplied only a partial, unused App
+  // configuration. A source that actually requires App auth will fail closed
+  // during preflight when the provider is still unavailable.
+  if ((appId === undefined && clientId === undefined) || configPath === undefined) {
+    return undefined;
+  }
+  const providerOptions: GhAppTokenProviderOptions = {
+    appId,
+    clientId,
+    configPath,
+    installationId: options.env[GITHUB_APP_INSTALLATION_ID],
+    processExecutor: options.processExecutor,
+    timeoutMs: positiveEnvNumber(options.env, GITHUB_APP_TIMEOUT_MS),
+    cacheTtlMs: positiveEnvNumber(options.env, GITHUB_APP_CACHE_TTL_MS),
+    now: options.now
+  };
+  return new GhAppTokenProvider(providerOptions);
+}
+
+/**
+ * Create category-specific GitHub clients for an opt-in source-aware run.
+ * @param options Environment and injected external boundaries.
+ * @returns Runtime wiring; setup remains an explicit caller responsibility
+ * unless the session factory below is used.
+ */
+export function createGitHubSourceAuthRuntime(
+  options: GitHubSourceAuthRuntimeOptions
+): GitHubSourceAuthRuntime {
+  const mode = publicAuthModeFromEnv(options.env, options.publicAuthMode);
+  const genericTokenProvider = options.genericTokenProvider
+    ?? new GenericPublicTokenProvider({ env: options.env });
+  const appTokenProvider = options.appTokenProvider ?? buildAppTokenProvider(options);
+  const preflightMaxRetries = options.preflightMaxRetries ?? 0;
+
+  const tokenProviderFor = (category: Exclude<GitHubSourceAuthCategory, 'unresolved'>): TokenProvider | undefined => {
+    if (category === 'app-authenticated') {
+      return appTokenProvider;
+    }
+    if (category === 'public-generic') {
+      return genericTokenProvider;
+    }
+    return undefined;
+  };
+
+  const buildClient = (
+    target: GitHubRepositoryTarget,
+    category: GitHubSourceAuthCategory,
+    clientOptions: Partial<Pick<GitHubApiClientOptions, 'maxRetries'>> = {}
+  ): GitHubApi => {
+    if (category === 'public-anonymous') {
+      throw new GitHubSourceAuthPolicyError();
+    }
+    if (category === 'unresolved') {
+      throw new Error('Cannot build a GitHub client for an unresolved source.');
+    }
+    const tokenProvider = tokenProviderFor(category);
+    if (category === 'app-authenticated' && tokenProvider === undefined) {
+      throw new Error('GitHub App authentication is not configured.');
+    }
+    return new GitHubApiClient(options.http, {
+      tokenProvider,
+      repositoryTarget: target,
+      authenticationCategory: category,
+      ...clientOptions
+    });
+  };
+  const clientFor = (target: GitHubRepositoryTarget, category: GitHubSourceAuthCategory): GitHubApi =>
+    buildClient(target, category);
+
+  return {
+    genericTokenProvider,
+    appTokenProvider,
+    tokenProviderFor,
+    clientFor,
+    preflight: (sources, overrides = {}) => preflightGitHubSources(sources, {
+      ...overrides,
+      clientFactory: (target, category, _tokenProvider) => buildClient(target, category, {
+        maxRetries: preflightMaxRetries
+      }),
+      genericTokenProvider,
+      appTokenProvider,
+      publicAuthMode: mode
+    })
+  };
+}
+
+/**
+ * Create a source-aware runtime whose App configuration is provisioned on
+ * demand from a caller-supplied App selector and private-key path.
+ *
+ * The temporary configuration is deliberately created here rather than in
+ * the token provider: setup is a bootstrap operation and must happen only
+ * after preflight has derived the actual organization routes. The private
+ * key is never read by this process; it is passed as a validated argv value
+ * to `gh app-auth setup`.
+ * @param options App setup inputs and runtime boundaries.
+ * @returns Runtime plus the ephemeral config path and cleanup operation.
+ */
+export async function createGitHubSourceAuthSession(
+  options: GitHubSourceAuthSessionOptions
+): Promise<GitHubSourceAuthSession> {
+  const appId = options.appId ?? options.env[GITHUB_APP_ID];
+  const clientId = options.clientId ?? options.env[GITHUB_APP_CLIENT_ID];
+  const installationId = options.installationId ?? options.env[GITHUB_APP_INSTALLATION_ID];
+  const tempRoot = options.tempRoot ?? os.tmpdir();
+  const tempDirectory = await mkdtemp(path.join(tempRoot, 'ai-primitives-hub-gh-app-'));
+  const configPath = path.join(tempDirectory, 'config.yml');
+  try {
+    const runtimeEnv: Record<string, string | undefined> = {
+      ...options.env,
+      [GITHUB_APP_ID]: appId === undefined ? undefined : String(appId),
+      [GITHUB_APP_CLIENT_ID]: clientId,
+      [GITHUB_APP_CONFIG]: configPath,
+      [GITHUB_APP_INSTALLATION_ID]: installationId === undefined ? undefined : String(installationId)
+    };
+    const runtime = createGitHubSourceAuthRuntime({
+      ...options,
+      env: runtimeEnv,
+      appTokenProvider: undefined
+    });
+    const prepareAppAuthentication = async (
+      routes: readonly string[],
+      _targets: readonly GitHubRepositoryTarget[]
+    ): Promise<void> => {
+      await new GhAppAuthSetupManager({
+        appId,
+        clientId,
+        keyFile: options.keyFile,
+        configPath,
+        routes,
+        installationId,
+        processExecutor: options.processExecutor,
+        timeoutMs: options.setupTimeoutMs
+      }).setup();
+    };
+    let cleaned = false;
+    return {
+      ...runtime,
+      configPath,
+      preflight: (sources, overrides = {}) => runtime.preflight(sources, {
+        ...overrides,
+        prepareAppAuthentication
+      }),
+      cleanup: async (): Promise<void> => {
+        if (cleaned) {
+          return;
+        }
+        cleaned = true;
+        await rm(tempDirectory, { recursive: true, force: true });
+      }
+    };
+  } catch (error) {
+    await rm(tempDirectory, { recursive: true, force: true });
+    throw error;
+  }
+}

--- a/packages/infra/src/harvest/github-source-preflight.ts
+++ b/packages/infra/src/harvest/github-source-preflight.ts
@@ -1,0 +1,512 @@
+/**
+ * Evidence-based authentication preflight for GitHub-backed hub sources.
+ *
+ * Every source is checked through an authenticated public-read path first.
+ * Public sources use the generic credential provider; sources whose access
+ * requires authentication are validated with the repository-scoped App
+ * provider. Anonymous GitHub access is not used by source-aware preflight.
+ * No source name or organization is treated as a policy exception.
+ * @module harvest/github-source-preflight
+ */
+import type {
+  GitHubApi,
+  GitHubRepositoryTarget,
+  GitHubSourceAuthCategory,
+  HubSourceSpec,
+  TokenProvider,
+} from '@ai-primitives-hub/core';
+import {
+  parseGitHubRepositoryTarget,
+} from '../http/github-repository-target';
+
+export type GitHubPublicAuthMode = 'auto' | 'anonymous' | 'generic';
+
+/** Raised when a caller explicitly requests the unsupported anonymous mode. */
+export class GitHubSourceAuthPolicyError extends Error {
+  public readonly code = 'GH_PUBLIC_ANONYMOUS_DISABLED';
+
+  public constructor() {
+    super('Anonymous GitHub access is disabled in source-aware mode; provide a generic public credential.');
+    this.name = 'GitHubSourceAuthPolicyError';
+  }
+}
+
+export interface GitHubSourcePreflightResult {
+  sourceId: string;
+  target?: GitHubRepositoryTarget;
+  category: GitHubSourceAuthCategory;
+  operations: string[];
+  credentialMode: 'none' | 'generic' | 'app';
+  /** Commit revision observed while checking the source branch. */
+  revision?: string;
+  errorCode?: string;
+}
+
+export interface GitHubSourcePreflightReport {
+  valid: boolean;
+  results: GitHubSourcePreflightResult[];
+  appRoutes: string[];
+}
+
+/**
+ * Fail-closed source preflight error.
+ *
+ * The report contains only repository identifiers, operation names, category
+ * decisions, and stable error codes. It intentionally contains no token,
+ * authorization header, private key, or child-process output.
+ */
+export class GitHubSourcePreflightError extends Error {
+  public readonly code = 'GH_SOURCE_PREFLIGHT_FAILED';
+
+  public constructor(public readonly report: GitHubSourcePreflightReport) {
+    super('GitHub source preflight failed.');
+    this.name = 'GitHubSourcePreflightError';
+  }
+}
+
+export interface GitHubSourcePreflightOptions {
+  /** Build a client for the requested category and credential provider. */
+  clientFactory: (
+    target: GitHubRepositoryTarget,
+    category: GitHubSourceAuthCategory,
+    tokenProvider?: TokenProvider
+  ) => GitHubApi;
+  /** Provider used for all public-source visibility and content checks. */
+  genericTokenProvider?: TokenProvider;
+  /** Provider used only for sources whose generic checks require App auth. */
+  appTokenProvider?: TokenProvider;
+  /** Optional setup hook called after generic checks and before App checks. */
+  prepareAppAuthentication?: (
+    routes: readonly string[],
+    targets: readonly GitHubRepositoryTarget[]
+  ) => Promise<void>;
+  /** Public credential policy. `auto` and `generic` are authenticated; `anonymous` is rejected. */
+  publicAuthMode?: GitHubPublicAuthMode;
+  /** Include release metadata in the required operation set for install/update callers. */
+  includeReleases?: boolean;
+  /** Safe diagnostic sink; never receives credential values. */
+  onLog?: (message: string) => void;
+}
+
+interface ProbeResult {
+  ok: boolean;
+  operations: string[];
+  revision?: string;
+  error?: unknown;
+  failedOperation?: string;
+  authenticationRequired: boolean;
+  rateLimitExceeded: boolean;
+  repositoryPrivate?: boolean;
+}
+
+const compareSources = (a: HubSourceSpec, b: HubSourceSpec): number => {
+  const left = `${a.owner.toLowerCase()}\u0000${a.repo.toLowerCase()}\u0000${a.id}`;
+  const right = `${b.owner.toLowerCase()}\u0000${b.repo.toLowerCase()}\u0000${b.id}`;
+  return left.localeCompare(right);
+};
+
+/**
+ * Run the deterministic source-level preflight.
+ * @param sources Enabled GitHub source specifications.
+ * @param options Client/provider and public-rate-limit policy.
+ * @returns One result per input source and derived App routes.
+ */
+export async function preflightGitHubSources(
+  sources: readonly HubSourceSpec[],
+  options: GitHubSourcePreflightOptions
+): Promise<GitHubSourcePreflightReport> {
+  const results: GitHubSourcePreflightResult[] = [];
+  const appCandidates: {
+    source: HubSourceSpec;
+    target: GitHubRepositoryTarget;
+    operations: string[];
+  }[] = [];
+  const genericVisibility = new Map<string, Promise<ProbeResult>>();
+  let genericRateLimitDetected = false;
+  if (options.publicAuthMode === 'anonymous') {
+    throw new GitHubSourceAuthPolicyError();
+  }
+
+  for (const source of [...sources].toSorted(compareSources)) {
+    if (genericRateLimitDetected) {
+      results.push(unresolvedForRateLimit(source));
+      continue;
+    }
+    const result = await classifySource(source, options, appCandidates, genericVisibility);
+    results.push(result);
+    genericRateLimitDetected = result.errorCode === 'GH_PUBLIC_GENERIC_RATE_LIMIT_UNSAFE';
+  }
+
+  // A generic rate-limit response makes visibility evidence unavailable for
+  // every source that has not been checked yet. Do not continue probing (or
+  // mint App tokens for earlier candidates) merely to produce more identical
+  // failures; the caller must wait for the provider's budget to recover.
+  if (genericRateLimitDetected) {
+    return {
+      valid: false,
+      results,
+      appRoutes: deriveGitHubAppRoutes(appCandidates.map((candidate) => candidate.target))
+    };
+  }
+
+  const appRoutes = deriveGitHubAppRoutes(appCandidates.map((candidate) => candidate.target));
+  if (appCandidates.length > 0 && options.prepareAppAuthentication !== undefined) {
+    await options.prepareAppAuthentication(
+      appRoutes,
+      appCandidates.map((candidate) => candidate.target)
+    );
+  }
+  // App setup/preparation runs after the authenticated generic checks. Re-run
+  // the App-only checks for those candidates now that routes/configuration are
+  // available.
+  if (appCandidates.length > 0) {
+    for (const candidate of appCandidates) {
+      const resultIndex = results.findIndex((result) => result.sourceId === candidate.source.id);
+      const appResult = await validateAppCandidate(
+        candidate.source,
+        candidate.target,
+        candidate.operations,
+        options
+      );
+      if (resultIndex !== -1) {
+        results[resultIndex] = appResult;
+      }
+    }
+  }
+  for (const result of results) {
+    options.onLog?.(
+      `source=${result.sourceId} category=${result.category} credential=${result.credentialMode}`
+      + (result.errorCode === undefined ? '' : ` error=${result.errorCode}`)
+    );
+  }
+  return {
+    valid: results.every((result) => result.category !== 'unresolved'),
+    results,
+    appRoutes
+  };
+}
+
+async function classifySource(
+  source: HubSourceSpec,
+  options: GitHubSourcePreflightOptions,
+  appCandidates: {
+    source: HubSourceSpec;
+    target: GitHubRepositoryTarget;
+    operations: string[];
+  }[],
+  genericVisibility: Map<string, Promise<ProbeResult>>
+): Promise<GitHubSourcePreflightResult> {
+  let target: GitHubRepositoryTarget;
+  try {
+    target = parseGitHubRepositoryTarget(source.url);
+    if (target.owner !== source.owner || target.repository !== source.repo) {
+      return unresolved(source, undefined, [], 'GH_SOURCE_REPOSITORY_MISMATCH');
+    }
+  } catch {
+    return unresolved(source, undefined, [], 'GH_SOURCE_REPOSITORY_INVALID');
+  }
+
+  const visibilityKey = `${target.host.toLowerCase()}/${target.owner.toLowerCase()}/${target.repository.toLowerCase()}`;
+  const buildGenericClient = async (): Promise<GitHubApi | undefined> => {
+    if (options.genericTokenProvider === undefined) {
+      return undefined;
+    }
+    try {
+      const token = await options.genericTokenProvider.getToken('api.github.com', target);
+      if (token === undefined || token.length === 0) {
+        return undefined;
+      }
+      return options.clientFactory(target, 'public-generic', options.genericTokenProvider);
+    } catch {
+      return undefined;
+    }
+  };
+  const genericClient = await buildGenericClient();
+  if (genericClient === undefined) {
+    return unresolved(source, target, [], 'GH_PUBLIC_GENERIC_TOKEN_UNAVAILABLE');
+  }
+
+  let visibilityProbe = genericVisibility.get(visibilityKey);
+  if (visibilityProbe === undefined) {
+    visibilityProbe = probeRepositoryMetadata(source, genericClient);
+    genericVisibility.set(visibilityKey, visibilityProbe);
+  }
+  const visibility = await visibilityProbe;
+  if (!visibility.ok) {
+    if (visibility.rateLimitExceeded) {
+      return unresolved(source, target, visibility.operations, 'GH_PUBLIC_GENERIC_RATE_LIMIT_UNSAFE');
+    }
+    if (!visibility.authenticationRequired) {
+      return unresolved(source, target, visibility.operations, 'GH_SOURCE_PREFLIGHT_UNRESOLVED');
+    }
+    appCandidates.push({ source, target, operations: visibility.operations });
+    return unresolved(source, target, visibility.operations, 'GH_APP_AUTH_PENDING');
+  }
+  if (visibility.repositoryPrivate === true) {
+    appCandidates.push({ source, target, operations: visibility.operations });
+    return unresolved(source, target, visibility.operations, 'GH_APP_AUTH_PENDING');
+  }
+  if (visibility.repositoryPrivate !== false) {
+    return unresolved(source, target, visibility.operations, 'GH_SOURCE_VISIBILITY_AMBIGUOUS');
+  }
+
+  const generic = await probeSource(source, genericClient, options.includeReleases === true, true);
+  if (!generic.ok) {
+    return unresolved(
+      source,
+      target,
+      [...visibility.operations, ...generic.operations],
+      generic.rateLimitExceeded ? 'GH_PUBLIC_GENERIC_RATE_LIMIT_UNSAFE' : 'GH_SOURCE_PREFLIGHT_UNRESOLVED'
+    );
+  }
+  return {
+    sourceId: source.id,
+    target,
+    category: 'public-generic',
+    operations: [...visibility.operations, ...generic.operations],
+    credentialMode: 'generic',
+    ...(generic.revision === undefined ? {} : { revision: generic.revision })
+  };
+}
+
+async function validateAppCandidate(
+  source: HubSourceSpec,
+  target: GitHubRepositoryTarget,
+  genericOperations: string[],
+  options: GitHubSourcePreflightOptions
+): Promise<GitHubSourcePreflightResult> {
+  if (options.appTokenProvider === undefined) {
+    return unresolved(source, target, genericOperations, 'GH_APP_AUTH_CONFIG_MISSING');
+  }
+  let appClient: GitHubApi;
+  try {
+    appClient = options.clientFactory(target, 'app-authenticated', options.appTokenProvider);
+  } catch {
+    return unresolved(source, target, genericOperations, 'GH_SOURCE_PREFLIGHT_UNRESOLVED');
+  }
+  const authenticated = await probeSource(source, appClient, options.includeReleases === true);
+  if (!authenticated.ok) {
+    return unresolved(source, target, [...genericOperations, ...authenticated.operations], errorCode(authenticated.error));
+  }
+  return {
+    sourceId: source.id,
+    target,
+    category: 'app-authenticated',
+    operations: [...genericOperations, ...authenticated.operations],
+    credentialMode: 'app',
+    ...(authenticated.revision === undefined ? {} : { revision: authenticated.revision })
+  };
+}
+
+/**
+ * Derive stable wildcard routes from source targets that require App auth.
+ * @param targets Authentication-required source targets.
+ * @returns Sorted, case-insensitively deduplicated routes.
+ */
+export function deriveGitHubAppRoutes(
+  targets: readonly GitHubRepositoryTarget[]
+): string[] {
+  const routes = new Map<string, string>();
+  for (const target of targets) {
+    const key = `${target.host.toLowerCase()}/${target.owner.toLowerCase()}`;
+    routes.set(key, `${target.host.toLowerCase()}/${target.owner}/*`);
+  }
+  return [...routes.entries()]
+    .toSorted(([left], [right]) => left.localeCompare(right))
+    .map(([, route]) => route);
+}
+
+async function probeRepositoryMetadata(source: HubSourceSpec, client: GitHubApi): Promise<ProbeResult> {
+  try {
+    const metadata = await client.getJson<{ private?: unknown }>(`/repos/${source.owner}/${source.repo}`);
+    return {
+      ok: true,
+      operations: ['repository metadata'],
+      authenticationRequired: false,
+      rateLimitExceeded: false,
+      repositoryPrivate: metadata.private === true ? true : (metadata.private === false ? false : undefined)
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      operations: ['repository metadata'],
+      error,
+      failedOperation: 'repository metadata',
+      authenticationRequired: isAuthenticationError(error, 'repository metadata'),
+      rateLimitExceeded: isRateLimitError(error)
+    };
+  }
+}
+
+async function probeSource(
+  source: HubSourceSpec,
+  client: GitHubApi,
+  includeReleases: boolean,
+  skipRepositoryMetadata = false
+): Promise<ProbeResult> {
+  const operations: string[] = [];
+  const run = async (operation: string, action: () => Promise<unknown>): Promise<ProbeResult | undefined> => {
+    operations.push(operation);
+    try {
+      await action();
+      return undefined;
+    } catch (error) {
+      return {
+        ok: false,
+        operations,
+        error,
+        failedOperation: operation,
+        authenticationRequired: isAuthenticationError(error, operation),
+        rateLimitExceeded: isRateLimitError(error)
+      };
+    }
+  };
+
+  const repositoryPath = `/repos/${source.owner}/${source.repo}`;
+  if (!skipRepositoryMetadata) {
+    const failedRepository = await run('repository metadata', () => client.getJson(repositoryPath));
+    if (failedRepository !== undefined) {
+      return failedRepository;
+    }
+  }
+  const commitPath = `${repositoryPath}/commits/${encodeURIComponent(source.branch)}`;
+  operations.push('default branch commit');
+  let revision: string | undefined;
+  try {
+    const commit = await client.getJson<{ sha?: unknown }>(commitPath);
+    if (typeof commit.sha === 'string' && commit.sha.length > 0) {
+      revision = commit.sha;
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      operations,
+      error,
+      failedOperation: 'default branch commit',
+      authenticationRequired: isAuthenticationError(error, 'default branch commit'),
+      rateLimitExceeded: isRateLimitError(error)
+    };
+  }
+  const treePath = `${repositoryPath}/git/trees/${encodeURIComponent(source.branch)}?recursive=1`;
+  const failedTree = await run('recursive repository tree', () => client.getJson(treePath));
+  if (failedTree !== undefined) {
+    return failedTree;
+  }
+  if (source.type === 'awesome-copilot') {
+    const collectionsPath = source.collectionsPath ?? 'collections';
+    const path = `${repositoryPath}/contents/${collectionsPath}?ref=${encodeURIComponent(source.branch)}`;
+    const failedCollections = await run('collection directory', () => client.getJson(path));
+    if (failedCollections !== undefined) {
+      return failedCollections;
+    }
+  }
+  if (source.type === 'awesome-copilot-plugin') {
+    const pluginsPath = source.pluginsPath ?? 'plugins';
+    const path = `${repositoryPath}/contents/${pluginsPath}?ref=${encodeURIComponent(source.branch)}`;
+    const failedPlugins = await run('plugin directory', () => client.getJson(path));
+    if (failedPlugins !== undefined) {
+      return failedPlugins;
+    }
+  }
+  if (includeReleases) {
+    const failedReleases = await run('release metadata', () => client.getJson(`${repositoryPath}/releases`));
+    if (failedReleases !== undefined) {
+      return failedReleases;
+    }
+  }
+  return {
+    ok: true,
+    operations,
+    ...(revision === undefined ? {} : { revision }),
+    authenticationRequired: false,
+    rateLimitExceeded: false
+  };
+}
+
+function unresolved(
+  source: HubSourceSpec,
+  target: GitHubRepositoryTarget | undefined,
+  operations: string[],
+  code: string
+): GitHubSourcePreflightResult {
+  return {
+    sourceId: source.id,
+    target,
+    category: 'unresolved',
+    operations,
+    credentialMode: 'none',
+    errorCode: code
+  };
+}
+
+function unresolvedForRateLimit(source: HubSourceSpec): GitHubSourcePreflightResult {
+  let target: GitHubRepositoryTarget | undefined;
+  try {
+    target = parseGitHubRepositoryTarget(source.url);
+  } catch {
+    // Keep the rate-limit reason stable even if a later source is also
+    // malformed; the first rate-limit result is what made the run unsafe.
+  }
+  return unresolved(source, target, [], 'GH_PUBLIC_GENERIC_RATE_LIMIT_UNSAFE');
+}
+
+function isAuthenticationError(error: unknown, operation: string): boolean {
+  const candidate = error as { statusCode?: unknown; code?: unknown; message?: unknown } | undefined;
+  const status = typeof candidate?.statusCode === 'number' ? candidate.statusCode : undefined;
+  if (status === 401 || status === 403) {
+    return !isRateLimitError(candidate);
+  }
+  if (status === 404) {
+    return operation === 'repository metadata';
+  }
+  if (typeof candidate?.code === 'string' && candidate.code.startsWith('GH_APP_AUTH_')) {
+    return true;
+  }
+  const message = typeof candidate?.message === 'string' ? candidate.message : String(error);
+  if (isRateLimitError(candidate)) {
+    return false;
+  }
+  if (/GH_APP_AUTH_(ROUTE_MISMATCH|INSTALLATION_MISSING|CONFIG_MISSING)/u.test(message)) {
+    return true;
+  }
+  if (/\b(401|403)\b|authentication failed|access forbidden/u.test(message.toLowerCase())) {
+    return true;
+  }
+  return operation === 'repository metadata' && /\b404\b|not found|not accessible/u.test(message.toLowerCase());
+}
+
+function isRateLimitError(error: unknown): boolean {
+  const candidate = error as {
+    message?: unknown;
+    statusCode?: unknown;
+    headers?: Record<string, string>;
+  } | undefined;
+  if (candidate?.statusCode === 429) {
+    return true;
+  }
+  if (candidate?.statusCode === 403 && candidate.headers?.['x-ratelimit-remaining'] === '0') {
+    return true;
+  }
+  const message = typeof candidate?.message === 'string'
+    ? candidate.message
+    : '';
+  return /rate.?limit|too many requests|retry-after/u.test(message.toLowerCase());
+}
+
+function errorCode(error: unknown): string {
+  const code = (error as { code?: unknown } | undefined)?.code;
+  if (typeof code === 'string' && code.startsWith('GH_')) {
+    return code;
+  }
+  const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+  if (/route/u.test(message)) {
+    return 'GH_APP_AUTH_ROUTE_MISMATCH';
+  }
+  if (/installation/u.test(message)) {
+    return 'GH_APP_AUTH_INSTALLATION_MISSING';
+  }
+  if (/\b401\b|\b403\b|\b404\b|authentication|forbidden|not accessible/u.test(message)) {
+    return 'GH_APP_AUTH_REQUEST_FAILED';
+  }
+  return 'GH_SOURCE_PREFLIGHT_UNRESOLVED';
+}

--- a/packages/infra/src/harvest/hub-config-parser.ts
+++ b/packages/infra/src/harvest/hub-config-parser.ts
@@ -3,9 +3,9 @@
  *
  * Reads a hub-config.yml (as produced by the VS Code extension / hub schema)
  * and emits a minimal, normalised list of sources the primitive-index
- * harvester understands. Only `github`, `awesome-copilot` and
- * `awesome-copilot-plugin` source types are supported today; everything
- * else is silently skipped (forward-compat).
+ * harvester/preflight understands. GitHub-backed `github`, `skills`, `apm`,
+ * `awesome-copilot`, and `awesome-copilot-plugin` source types are supported;
+ * everything else is silently skipped in permissive mode (forward-compat).
  *
  * Unknown `config.*` keys are preserved under `rawConfig` so downstream
  * experiments can consume new fields without forcing a schema bump here.
@@ -20,6 +20,14 @@ import type {
   HubSourceSpec,
 } from '@ai-primitives-hub/core';
 import * as yaml from 'js-yaml';
+import {
+  parseGitHubRepositoryTarget,
+} from '../http/github-repository-target';
+
+export interface ParseHubConfigOptions {
+  /** Reject enabled non-local entries that cannot be safely classified. */
+  strict?: boolean;
+}
 
 /**
  * Check if the entry type is supported.
@@ -27,7 +35,11 @@ import * as yaml from 'js-yaml';
  * @returns True if type is supported.
  */
 function isSupportedType(type: string | undefined): boolean {
-  return type === 'github' || type === 'awesome-copilot' || type === 'awesome-copilot-plugin';
+  return type === 'github'
+    || type === 'awesome-copilot'
+    || type === 'awesome-copilot-plugin'
+    || type === 'skills'
+    || type === 'apm';
 }
 
 /**
@@ -86,21 +98,31 @@ function extractPluginsPath(config: Record<string, unknown>, type: string | unde
  * Parse a single hub-config entry into a HubSourceSpec.
  * Returns undefined if the entry should be filtered out.
  * @param entry - Raw config entry object.
+ * @param strict
  */
-function parseHubConfigEntry(entry: Record<string, unknown>): HubSourceSpec | undefined {
+function parseHubConfigEntry(entry: Record<string, unknown>, strict: boolean): HubSourceSpec | undefined {
   if (entry.enabled === false) {
     return undefined;
   }
   const type = entry.type as string | undefined;
   if (!isSupportedType(type)) {
+    if (strict && type !== 'local' && type !== 'local-apm' && type !== 'local-skills' && type !== 'local-awesome-copilot' && type !== 'azure-devops') {
+      throw new Error(`Enabled source has unsupported type: ${String(type)}`);
+    }
     return undefined;
   }
   const url = extractUrl(entry);
   if (!url) {
+    if (strict) {
+      throw new Error(`Enabled ${type} source is missing a URL.`);
+    }
     return undefined;
   }
   const ownerRepo = normalizeRepoFromUrl(url);
   if (!ownerRepo) {
+    if (strict) {
+      throw new Error(`Enabled ${type} source has an invalid or non-GitHub repository URL: ${url}`);
+    }
     return undefined;
   }
   const config = (entry.config ?? {}) as Record<string, unknown>;
@@ -110,7 +132,7 @@ function parseHubConfigEntry(entry: Record<string, unknown>): HubSourceSpec | un
   return {
     id: idStr,
     name: nameStr,
-    type: type as 'github' | 'awesome-copilot' | 'awesome-copilot-plugin',
+    type: type as 'github' | 'awesome-copilot' | 'awesome-copilot-plugin' | 'skills' | 'apm',
     url,
     owner: ownerRepo.owner,
     repo: ownerRepo.repo,
@@ -125,12 +147,16 @@ function parseHubConfigEntry(entry: Record<string, unknown>): HubSourceSpec | un
  * Parse a hub-config.yml string (or already-parsed object) into normalised
  * source specs. Disabled sources and non-github hosts are filtered out.
  * @param input - Raw YAML string or already-parsed object.
+ * @param options
  */
-export function parseHubConfig(input: string | Record<string, unknown>): HubSourceSpec[] {
+export function parseHubConfig(
+  input: string | Record<string, unknown>,
+  options: ParseHubConfigOptions = {}
+): HubSourceSpec[] {
   const data = typeof input === 'string' ? (yaml.load(input) as Record<string, unknown>) : input;
   const raw = Array.isArray(data?.sources) ? (data.sources as Record<string, unknown>[]) : [];
   return raw.flatMap((entry) => {
-    const spec = parseHubConfigEntry(entry);
+    const spec = parseHubConfigEntry(entry, options.strict === true);
     return spec ? [spec] : [];
   });
 }
@@ -141,20 +167,10 @@ export function parseHubConfig(input: string | Record<string, unknown>): HubSour
  * @param url - URL to parse.
  */
 export function normalizeRepoFromUrl(url: string): { owner: string; repo: string } | undefined {
-  let u: URL;
   try {
-    u = new URL(url);
+    const target = parseGitHubRepositoryTarget(url);
+    return { owner: target.owner, repo: target.repository };
   } catch {
     return undefined;
   }
-  if (u.hostname !== 'github.com' && u.hostname !== 'www.github.com') {
-    return undefined;
-  }
-  const segments = u.pathname.split('/').filter((s) => s.length > 0);
-  if (segments.length < 2) {
-    return undefined;
-  }
-  const [owner, repoRaw] = segments;
-  const repo = repoRaw.endsWith('.git') ? repoRaw.slice(0, -4) : repoRaw;
-  return { owner, repo };
 }

--- a/packages/infra/src/harvest/hub-harvester.ts
+++ b/packages/infra/src/harvest/hub-harvester.ts
@@ -36,10 +36,12 @@ import {
 import * as path from 'node:path';
 import type {
   GitHubApi,
+  GitHubSourceAuthCategory,
+  HttpClient,
   HubSourceSpec,
   PrimitiveIndexKey,
   PrimitiveIndexStore,
-  TokenProvider,
+  ProcessExecutor,
 } from '@ai-primitives-hub/core';
 import {
   StaticTokenProvider,
@@ -47,6 +49,7 @@ import {
 import {
   GitHubApiClient,
   NodeHttpClient,
+  parseGitHubRepositoryTarget,
 } from '../http';
 import {
   PrimitiveIndex,
@@ -82,6 +85,23 @@ import {
 import {
   parseExtraSource,
 } from './extra-source';
+import {
+  createGitHubSourceAuthRuntime,
+  createGitHubSourceAuthSession,
+  GITHUB_APP_AUTH_KEY_FILE,
+  GITHUB_APP_CLIENT_ID,
+  GITHUB_APP_ID,
+  GITHUB_APP_INSTALLATION_ID,
+  type GitHubSourceAuthRuntime,
+  type GitHubSourceAuthSession,
+  isGitHubAppAuthEnabled,
+} from './github-source-auth-runtime';
+import {
+  GitHubSourcePreflightError,
+} from './github-source-preflight';
+import type {
+  GitHubSourcePreflightReport,
+} from './github-source-preflight';
 import {
   harvestBundle,
 } from './harvester';
@@ -128,6 +148,7 @@ interface ResolveHubSourcesParams {
   onLog: ((msg: string) => void) | undefined;
   sourcesInclude: string[] | undefined;
   sourcesExclude: string[] | undefined;
+  strictSourceParsing: boolean;
 }
 
 /**
@@ -146,6 +167,7 @@ interface BuildHarvestResultParams {
   client: GitHubApi;
   sourceRevision: string;
   hubId: string;
+  sourcePreflight?: GitHubSourcePreflightReport;
 }
 
 /** Reported when the transport carries no rate-limit telemetry (e.g. a fake). */
@@ -221,6 +243,20 @@ export interface HubHarvestPipelineOptions {
   hubId?: string;
   /** Optional shared namespaced index location resolver. */
   indexStore?: PrimitiveIndexStore;
+  /** Optional HTTP boundary for tests and advanced embedding callers. */
+  httpClient?: HttpClient;
+  /** Optional argv-safe process boundary for source-aware App auth. */
+  processExecutor?: ProcessExecutor;
+  /** App ID used to provision an ephemeral source-aware auth session. */
+  githubAppId?: string;
+  /** Alternative App Client ID used to provision an ephemeral auth session. */
+  githubAppClientId?: string;
+  /** Private-key PEM path used only by the explicit setup bootstrap. */
+  githubAppKeyFile?: string;
+  /** Optional installation ID for setup and repository-scoped token minting. */
+  githubAppInstallationId?: string;
+  /** Timeout for the explicit App setup process. */
+  githubAppSetupTimeoutMs?: number;
 }
 
 export interface HubHarvestPipelineResult {
@@ -245,6 +281,8 @@ export interface HubHarvestPipelineResult {
   tokenSource: string;
   sourceRevision: string;
   hubId: string;
+  /** Detailed source-aware classification and operation evidence, when enabled. */
+  sourcePreflight?: GitHubSourcePreflightReport;
   /** Per-source outcomes used by lifecycle adapters to expose index coverage. */
   sourceCoverage: HarvestSourceCoverage[];
 }
@@ -262,7 +300,14 @@ function resolveHubRepo(
 }
 
 async function resolveHubSources(params: ResolveHubSourcesParams): Promise<HubSourceSpec[]> {
-  let sources = await loadBaseSources(params.noHubConfig, params.hubConfigFile, params.hubRepo, params.hubBranch, params.client);
+  let sources = await loadBaseSources(
+    params.noHubConfig,
+    params.hubConfigFile,
+    params.hubRepo,
+    params.hubBranch,
+    params.client,
+    params.strictSourceParsing
+  );
   sources = injectExtraSources(sources, params.extraSources, params.onLog);
   sources = filterSources(sources, params.sourcesInclude, params.sourcesExclude);
   return sources;
@@ -273,10 +318,11 @@ async function loadBaseSources(
   hubConfigFile: string | undefined,
   hubRepo: string,
   hubBranch: string,
-  client: GitHubApi | undefined
+  client: GitHubApi | undefined,
+  strictSourceParsing: boolean
 ): Promise<HubSourceSpec[]> {
   if (hubConfigFile !== undefined) {
-    return parseHubConfig(await readFile(hubConfigFile, 'utf8'));
+    return parseHubConfig(await readFile(hubConfigFile, 'utf8'), { strict: strictSourceParsing });
   }
   if (noHubConfig) {
     return [];
@@ -288,7 +334,7 @@ async function loadBaseSources(
   const yamlText = await client.getText(
     `https://raw.githubusercontent.com/${owner}/${repo}/${hubBranch}/hub-config.yml`
   );
-  return parseHubConfig(yamlText);
+  return parseHubConfig(yamlText, { strict: strictSourceParsing });
 }
 
 function injectExtraSources(
@@ -338,47 +384,145 @@ export const harvestHub = async (
   env: NodeJS.ProcessEnv = process.env
 ): Promise<HubHarvestPipelineResult> => {
   validateHarvestOptions(opts);
+  const appBootstrapRequested = opts.githubAppId !== undefined
+    || opts.githubAppClientId !== undefined
+    || opts.githubAppKeyFile !== undefined
+    || env[GITHUB_APP_AUTH_KEY_FILE] !== undefined;
+  const appSession = appBootstrapRequested
+    ? await createGitHubSourceAuthSession({
+      env,
+      http: opts.httpClient ?? new NodeHttpClient(),
+      processExecutor: opts.processExecutor,
+      appId: opts.githubAppId ?? env[GITHUB_APP_ID],
+      clientId: opts.githubAppClientId ?? env[GITHUB_APP_CLIENT_ID],
+      keyFile: opts.githubAppKeyFile ?? env[GITHUB_APP_AUTH_KEY_FILE] ?? '',
+      installationId: opts.githubAppInstallationId ?? env[GITHUB_APP_INSTALLATION_ID],
+      setupTimeoutMs: opts.githubAppSetupTimeoutMs
+    })
+    : undefined;
+  try {
+    return await harvestHubWithAuth(opts, env, appSession);
+  } finally {
+    await appSession?.cleanup();
+  }
+};
+
+async function harvestHubWithAuth(
+  opts: HubHarvestPipelineOptions,
+  env: NodeJS.ProcessEnv,
+  appSession: GitHubSourceAuthSession | undefined
+): Promise<HubHarvestPipelineResult> {
   const { hubRepo, hubBranch, cacheDir, progressFile, outFile, concurrency } = resolveHarvestPaths(opts, env);
   const hubId = opts.hubId ?? (opts.noHubConfig === true || opts.hubConfigFile !== undefined ? 'local' : hubRepo);
 
   const requiresHubConfig = opts.noHubConfig !== true && opts.hubConfigFile === undefined;
+  const sourceAwareAuthentication = appSession !== undefined || isGitHubAppAuthEnabled(env);
   let client: GitHubApi | undefined;
   let resolvedToken: string | undefined;
   let tokenSource = 'none';
+  let sourcePreflight: GitHubSourcePreflightReport | undefined;
+  let sourcePreflightRevisions: ReadonlyMap<string, string> | undefined;
+  let sourceAuthenticationCategories: ReadonlyMap<string, GitHubSourceAuthCategory> | undefined;
+  const sourceAuth: GitHubSourceAuthRuntime | undefined = appSession ?? (sourceAwareAuthentication
+    ? createGitHubSourceAuthRuntime({
+      env,
+      http: opts.httpClient ?? new NodeHttpClient(),
+      processExecutor: opts.processExecutor
+    })
+    : undefined);
 
   if (requiresHubConfig) {
-    ({ resolvedToken, client, tokenSource } = await createGitHubClient(hubRepo, opts, env));
+    if (sourceAwareAuthentication) {
+      const hubTarget = parseGitHubRepositoryTarget(`https://github.com/${hubRepo}`);
+      client = sourceAuth!.clientFor(hubTarget, 'public-generic');
+    } else {
+      ({ resolvedToken, client, tokenSource } = await createGitHubClient(hubRepo, opts, env, undefined, opts.httpClient));
+    }
   } else {
-    client = opts.githubApi ?? createUnauthenticatedClient();
+    client = opts.githubApi ?? createUnauthenticatedClient(opts.httpClient);
   }
 
-  const sources = await resolveHubSources({
-    noHubConfig: opts.noHubConfig === true,
-    hubConfigFile: opts.hubConfigFile,
-    hubRepo,
-    hubBranch,
-    client,
-    extraSources: opts.extraSources,
-    onLog: opts.onLog,
-    sourcesInclude: opts.sourcesInclude,
-    sourcesExclude: opts.sourcesExclude
-  });
+  let sources: HubSourceSpec[];
+  try {
+    sources = await resolveHubSources({
+      noHubConfig: opts.noHubConfig === true,
+      hubConfigFile: opts.hubConfigFile,
+      hubRepo,
+      hubBranch,
+      client,
+      extraSources: opts.extraSources,
+      onLog: opts.onLog,
+      sourcesInclude: opts.sourcesInclude,
+      sourcesExclude: opts.sourcesExclude,
+      strictSourceParsing: sourceAwareAuthentication
+    });
+  } catch (error) {
+    if (!sourceAwareAuthentication || !requiresHubConfig || sourceAuth?.appTokenProvider === undefined || !isAuthenticationFailure(error)) {
+      throw error;
+    }
+    // The hub configuration itself is a runtime input. Retry it with the
+    // repository-scoped App only when authenticated generic loading indicates
+    // that this hub requires authentication; public hubs never receive App
+    // credentials.
+    const hubTarget = parseGitHubRepositoryTarget(`https://github.com/${hubRepo}`);
+    client = sourceAuth.clientFor(hubTarget, 'app-authenticated');
+    sources = await resolveHubSources({
+      noHubConfig: opts.noHubConfig === true,
+      hubConfigFile: opts.hubConfigFile,
+      hubRepo,
+      hubBranch,
+      client,
+      extraSources: opts.extraSources,
+      onLog: opts.onLog,
+      sourcesInclude: opts.sourcesInclude,
+      sourcesExclude: opts.sourcesExclude,
+      strictSourceParsing: sourceAwareAuthentication
+    });
+  }
+  let sourceClientFactory: ((source: HubSourceSpec) => GitHubApi) | undefined;
+  if (sourceAwareAuthentication) {
+    const preflight = await sourceAuth!.preflight(sources, {
+      onLog: (message) => opts.onLog?.(`[github preflight] ${message}`)
+    });
+    sourcePreflight = preflight;
+    if (!preflight.valid) {
+      throw new GitHubSourcePreflightError(preflight);
+    }
+    const decisions = new Map(preflight.results.map((sourceResult) => [sourceResult.sourceId, sourceResult]));
+    sourceClientFactory = (source) => {
+      const decision = decisions.get(source.id);
+      if (decision === undefined || decision.target === undefined || decision.category === 'unresolved') {
+        throw new Error(`GitHub source ${source.id} has no usable preflight decision.`);
+      }
+      return sourceAuth!.clientFor(decision.target, decision.category);
+    };
+    resolvedToken = undefined;
+    tokenSource = 'source-aware';
+    sourceAuthenticationCategories = new Map(
+      preflight.results
+        .filter((sourceResult) => sourceResult.category !== 'unresolved')
+        .map((sourceResult) => [sourceResult.sourceId, sourceResult.category])
+    );
+    sourcePreflightRevisions = new Map(
+      preflight.results
+        .filter((sourceResult): sourceResult is typeof sourceResult & { revision: string } => sourceResult.revision !== undefined)
+        .map((sourceResult) => [sourceResult.sourceId, sourceResult.revision])
+    );
+  }
 
-  // A local hub-config still needs an authenticated client for its GitHub
-  // sources. The unauthenticated client above is only sufficient to read the
-  // local config itself; leaving it in place silently bypasses env/gh token
-  // resolution and throttles every source as an anonymous request.
-  if (!requiresHubConfig && sources.length > 0) {
-    // A local hub-config should still use env/gh credentials when available,
-    // but harvesting public sources must continue to work anonymously when
-    // no token exists. Token resolution is diagnostic here, not mandatory.
-    ({ resolvedToken, client, tokenSource } = await createGitHubClient(hubRepo, opts, env, client));
+  // A local hub-config still needs a credentialed client for its GitHub
+  // sources. The empty client above is only sufficient to read the local
+  // config itself; leaving it in place bypasses env/gh token resolution.
+  if (!sourceAwareAuthentication && !requiresHubConfig && sources.length > 0) {
+    // Preserve the normal developer token chain when App mode is disabled.
+    // Source-aware mode has already failed closed before reaching this path.
+    ({ resolvedToken, client, tokenSource } = await createGitHubClient(hubRepo, opts, env, client, opts.httpClient));
   }
 
   // An empty offline harvest must succeed without GitHub credentials.
   // HubHarvester never calls the client when there are no sources.
   const harvestClient = client ?? opts.githubApi ?? new GitHubApiClient(
-    new NodeHttpClient(),
+    opts.httpClient ?? new NodeHttpClient(),
     { tokenProvider: new StaticTokenProvider('') }
   );
 
@@ -386,12 +530,14 @@ export const harvestHub = async (
   const result = await runHarvester(
     sources,
     harvestClient,
-    new StaticTokenProvider(resolvedToken ?? ''),
     cacheDir,
     progressFile,
     concurrency,
     opts,
-    hubId
+    hubId,
+    sourceClientFactory,
+    sourceAuthenticationCategories,
+    sourcePreflightRevisions
   );
   const searchProfileId = opts.searchProfileId ?? 'bm25-v1';
   const indexKey: PrimitiveIndexKey = {
@@ -418,9 +564,15 @@ export const harvestHub = async (
     tokenSource,
     client: harvestClient,
     sourceRevision: result.sourceRevision,
-    hubId
+    hubId,
+    sourcePreflight
   });
-};
+}
+
+function isAuthenticationFailure(error: unknown): boolean {
+  const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+  return /\b401\b|\b403\b|\b404\b|authentication failed|access forbidden|not accessible/u.test(message);
+}
 
 function validateHarvestOptions(opts: HubHarvestPipelineOptions): void {
   const noHubConfig = opts.noHubConfig === true;
@@ -454,7 +606,8 @@ async function createGitHubClient(
   hubRepo: string,
   opts: HubHarvestPipelineOptions,
   env: NodeJS.ProcessEnv,
-  fallbackClient?: GitHubApi
+  fallbackClient?: GitHubApi,
+  httpClient?: HttpClient
 ): Promise<{
   resolvedToken: string | undefined;
   client: GitHubApi;
@@ -465,7 +618,9 @@ async function createGitHubClient(
       const value = env[name];
       return value && value.length > 0 ? value : undefined;
     },
-    readGhCli: (): Promise<string | undefined> => defaultResolver.readGhCli()
+    readGhCli: (): Promise<string | undefined> => env.AI_PRIMITIVES_HUB_DISABLE_GH_CLI === '1'
+      ? Promise.resolve(undefined)
+      : defaultResolver.readGhCli()
   };
   const token = await resolveGithubToken({ explicit: opts.explicitToken }, resolver);
   if (token.token === undefined || token.token.length === 0) {
@@ -478,7 +633,7 @@ async function createGitHubClient(
   // An injected transport wins over building a real one, so a caller that
   // supplied a fake never reaches the network even once a token resolves.
   const client = opts.githubApi
-    ?? new GitHubApiClient(new NodeHttpClient(), { tokenProvider: new StaticTokenProvider(resolvedToken) });
+    ?? new GitHubApiClient(httpClient ?? new NodeHttpClient(), { tokenProvider: new StaticTokenProvider(resolvedToken) });
   const [owner, repo] = hubRepo.split('/');
   if (owner === undefined || repo === undefined || owner.length === 0 || repo.length === 0) {
     throw new Error(`Invalid hubRepo: ${hubRepo} (expected "owner/repo").`);
@@ -486,8 +641,8 @@ async function createGitHubClient(
   return { resolvedToken, client, tokenSource: token.source };
 }
 
-function createUnauthenticatedClient(): GitHubApiClient {
-  return new GitHubApiClient(new NodeHttpClient(), { tokenProvider: new StaticTokenProvider('') });
+function createUnauthenticatedClient(httpClient?: HttpClient): GitHubApiClient {
+  return new GitHubApiClient(httpClient ?? new NodeHttpClient(), { tokenProvider: new StaticTokenProvider('') });
 }
 
 function logHarvestStart(
@@ -509,17 +664,21 @@ function logHarvestStart(
 async function runHarvester(
   sources: HubSourceSpec[],
   client: GitHubApi,
-  tokenProvider: TokenProvider,
   cacheDir: string,
   progressFile: string,
   concurrency: number,
   opts: HubHarvestPipelineOptions,
-  hubId: string
+  hubId: string,
+  clientFactory?: (source: HubSourceSpec) => GitHubApi,
+  sourceAuthenticationCategories?: ReadonlyMap<string, GitHubSourceAuthCategory>,
+  sourcePreflightRevisions?: ReadonlyMap<string, string>
 ): Promise<HubHarvestResult> {
   const cache = new BlobCache(path.join(cacheDir, 'blobs'));
   const etagStore = await EtagStore.open(path.join(cacheDir, 'etags.json'));
   const harvester = new HubHarvester({
     sources, client, cache, etagStore,
+    clientFactory,
+    sourceAuthenticationCategories,
     progressFile, concurrency,
     force: opts.force ?? false,
     dryRun: opts.dryRun ?? false,
@@ -528,7 +687,8 @@ async function runHarvester(
     embeddings: opts.embeddings,
     embeddingStrategy: opts.embeddingStrategy,
     searchProfileId: opts.searchProfileId,
-    hubId
+    hubId,
+    sourcePreflightRevisions
   });
   const result = await harvester.run();
   await etagStore.save();
@@ -567,6 +727,7 @@ function buildHarvestResult(params: BuildHarvestResultParams): HubHarvestPipelin
     tokenSource: params.tokenSource,
     sourceRevision: params.sourceRevision,
     hubId: params.hubId,
+    ...(params.sourcePreflight === undefined ? {} : { sourcePreflight: params.sourcePreflight }),
     sourceCoverage: params.result.sourceCoverage
   };
 }
@@ -574,6 +735,12 @@ function buildHarvestResult(params: BuildHarvestResultParams): HubHarvestPipelin
 export interface HubHarvesterOptions {
   sources: HubSourceSpec[];
   client: GitHubApi;
+  /** Optional immutable per-source client factory for repository-aware auth. */
+  clientFactory?: (source: HubSourceSpec) => GitHubApi;
+  /** Optional preflight categories for safe source-level coverage reporting. */
+  sourceAuthenticationCategories?: ReadonlyMap<string, GitHubSourceAuthCategory>;
+  /** Commit revisions already verified by source-aware preflight. */
+  sourcePreflightRevisions?: ReadonlyMap<string, string>;
   cache: BlobCache;
   progressFile: string;
   /** Max number of bundles harvested in parallel. Default 1 (serial). */
@@ -619,6 +786,7 @@ export interface HarvestSourceCoverage {
   primitives?: number;
   revision?: string;
   message?: string;
+  authenticationCategory?: GitHubSourceAuthCategory;
 }
 
 export interface HubHarvestResult extends ProgressSummary {
@@ -638,6 +806,10 @@ export interface HubHarvestResult extends ProgressSummary {
 /* eslint-disable @typescript-eslint/member-ordering -- public API kept at top. */
 export class HubHarvester {
   public constructor(private readonly opts: HubHarvesterOptions) {}
+
+  private clientFor(source: HubSourceSpec): GitHubApi {
+    return this.opts.clientFactory?.(source) ?? this.opts.client;
+  }
 
   public async run(): Promise<HubHarvestResult> {
     const startedAt = Date.now();
@@ -726,7 +898,8 @@ export class HubHarvester {
     this.opts.onEvent?.({ kind: 'source-start', sourceId: spec.id });
     let commitSha: string | undefined;
     try {
-      commitSha = await this.resolveCommitShaForSource(spec);
+      const client = this.clientFor(spec);
+      commitSha = await this.resolveCommitShaForSource(spec, client);
       sourceRevisions.set(spec.id, {
         sourceId: spec.id,
         url: spec.url,
@@ -739,17 +912,19 @@ export class HubHarvester {
           sourceId: spec.id,
           state: 'skipped',
           revision: commitSha,
-          message: skipReason
+          message: skipReason,
+          ...this.authenticationCoverage(spec.id)
         });
         this.opts.onLog?.(`source ${spec.id} skipped`);
         return;
       }
-      const primsTotal = await this.harvestSource(spec, bundleId, commitSha, log, out);
+      const primsTotal = await this.harvestSource(spec, bundleId, commitSha, log, out, client);
       sourceCoverage.set(spec.id, {
         sourceId: spec.id,
         state: 'indexed',
         primitives: primsTotal,
-        revision: commitSha
+        revision: commitSha,
+        ...this.authenticationCoverage(spec.id)
       });
       this.opts.onLog?.(`source ${spec.id} done: ${String(primsTotal)} primitive${primsTotal === 1 ? '' : 's'}`);
       this.opts.onEvent?.({
@@ -774,14 +949,24 @@ export class HubHarvester {
         sourceId: spec.id,
         state: 'failed',
         revision: commitSha,
-        message: msg
+        message: msg,
+        ...this.authenticationCoverage(spec.id)
       });
       this.opts.onEvent?.({ kind: 'source-error', sourceId: spec.id, error: msg });
     }
   }
 
-  private async resolveCommitShaForSource(spec: HubSourceSpec): Promise<string> {
-    return resolveCommitSha(this.opts.client, {
+  private authenticationCoverage(sourceId: string): { authenticationCategory?: GitHubSourceAuthCategory } {
+    const category = this.opts.sourceAuthenticationCategories?.get(sourceId);
+    return category === undefined ? {} : { authenticationCategory: category };
+  }
+
+  private async resolveCommitShaForSource(spec: HubSourceSpec, client: GitHubApi): Promise<string> {
+    const preflightRevision = this.opts.sourcePreflightRevisions?.get(spec.id);
+    if (preflightRevision !== undefined) {
+      return preflightRevision;
+    }
+    return resolveCommitSha(client, {
       owner: spec.owner,
       repo: spec.repo,
       ref: spec.branch,
@@ -827,16 +1012,17 @@ export class HubHarvester {
     bundleId: string,
     commitSha: string,
     log: HarvestProgressLog,
-    out: Primitive[]
+    out: Primitive[],
+    client: GitHubApi
   ): Promise<number> {
     const startedRepo = Date.now();
     if (spec.type === 'awesome-copilot-plugin') {
-      return this.harvestPluginSource(spec, bundleId, commitSha, log, out, startedRepo);
+      return this.harvestPluginSource(spec, bundleId, commitSha, log, out, startedRepo, client);
     }
     if (spec.type === 'awesome-copilot') {
-      return this.harvestAwesomeCopilotSource(spec, bundleId, commitSha, log, out, startedRepo);
+      return this.harvestAwesomeCopilotSource(spec, bundleId, commitSha, log, out, startedRepo, client);
     }
-    return this.harvestGitHubSource(spec, bundleId, commitSha, log, out, startedRepo);
+    return this.harvestGitHubSource(spec, bundleId, commitSha, log, out, startedRepo, client);
   }
 
   private async harvestPluginSource(
@@ -845,10 +1031,11 @@ export class HubHarvester {
     commitSha: string,
     log: HarvestProgressLog,
     out: Primitive[],
-    startedRepo: number
+    startedRepo: number,
+    client: GitHubApi
   ): Promise<number> {
     const provider = new AwesomeCopilotPluginBundleProvider({
-      spec, client: this.opts.client, cache: this.opts.cache,
+      spec, client, cache: this.opts.cache,
       etagStore: this.opts.etagStore
     });
     const refs = await this.collectRefs(provider);
@@ -867,10 +1054,11 @@ export class HubHarvester {
     commitSha: string,
     log: HarvestProgressLog,
     out: Primitive[],
-    startedRepo: number
+    startedRepo: number,
+    client: GitHubApi
   ): Promise<number> {
     const provider = new AwesomeCopilotBundleProvider({
-      spec, client: this.opts.client, cache: this.opts.cache
+      spec, client, cache: this.opts.cache
     });
     const refs = await this.collectRefs(provider);
     const collectionConcurrency = Math.max(1, this.opts.concurrency ?? 4);
@@ -888,11 +1076,12 @@ export class HubHarvester {
     commitSha: string,
     log: HarvestProgressLog,
     out: Primitive[],
-    startedRepo: number
+    startedRepo: number,
+    client: GitHubApi
   ): Promise<number> {
     await log.recordStart({ sourceId: spec.id, bundleId, commitSha });
     const provider = new GitHubSingleBundleProvider({
-      spec, client: this.opts.client, cache: this.opts.cache
+      spec, client, cache: this.opts.cache
     });
     const refs = await this.collectRefs(provider);
     const ref = refs[0];

--- a/packages/infra/src/harvest/index.ts
+++ b/packages/infra/src/harvest/index.ts
@@ -10,6 +10,8 @@ export * from './extra-source';
 export * from './extractor';
 export * from './harvester';
 export * from './hub-config-parser';
+export * from './github-source-preflight';
+export * from './github-source-auth-runtime';
 export * from './hub-harvester';
 export * from './integrity';
 export * from './plugin-manifest';

--- a/packages/infra/src/http/github-api-client.ts
+++ b/packages/infra/src/http/github-api-client.ts
@@ -32,6 +32,8 @@
 import type {
   EtaggedResult,
   GitHubApi,
+  GitHubRepositoryTarget,
+  GitHubSourceAuthCategory,
   HttpClient,
   HttpResponse,
   TokenProvider,
@@ -77,6 +79,10 @@ export interface GitHubApiClientOptions {
   userAgent?: string;
   /** Resolves a bearer token for each request; omit for unauthenticated access. */
   tokenProvider?: TokenProvider;
+  /** Source repository used when a token provider mints repository-scoped credentials. */
+  repositoryTarget?: GitHubRepositoryTarget;
+  /** Preflight category controlling whether this client may resolve credentials. */
+  authenticationCategory?: GitHubSourceAuthCategory;
   /** Max retries after a transient failure. Default 4. */
   maxRetries?: number;
   /** Initial backoff (ms). Each retry doubles it. Default 250. */
@@ -160,8 +166,23 @@ export class GitHubApiClient implements GitHubApi {
       Accept: accept,
       ...extraHeaders
     };
+    if (this.options.authenticationCategory === 'public-anonymous') {
+      return headers;
+    }
     const host = new URL(url).hostname;
-    const token = await this.options.tokenProvider?.getToken(host);
+    const token = await this.options.tokenProvider?.getToken(host, this.options.repositoryTarget);
+    if (token === undefined && this.options.authenticationCategory === 'public-generic') {
+      throw authenticationRequiredError(
+        'GH_PUBLIC_GENERIC_TOKEN_UNAVAILABLE',
+        'A generic GitHub token is required for public source access.'
+      );
+    }
+    if (token === undefined && this.options.authenticationCategory === 'app-authenticated') {
+      throw authenticationRequiredError(
+        'GH_APP_AUTH_TOKEN_UNAVAILABLE',
+        'A repository-scoped GitHub App token is required for source access.'
+      );
+    }
     if (token) {
       headers.Authorization = `token ${token}`;
     }
@@ -305,16 +326,29 @@ export class GitHubApiClient implements GitHubApi {
   }
 }
 
+function authenticationRequiredError(code: string, message: string): Error & { code: string } {
+  return Object.assign(new Error(message), { code });
+}
+
 function describeError(response: HttpResponse, url: string): string {
   switch (response.statusCode) {
     case 401: {
       return `GitHub API error: 401 - Authentication failed. Token may be invalid or expired. (${url})`;
     }
     case 403: {
+      if (response.headers['x-ratelimit-remaining'] === '0') {
+        return `GitHub API error: 403 - GitHub primary rate limit exceeded. (${url})`;
+      }
+      if (response.headers['retry-after'] !== undefined) {
+        return `GitHub API error: 403 - GitHub secondary rate limit exceeded. (${url})`;
+      }
       return `GitHub API error: 403 - Access forbidden. Token may lack required scopes (repo). (${url})`;
     }
     case 404: {
       return `GitHub API error: 404 - Not found or not accessible. Check authentication. (${url})`;
+    }
+    case 429: {
+      return `GitHub API error: 429 - GitHub rate limit exceeded. (${url})`;
     }
     default: {
       return `GitHub API error: ${response.statusCode} (${url})`;

--- a/packages/infra/src/http/github-repository-target.ts
+++ b/packages/infra/src/http/github-repository-target.ts
@@ -1,0 +1,108 @@
+/**
+ * GitHub repository URL parsing and canonicalization shared by source-aware
+ * clients and authentication providers.
+ * @module http/github-repository-target
+ */
+import type {
+  GitHubRepositoryTarget,
+} from '@ai-primitives-hub/core';
+import {
+  isGitHubHost,
+} from './github-host';
+
+const SAFE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_.-]*$/u;
+const SAFE_HOST_PATTERN = /^[A-Za-z0-9.-]+$/u;
+const hasControlCharacters = (input: string): boolean => {
+  for (const character of input) {
+    const code = character.codePointAt(0) ?? 0;
+    if (code < 0x20 || code === 0x7F) {
+      return true;
+    }
+  }
+  return false;
+};
+
+/**
+ * Parse an HTTPS URL, SSH URL, or canonical `owner/repository` slug.
+ * @param value Repository URL or slug.
+ * @returns Normalized repository target.
+ * @throws {Error} When the input is not a safe GitHub repository reference.
+ */
+export function parseGitHubRepositoryTarget(value: string): GitHubRepositoryTarget {
+  if (typeof value !== 'string' || value.length === 0 || value.trim() !== value) {
+    throw new Error('GitHub repository reference must be a non-empty trimmed string.');
+  }
+
+  if (value.startsWith('git@')) {
+    const match = /^git@([^:]+):(.+)$/u.exec(value);
+    if (match === null) {
+      throw new Error('Invalid GitHub SSH repository reference.');
+    }
+    return createTarget(match[1], match[2]);
+  }
+
+  if (value.includes('://')) {
+    let url: URL;
+    try {
+      url = new URL(value);
+    } catch {
+      throw new Error('Invalid GitHub repository URL.');
+    }
+    const hasForbiddenUrlParts = url.protocol !== 'https:'
+      || url.port.length > 0
+      || url.username.length > 0
+      || url.password.length > 0
+      || url.search.length > 0
+      || url.hash.length > 0
+      || value.includes('?')
+      || value.includes('#');
+    if (hasForbiddenUrlParts) {
+      throw new Error('GitHub repository URL must be HTTPS without credentials, query, or fragment.');
+    }
+    return createTarget(url.hostname, url.pathname);
+  }
+
+  const canonicalValue = value.replace(/\/+$/u, '');
+  const segments = canonicalValue.split('/');
+  if (segments.length === 3 && isGitHubHost(segments[0].toLowerCase())) {
+    return createTarget(segments[0], `${segments[1]}/${segments[2]}`);
+  }
+  return createTarget('github.com', value);
+}
+
+/**
+ * Canonicalize a repository target for `gh app-auth token --repo`.
+ * @param target Repository target.
+ * @returns `host/owner/repository`.
+ */
+export function canonicalizeGitHubRepositoryTarget(target: GitHubRepositoryTarget): string {
+  const normalized = createTarget(target.host, `${target.owner}/${target.repository}`);
+  return `${normalized.host}/${normalized.owner}/${normalized.repository}`;
+}
+
+function createTarget(hostValue: string, pathValue: string): GitHubRepositoryTarget {
+  if (hostValue.length === 0 || hostValue.trim() !== hostValue || !SAFE_HOST_PATTERN.test(hostValue)) {
+    throw new Error('GitHub repository host is invalid.');
+  }
+  const host = hostValue.toLowerCase();
+  if (!isGitHubHost(host)) {
+    throw new Error('GitHub repository host is not GitHub-owned.');
+  }
+  if (pathValue.includes('?') || pathValue.includes('#') || hasControlCharacters(pathValue)) {
+    throw new Error('GitHub repository path is invalid.');
+  }
+  const pathWithoutLeadingSlash = pathValue.startsWith('/') ? pathValue.slice(1) : pathValue;
+  const segments = pathWithoutLeadingSlash.split('/');
+  while (segments.at(-1) === '') {
+    segments.pop();
+  }
+  if (segments.length !== 2) {
+    throw new Error('GitHub repository reference must contain exactly owner/repository.');
+  }
+  const owner = segments[0];
+  const repository = segments[1].endsWith('.git') ? segments[1].slice(0, -4) : segments[1];
+  if (owner.length === 0 || repository.length === 0 || !SAFE_ID_PATTERN.test(owner) || !SAFE_ID_PATTERN.test(repository)) {
+    throw new Error('GitHub repository owner or repository is invalid.');
+  }
+  return { host, owner, repository };
+}

--- a/packages/infra/src/http/index.ts
+++ b/packages/infra/src/http/index.ts
@@ -6,5 +6,6 @@ export * from './azure-devops-api-client';
 export * from './azure-devops-host';
 export * from './github-api-client';
 export * from './github-host';
+export * from './github-repository-target';
 export * from './node-http-client';
 export * from './proxy-env';

--- a/packages/infra/src/hub/hub-resolver.ts
+++ b/packages/infra/src/hub/hub-resolver.ts
@@ -19,12 +19,16 @@
  */
 import type {
   FileSystem,
+  GitHubRepositoryTarget,
   HttpClient,
   HubConfig,
   HubReference,
   TokenProvider,
 } from '@ai-primitives-hub/core';
 import * as yaml from 'js-yaml';
+import {
+  parseGitHubRepositoryTarget,
+} from '../http/github-repository-target';
 
 export interface ResolvedHub {
   config: HubConfig;
@@ -43,6 +47,14 @@ export interface HubResolver {
   resolve(ref: HubReference): Promise<ResolvedHub>;
 }
 
+export interface GitHubHubResolverOptions {
+  /** Use generic public auth first, with an App-only retry for private hubs. */
+  sourceAware?: {
+    genericTokenProvider?: TokenProvider;
+    appTokenProvider?: TokenProvider;
+  };
+}
+
 /**
  * Shared GET-and-parse-YAML logic for the `url`/`github` resolvers,
  * mirroring the extension's `fetchFromUrl` (minus manual redirect
@@ -50,10 +62,24 @@ export interface HubResolver {
  * @param http HttpClient to fetch with.
  * @param tokens TokenProvider consulted for the target host.
  * @param url Absolute URL to GET.
+ * @param repositoryTarget
+ * @param requireToken
  */
-async function fetchYamlConfig(http: HttpClient, tokens: TokenProvider, url: string): Promise<HubConfig> {
+async function fetchYamlConfig(
+  http: HttpClient,
+  tokens: TokenProvider | undefined,
+  url: string,
+  repositoryTarget?: GitHubRepositoryTarget,
+  requireToken = false
+): Promise<HubConfig> {
   const headers: Record<string, string> = {};
-  const token = await tokens.getToken(new URL(url).hostname);
+  const token = await tokens?.getToken(new URL(url).hostname, repositoryTarget);
+  if (token === undefined && requireToken) {
+    throw Object.assign(
+      new Error('A generic GitHub token is required to fetch a hub configuration.'),
+      { code: 'GH_PUBLIC_GENERIC_TOKEN_UNAVAILABLE' }
+    );
+  }
   if (token !== undefined) {
     headers.Authorization = `token ${token}`;
   }
@@ -138,10 +164,12 @@ export class GitHubHubResolver implements HubResolver {
    * Construct a GitHubHubResolver instance.
    * @param http HttpClient for the GET request.
    * @param tokens TokenProvider for private repos.
+   * @param options
    */
   public constructor(
     private readonly http: HttpClient,
-    private readonly tokens: TokenProvider
+    private readonly tokens: TokenProvider,
+    private readonly options: GitHubHubResolverOptions = {}
   ) {}
 
   /**
@@ -153,9 +181,41 @@ export class GitHubHubResolver implements HubResolver {
     const branch = ref.ref ?? 'main';
     const timestamp = Date.now();
     const url = `https://raw.githubusercontent.com/${ref.location}/${branch}/hub-config.yml?t=${timestamp}`;
-    const config = await fetchYamlConfig(this.http, this.tokens, url);
-    return { config, reference: ref };
+    const repositoryTarget = parseGitHubRepositoryTarget(ref.location);
+    if (this.options.sourceAware === undefined) {
+      const config = await fetchYamlConfig(this.http, this.tokens, url, repositoryTarget);
+      return { config, reference: ref };
+    }
+    try {
+      const config = await fetchYamlConfig(
+        this.http,
+        this.options.sourceAware.genericTokenProvider,
+        url,
+        repositoryTarget,
+        true
+      );
+      return { config, reference: ref };
+    } catch (error) {
+      if (this.options.sourceAware.appTokenProvider === undefined || !isAuthenticationFailure(error)) {
+        throw error;
+      }
+      const config = await fetchYamlConfig(
+        this.http,
+        this.options.sourceAware.appTokenProvider,
+        url,
+        repositoryTarget
+      );
+      return { config, reference: ref };
+    }
   }
+}
+
+function isAuthenticationFailure(error: unknown): boolean {
+  const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+  if (/rate.?limit|too many requests|retry-after/u.test(message)) {
+    return false;
+  }
+  return /\b401\b|\b403\b|\b404\b|authentication failed|access forbidden|not accessible/u.test(message);
 }
 
 /**

--- a/packages/infra/src/process/index.ts
+++ b/packages/infra/src/process/index.ts
@@ -3,3 +3,4 @@
  * @module process
  */
 export * from './node-process-runner';
+export * from './node-process-executor';

--- a/packages/infra/src/process/node-process-executor.ts
+++ b/packages/infra/src/process/node-process-executor.ts
@@ -1,0 +1,40 @@
+/**
+ * Node `child_process.execFile` implementation of the argv-safe
+ * `ProcessExecutor` port.
+ * @module process/node-process-executor
+ */
+import {
+  execFile,
+} from 'node:child_process';
+import {
+  promisify,
+} from 'node:util';
+import type {
+  ProcessExecutor,
+  ProcessResult,
+  ProcessRunOptions,
+} from '@ai-primitives-hub/core';
+
+const execFileAsync = promisify(execFile);
+
+/** Environment variables never forwarded to a spawned process. */
+const UNSAFE_ENV_VARS = ['LD_PRELOAD', 'DYLD_INSERT_LIBRARIES'];
+
+export class NodeProcessExecutor implements ProcessExecutor {
+  public async execFile(
+    file: string,
+    args: readonly string[],
+    options: ProcessRunOptions = {}
+  ): Promise<ProcessResult> {
+    const env: Record<string, string | undefined> = { ...process.env, ...options.env };
+    for (const unsafeVar of UNSAFE_ENV_VARS) {
+      delete env[unsafeVar];
+    }
+
+    return execFileAsync(file, [...args], {
+      cwd: options.cwd,
+      env,
+      timeout: options.timeoutMs
+    });
+  }
+}

--- a/packages/infra/src/resolvers/resolver-registry.ts
+++ b/packages/infra/src/resolvers/resolver-registry.ts
@@ -21,8 +21,9 @@
  * dispatch is intentional and stays (list-all-bundles vs resolve-one-spec
  * are different consumer needs — see `github-resolver.ts`'s module doc).
  * What *was* consolidated: every GitHub-backed resolver constructed here
- * now shares the one `GitHubApi` instance passed in, instead of each
- * resolver rebuilding its own raw-HTTP auth/error handling.
+ * uses the injected shared `GitHubApi` by default, or an explicit
+ * source-bound factory when repository-aware authentication is enabled,
+ * instead of rebuilding raw-HTTP auth/error handling.
  * @module resolvers/resolver-registry
  */
 
@@ -32,6 +33,9 @@ import type {
   GitHubApi,
   RegistrySource,
 } from '@ai-primitives-hub/core';
+import {
+  parseGitHubRepositoryTarget,
+} from '../http/github-repository-target';
 import {
   AwesomeCopilotBundleResolver,
 } from './awesome-copilot-resolver';
@@ -47,6 +51,8 @@ import {
 export interface SourceDispatcherOptions {
   /** Shared GitHub API client, reused across every GitHub-backed resolver. */
   githubApi: GitHubApi;
+  /** Optional source-bound client factory; overrides `githubApi` for remote sources. */
+  githubApiFactory?: (source: RegistrySource) => GitHubApi;
   /** Filesystem abstraction for local sources. */
   fs: FileSystem;
 }
@@ -56,10 +62,12 @@ export interface SourceDispatcherOptions {
  */
 export class SourceDispatcher {
   private readonly githubApi: GitHubApi;
+  private readonly githubApiFactory: ((source: RegistrySource) => GitHubApi) | undefined;
   private readonly fs: FileSystem;
 
   public constructor(opts: SourceDispatcherOptions) {
     this.githubApi = opts.githubApi;
+    this.githubApiFactory = opts.githubApiFactory;
     this.fs = opts.fs;
   }
 
@@ -69,10 +77,12 @@ export class SourceDispatcher {
    * @returns Repo slug (e.g., "owner/repo").
    */
   private repoSlug(url: string): string {
-    return url
-      .replace(/^https?:\/\/github\.com\//, '')
-      .replace(/\.git$/, '')
-      .replace(/\/+$/, '');
+    const target = parseGitHubRepositoryTarget(url);
+    return `${target.owner}/${target.repository}`;
+  }
+
+  private apiFor(source: RegistrySource): GitHubApi {
+    return this.githubApiFactory?.(source) ?? this.githubApi;
   }
 
   /**
@@ -85,7 +95,7 @@ export class SourceDispatcher {
       case 'github': {
         return new GitHubBundleResolver({
           repoSlug: this.repoSlug(source.url),
-          githubApi: this.githubApi
+          githubApi: this.apiFor(source)
         });
       }
       case 'awesome-copilot': {
@@ -94,14 +104,14 @@ export class SourceDispatcher {
           repoSlug: this.repoSlug(source.url),
           branch: config.branch,
           collectionsPath: config.collectionsPath,
-          githubApi: this.githubApi
+          githubApi: this.apiFor(source)
         });
       }
       case 'skills': {
         return new SkillsBundleResolver({
           repoSlug: this.repoSlug(source.url),
           ref: (source as { ref?: string }).ref,
-          githubApi: this.githubApi
+          githubApi: this.apiFor(source)
         });
       }
       case 'local-skills': {

--- a/packages/infra/test/auth/composite-token-provider.test.ts
+++ b/packages/infra/test/auth/composite-token-provider.test.ts
@@ -1,4 +1,5 @@
 import type {
+  GitHubRepositoryTarget,
   TokenProvider,
 } from '@ai-primitives-hub/core';
 import {
@@ -82,5 +83,32 @@ describe('CompositeTokenProvider', () => {
 
     await provider.getToken('api.github.com');
     expect(seenHosts).toEqual(['api.github.com', 'api.github.com']);
+  });
+
+  it('passes optional repository context through to every provider', async () => {
+    const target: GitHubRepositoryTarget = {
+      host: 'github.com',
+      owner: 'owner',
+      repository: 'repo'
+    };
+    const seenTargets: (GitHubRepositoryTarget | undefined)[] = [];
+    const provider = new CompositeTokenProvider([
+      {
+        getToken: async (_host: string, repositoryTarget?: GitHubRepositoryTarget) => {
+          seenTargets.push(repositoryTarget);
+          return undefined;
+        }
+      },
+      {
+        getToken: async (_host: string, repositoryTarget?: GitHubRepositoryTarget) => {
+          seenTargets.push(repositoryTarget);
+          return undefined;
+        }
+      }
+    ]);
+
+    await provider.getToken('api.github.com', target);
+
+    expect(seenTargets).toEqual([target, target]);
   });
 });

--- a/packages/infra/test/auth/generic-public-token-provider.test.ts
+++ b/packages/infra/test/auth/generic-public-token-provider.test.ts
@@ -1,0 +1,81 @@
+import type {
+  TokenProvider,
+} from '@ai-primitives-hub/core';
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  GenericPublicTokenProvider,
+} from '../../src/auth/generic-public-token-provider';
+
+class StubGhTokenProvider implements TokenProvider {
+  public calls = 0;
+
+  public constructor(private readonly token: string | undefined) {}
+
+  public async getToken(): Promise<string | undefined> {
+    this.calls += 1;
+    return this.token;
+  }
+}
+
+describe('GenericPublicTokenProvider', () => {
+  it('prefers GH_TOKEN over GITHUB_TOKEN', async () => {
+    const ghCli = new StubGhTokenProvider('from-gh-cli');
+    const provider = new GenericPublicTokenProvider({
+      env: { GH_TOKEN: 'from-gh-token', GITHUB_TOKEN: 'from-github-token' },
+      ghCli
+    });
+
+    await expect(provider.getToken('api.github.com')).resolves.toBe('from-gh-token');
+    expect(ghCli.calls).toBe(0);
+  });
+
+  it('falls back to GITHUB_TOKEN when GH_TOKEN is unavailable', async () => {
+    const provider = new GenericPublicTokenProvider({
+      env: { GITHUB_TOKEN: 'from-github-token' },
+      ghCli: new StubGhTokenProvider('from-gh-cli')
+    });
+
+    await expect(provider.getToken('github.com')).resolves.toBe('from-github-token');
+  });
+
+  it('uses gh auth token locally when no generic environment token exists', async () => {
+    const ghCli = new StubGhTokenProvider('from-gh-cli');
+    const provider = new GenericPublicTokenProvider({ env: {}, ghCli, allowGhCli: true });
+
+    await expect(provider.getToken('github.com')).resolves.toBe('from-gh-cli');
+    expect(ghCli.calls).toBe(1);
+  });
+
+  it('single-flights and caches the local gh token for the process lifetime', async () => {
+    const ghCli = new StubGhTokenProvider('from-gh-cli');
+    const provider = new GenericPublicTokenProvider({ env: {}, ghCli, allowGhCli: true });
+
+    await expect(Promise.all([
+      provider.getToken('api.github.com'),
+      provider.getToken('api.github.com'),
+      provider.getToken('api.github.com')
+    ])).resolves.toEqual(['from-gh-cli', 'from-gh-cli', 'from-gh-cli']);
+    await expect(provider.getToken('api.github.com')).resolves.toBe('from-gh-cli');
+    expect(ghCli.calls).toBe(1);
+  });
+
+  it('does not use gh auth token in CI when no generic environment token exists', async () => {
+    const ghCli = new StubGhTokenProvider('from-gh-cli');
+    const provider = new GenericPublicTokenProvider({ env: { CI: 'true' }, ghCli });
+
+    await expect(provider.getToken('github.com')).resolves.toBeUndefined();
+    expect(ghCli.calls).toBe(0);
+  });
+
+  it('does not invoke any credential source for a foreign host', async () => {
+    const ghCli = new StubGhTokenProvider('from-gh-cli');
+    const provider = new GenericPublicTokenProvider({ env: { GH_TOKEN: 'token' }, ghCli });
+
+    await expect(provider.getToken('example.com')).resolves.toBeUndefined();
+    expect(ghCli.calls).toBe(0);
+  });
+});

--- a/packages/infra/test/auth/gh-app-auth-setup-manager.test.ts
+++ b/packages/infra/test/auth/gh-app-auth-setup-manager.test.ts
@@ -1,0 +1,67 @@
+import type {
+  ProcessExecutor,
+  ProcessResult,
+  ProcessRunOptions,
+} from '@ai-primitives-hub/core';
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  GhAppAuthSetupManager,
+} from '../../src/auth/gh-app-auth-setup-manager';
+
+class RecordingExecutor implements ProcessExecutor {
+  public file = '';
+  public args: readonly string[] = [];
+  public options: ProcessRunOptions | undefined;
+
+  public async execFile(file: string, args: readonly string[], options?: ProcessRunOptions): Promise<ProcessResult> {
+    this.file = file;
+    this.args = args;
+    this.options = options;
+    return { stdout: '', stderr: '' };
+  }
+}
+
+describe('GhAppAuthSetupManager', () => {
+  it('invokes setup with sorted routes and an isolated config path', async () => {
+    const executor = new RecordingExecutor();
+    const manager = new GhAppAuthSetupManager({
+      appId: '123',
+      keyFile: '/run/secrets/app-key',
+      configPath: '/tmp/gh-app-auth.yml',
+      routes: ['github.com/Z-org/*', 'github.com/a-org/*'],
+      processExecutor: executor
+    });
+
+    await manager.setup();
+
+    expect(executor.file).toBe('gh');
+    expect(executor.args).toEqual([
+      'app-auth', 'setup',
+      '--app-id', '123',
+      '--key-file', '/run/secrets/app-key',
+      '--patterns', 'github.com/a-org/*,github.com/Z-org/*',
+      '--use-filesystem'
+    ]);
+    expect(executor.options).toEqual({
+      env: { GH_APP_AUTH_CONFIG: '/tmp/gh-app-auth.yml' },
+      timeoutMs: 120_000
+    });
+  });
+
+  it('rejects an empty route set before spawning', async () => {
+    const executor = new RecordingExecutor();
+    const manager = new GhAppAuthSetupManager({
+      appId: '123',
+      configPath: '/tmp/config.yml',
+      routes: [],
+      processExecutor: executor
+    });
+
+    await expect(manager.setup()).rejects.toMatchObject({ code: 'GH_APP_AUTH_SETUP_ROUTES_MISSING' });
+    expect(executor.file).toBe('');
+  });
+});

--- a/packages/infra/test/auth/gh-app-token-provider.test.ts
+++ b/packages/infra/test/auth/gh-app-token-provider.test.ts
@@ -1,0 +1,196 @@
+import type {
+  GitHubRepositoryTarget,
+  ProcessExecutor,
+  ProcessResult,
+  ProcessRunOptions,
+} from '@ai-primitives-hub/core';
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  GhAppAuthError,
+  GhAppTokenProvider,
+} from '../../src/auth/gh-app-token-provider';
+
+interface ProcessCall {
+  file: string;
+  args: readonly string[];
+  options: ProcessRunOptions | undefined;
+}
+
+class FakeProcessExecutor implements ProcessExecutor {
+  public readonly calls: ProcessCall[] = [];
+  public outputs: string[] = ['installation-token'];
+  public pending: Promise<ProcessResult> | undefined;
+
+  public async execFile(file: string, args: readonly string[], options?: ProcessRunOptions): Promise<ProcessResult> {
+    this.calls.push({ file, args, options });
+    if (this.pending !== undefined) {
+      return this.pending;
+    }
+    return {
+      stdout: this.outputs.shift() ?? 'installation-token',
+      stderr: ''
+    };
+  }
+}
+
+const target = (owner: string, repository: string): GitHubRepositoryTarget => ({
+  host: 'github.com',
+  owner,
+  repository
+});
+
+const makeProvider = (executor: FakeProcessExecutor, now: () => number = () => 1000): GhAppTokenProvider =>
+  new GhAppTokenProvider({
+    appId: '123',
+    configPath: '/tmp/isolated-gh-app-auth.yml',
+    processExecutor: executor,
+    now,
+    cacheTtlMs: 500,
+    timeoutMs: 10_000
+  });
+
+describe('GhAppTokenProvider', () => {
+  it('does not invoke gh for a non-GitHub request host', async () => {
+    const executor = new FakeProcessExecutor();
+    const provider = makeProvider(executor);
+
+    await expect(provider.getToken('example.com', target('owner', 'repo'))).resolves.toBeUndefined();
+    expect(executor.calls).toHaveLength(0);
+  });
+
+  it('requires repository context for a GitHub request', async () => {
+    const provider = makeProvider(new FakeProcessExecutor());
+
+    await expect(provider.getToken('api.github.com')).rejects.toMatchObject({
+      code: 'GH_APP_AUTH_REPOSITORY_CONTEXT_MISSING'
+    });
+  });
+
+  it('invokes gh with exact argv, repository context, isolated config, and timeout', async () => {
+    const executor = new FakeProcessExecutor();
+    const provider = makeProvider(executor);
+
+    await expect(provider.getToken('raw.githubusercontent.com', target('owner', 'repo'))).resolves.toBe('installation-token');
+
+    expect(executor.calls).toEqual([{
+      file: 'gh',
+      args: ['app-auth', 'token', '--app-id', '123', '--repo', 'github.com/owner/repo'],
+      options: {
+        env: { GH_APP_AUTH_CONFIG: '/tmp/isolated-gh-app-auth.yml' },
+        timeoutMs: 10_000
+      }
+    }]);
+  });
+
+  it('includes an optional installation id in the argv', async () => {
+    const executor = new FakeProcessExecutor();
+    const provider = new GhAppTokenProvider({
+      clientId: 'Iv1.client',
+      configPath: '/tmp/config.yml',
+      installationId: 456,
+      processExecutor: executor
+    });
+
+    await provider.getToken('github.com', target('owner', 'repo'));
+
+    expect(executor.calls[0]?.args).toEqual([
+      'app-auth', 'token', '--client-id', 'Iv1.client',
+      '--repo', 'github.com/owner/repo', '--installation-id', '456'
+    ]);
+  });
+
+  it('caches per exact repository and refreshes after the safety ttl', async () => {
+    let now = 1000;
+    const executor = new FakeProcessExecutor();
+    executor.outputs = ['token-one', 'token-two', 'token-three'];
+    const provider = makeProvider(executor, () => now);
+
+    await expect(provider.getToken('api.github.com', target('owner', 'one'))).resolves.toBe('token-one');
+    now = 1499;
+    await expect(provider.getToken('api.github.com', target('owner', 'one'))).resolves.toBe('token-one');
+    await expect(provider.getToken('api.github.com', target('owner', 'two'))).resolves.toBe('token-two');
+    now = 1500;
+    await expect(provider.getToken('api.github.com', target('owner', 'one'))).resolves.toBe('token-three');
+
+    expect(executor.calls).toHaveLength(3);
+  });
+
+  it('single-flights concurrent requests for the same repository', async () => {
+    let release!: (result: ProcessResult) => void;
+    const pending = new Promise<ProcessResult>((resolve) => {
+      release = resolve;
+    });
+    const executor = new FakeProcessExecutor();
+    executor.pending = pending;
+    const provider = makeProvider(executor);
+
+    const first = provider.getToken('api.github.com', target('owner', 'repo'));
+    const second = provider.getToken('raw.githubusercontent.com', target('owner', 'repo'));
+    expect(executor.calls).toHaveLength(1);
+
+    release({ stdout: 'shared-token\n', stderr: '' });
+    await expect(Promise.all([first, second])).resolves.toEqual(['shared-token', 'shared-token']);
+  });
+
+  it.each([
+    ['', 'GH_APP_AUTH_OUTPUT_INVALID'],
+    ['   \n', 'GH_APP_AUTH_OUTPUT_INVALID'],
+    ['one\ntwo\n', 'GH_APP_AUTH_OUTPUT_INVALID'],
+    ['one\r\n', 'GH_APP_AUTH_OUTPUT_INVALID'],
+    ['one\u0000two\n', 'GH_APP_AUTH_OUTPUT_INVALID']
+  ])('rejects unsafe stdout %j with %s', async (stdout, code) => {
+    const executor = new FakeProcessExecutor();
+    executor.outputs = [stdout];
+    const provider = makeProvider(executor);
+
+    await expect(provider.getToken('github.com', target('owner', 'repo'))).rejects.toMatchObject({ code });
+  });
+
+  it('rejects invalid selector and config combinations before spawning', () => {
+    expect(() => new GhAppTokenProvider({
+      appId: '123',
+      clientId: 'client',
+      configPath: '/tmp/config.yml',
+      processExecutor: new FakeProcessExecutor()
+    })).toThrowError(GhAppAuthError);
+    expect(() => new GhAppTokenProvider({
+      appId: '123',
+      processExecutor: new FakeProcessExecutor()
+    })).toThrowError(GhAppAuthError);
+  });
+
+  it.each([
+    [{ code: 'ENOENT' }, 'GH_APP_AUTH_CLI_UNAVAILABLE'],
+    [{ message: 'configured route does not cover repository' }, 'GH_APP_AUTH_ROUTE_MISMATCH'],
+    [{ message: 'no installation found for organization' }, 'GH_APP_AUTH_INSTALLATION_MISSING'],
+    [{ code: 'ETIMEDOUT' }, 'GH_APP_AUTH_TIMEOUT'],
+    [{ message: 'GitHub rejected the request' }, 'GH_APP_AUTH_MINT_FAILED']
+  ])('maps process failure %j to %s', async (failure, code) => {
+    const executor: ProcessExecutor = {
+      execFile: () => Promise.reject(Object.assign(new Error('gh failed'), failure))
+    };
+    const provider = new GhAppTokenProvider({
+      appId: '123',
+      configPath: '/tmp/config.yml',
+      processExecutor: executor
+    });
+
+    await expect(provider.getToken('github.com', target('owner', 'repo'))).rejects.toMatchObject({ code });
+  });
+
+  it('rejects an invalid repository target without invoking gh', async () => {
+    const executor = new FakeProcessExecutor();
+    const provider = makeProvider(executor);
+
+    await expect(provider.getToken('github.com', {
+      host: 'github.com',
+      owner: 'owner/name',
+      repository: 'repo'
+    })).rejects.toMatchObject({ code: 'GH_APP_AUTH_REPOSITORY_INVALID' });
+    expect(executor.calls).toHaveLength(0);
+  });
+});

--- a/packages/infra/test/downloaders/https-bundle-downloader.test.ts
+++ b/packages/infra/test/downloaders/https-bundle-downloader.test.ts
@@ -1,0 +1,93 @@
+import type {
+  GitHubRepositoryTarget,
+  GitHubSourceAuthCategory,
+  HttpClient,
+  HttpRequest,
+  HttpResponse,
+  Installable,
+  TokenProvider,
+} from '@ai-primitives-hub/core';
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  HttpsBundleDownloader,
+} from '../../src/downloaders/https-bundle-downloader';
+
+class RecordingHttpClient implements HttpClient {
+  public request: HttpRequest | undefined;
+
+  public async fetch(request: HttpRequest): Promise<HttpResponse> {
+    this.request = request;
+    return {
+      statusCode: 200,
+      body: new Uint8Array([1, 2, 3]),
+      finalUrl: request.url,
+      headers: {}
+    };
+  }
+}
+
+class RecordingTokenProvider implements TokenProvider {
+  public host: string | undefined;
+  public target: GitHubRepositoryTarget | undefined;
+
+  public async getToken(host: string, target?: GitHubRepositoryTarget): Promise<string | undefined> {
+    this.host = host;
+    this.target = target;
+    return 'token';
+  }
+}
+
+class EmptyTokenProvider implements TokenProvider {
+  public async getToken(): Promise<string | undefined> {
+    return undefined;
+  }
+}
+
+describe('HttpsBundleDownloader', () => {
+  it('passes the source repository target for release asset downloads', async () => {
+    const http = new RecordingHttpClient();
+    const tokens = new RecordingTokenProvider();
+    const target: GitHubRepositoryTarget = {
+      host: 'github.com',
+      owner: 'owner',
+      repository: 'repo'
+    };
+    const downloader = new HttpsBundleDownloader(http, tokens, target);
+
+    await downloader.download({
+      downloadUrl: 'https://api.github.com/repos/owner/repo/releases/assets/1'
+    } as Installable);
+
+    expect(tokens.host).toBe('api.github.com');
+    expect(tokens.target).toEqual(target);
+    expect(http.request?.headers?.Authorization).toBe('Bearer token');
+  });
+
+  it('does not invoke credentials for a public-anonymous download', async () => {
+    const http = new RecordingHttpClient();
+    const tokens = new RecordingTokenProvider();
+    const category: GitHubSourceAuthCategory = 'public-anonymous';
+    const downloader = new HttpsBundleDownloader(http, tokens, undefined, category);
+
+    await downloader.download({
+      downloadUrl: 'https://github.com/owner/repo/archive.zip'
+    } as Installable);
+
+    expect(tokens.host).toBeUndefined();
+    expect(http.request?.headers?.Authorization).toBeUndefined();
+  });
+
+  it('does not make an anonymous request for a public-generic download when its token is unavailable', async () => {
+    const http = new RecordingHttpClient();
+    const downloader = new HttpsBundleDownloader(http, new EmptyTokenProvider(), undefined, 'public-generic');
+
+    await expect(downloader.download({
+      downloadUrl: 'https://github.com/owner/repo/archive.zip'
+    } as Installable)).rejects.toMatchObject({ code: 'GH_PUBLIC_GENERIC_TOKEN_UNAVAILABLE' });
+    expect(http.request).toBeUndefined();
+  });
+});

--- a/packages/infra/test/harvest/github-source-auth-runtime.test.ts
+++ b/packages/infra/test/harvest/github-source-auth-runtime.test.ts
@@ -1,0 +1,65 @@
+import type {
+  GitHubRepositoryTarget,
+} from '@ai-primitives-hub/core';
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  createGitHubSourceAuthRuntime,
+  isGitHubAppAuthEnabled,
+  parseGitHubAppAuthEnabled,
+} from '../../src/harvest/github-source-auth-runtime';
+
+const target: GitHubRepositoryTarget = {
+  host: 'github.com',
+  owner: 'owner',
+  repository: 'repo'
+};
+
+describe('GitHub source auth runtime', () => {
+  it('recognizes only explicit true opt-in values', () => {
+    expect(isGitHubAppAuthEnabled({})).toBe(false);
+    expect(isGitHubAppAuthEnabled({ AI_PRIMITIVES_HUB_GH_APP_AUTH_ENABLED: 'true' })).toBe(true);
+    expect(isGitHubAppAuthEnabled({ AI_PRIMITIVES_HUB_GH_APP_AUTH_ENABLED: 'YES' })).toBe(true);
+    expect(isGitHubAppAuthEnabled({ AI_PRIMITIVES_HUB_GH_APP_AUTH_ENABLED: '0' })).toBe(false);
+    expect(() => parseGitHubAppAuthEnabled({ AI_PRIMITIVES_HUB_GH_APP_AUTH_ENABLED: 'enabled' })).toThrow();
+  });
+
+  it('rejects anonymous clients in source-aware mode', () => {
+    const runtime = createGitHubSourceAuthRuntime({
+      env: {},
+      http: {} as never
+    });
+
+    expect(() => runtime.clientFor(target, 'public-anonymous'))
+      .toThrowError(expect.objectContaining({ code: 'GH_PUBLIC_ANONYMOUS_DISABLED' }));
+  });
+
+  it('uses an App client only when the App environment is complete', () => {
+    const runtime = createGitHubSourceAuthRuntime({
+      env: {
+        AI_PRIMITIVES_HUB_GH_APP_AUTH_APP_ID: '123',
+        AI_PRIMITIVES_HUB_GH_APP_AUTH_CONFIG: '/tmp/isolated.yml'
+      },
+      http: {} as never,
+      processExecutor: {
+        execFile: async () => ({ stdout: 'token', stderr: '' })
+      }
+    });
+
+    const client = runtime.clientFor(target, 'app-authenticated');
+    expect(client).toBeDefined();
+  });
+
+  it('does not use the App client for public-generic category', () => {
+    const runtime = createGitHubSourceAuthRuntime({
+      env: { GH_TOKEN: 'generic-token' },
+      http: {} as never
+    });
+
+    const client = runtime.clientFor(target, 'public-generic');
+    expect(client).toBeDefined();
+  });
+});

--- a/packages/infra/test/harvest/github-source-auth-session.test.ts
+++ b/packages/infra/test/harvest/github-source-auth-session.test.ts
@@ -1,0 +1,90 @@
+import {
+  access,
+  writeFile,
+} from 'node:fs/promises';
+import type {
+  HttpClient,
+  HttpRequest,
+  HttpResponse,
+  HubSourceSpec,
+  ProcessExecutor,
+  ProcessResult,
+  ProcessRunOptions,
+} from '@ai-primitives-hub/core';
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  createGitHubSourceAuthSession,
+} from '../../src/harvest/github-source-auth-runtime';
+
+class SessionExecutor implements ProcessExecutor {
+  public readonly calls: { file: string; args: readonly string[]; options: ProcessRunOptions | undefined }[] = [];
+
+  public async execFile(file: string, args: readonly string[], options?: ProcessRunOptions): Promise<ProcessResult> {
+    this.calls.push({ file, args, options });
+    if (args.includes('setup')) {
+      const configPath = options?.env?.GH_APP_AUTH_CONFIG;
+      if (configPath !== undefined) {
+        await writeFile(configPath, 'generated: true\n', { mode: 0o600 });
+      }
+      return { stdout: '', stderr: '' };
+    }
+    return { stdout: 'installation-token\n', stderr: '' };
+  }
+}
+
+class SessionHttpClient implements HttpClient {
+  public async fetch(request: HttpRequest): Promise<HttpResponse> {
+    const authenticated = request.headers?.Authorization !== undefined;
+    return {
+      statusCode: authenticated ? 200 : 404,
+      body: new TextEncoder().encode(authenticated ? '{"private":true}' : '{}'),
+      finalUrl: request.url,
+      headers: {}
+    };
+  }
+}
+
+const source: HubSourceSpec = {
+  id: 'private-source',
+  name: 'Private Source',
+  type: 'github',
+  url: 'https://github.com/org/private-repo',
+  owner: 'org',
+  repo: 'private-repo',
+  branch: 'main'
+};
+
+describe('createGitHubSourceAuthSession', () => {
+  it('derives a temporary config, runs setup after generic classification, and cleans it up', async () => {
+    const executor = new SessionExecutor();
+    const session = await createGitHubSourceAuthSession({
+      env: {},
+      http: new SessionHttpClient(),
+      appId: '123',
+      keyFile: '/tmp/input-private-key.pem',
+      processExecutor: executor,
+      genericTokenProvider: { getToken: async () => 'generic-token' }
+    });
+
+    expect(session.configPath).toBeDefined();
+    const report = await session.preflight([source]);
+
+    expect(report.valid).toBe(true);
+    expect(report.results[0]?.category).toBe('app-authenticated');
+    expect(executor.calls.map((call) => call.args.slice(0, 3))).toEqual([
+      ['app-auth', 'setup', '--app-id'],
+      ['app-auth', 'token', '--app-id']
+    ]);
+    expect(executor.calls[0]?.args).toContain('github.com/org/*');
+    expect(executor.calls[1]?.args).toContain('github.com/org/private-repo');
+    expect(executor.calls[0]?.options?.env?.GH_APP_AUTH_CONFIG).toBe(session.configPath);
+
+    await access(session.configPath);
+    await session.cleanup();
+    await expect(access(session.configPath)).rejects.toThrow();
+  });
+});

--- a/packages/infra/test/harvest/github-source-preflight.test.ts
+++ b/packages/infra/test/harvest/github-source-preflight.test.ts
@@ -1,0 +1,380 @@
+import type {
+  GitHubApi,
+  GitHubRepositoryTarget,
+  GitHubSourceAuthCategory,
+  HubSourceSpec,
+  TokenProvider,
+} from '@ai-primitives-hub/core';
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  createGitHubSourceAuthRuntime,
+} from '../../src/harvest/github-source-auth-runtime';
+import {
+  preflightGitHubSources,
+} from '../../src/harvest/github-source-preflight';
+
+class ScenarioApi implements GitHubApi {
+  public readonly calls: string[] = [];
+
+  public constructor(
+    private readonly failurePath?: string,
+    private readonly failure?: Error,
+    private readonly repositoryMetadata: unknown = {}
+  ) {}
+
+  public async getJson<T>(path: string): Promise<T> {
+    this.calls.push(path);
+    if (this.failure !== undefined && path === this.failurePath) {
+      throw this.failure;
+    }
+    if (path.includes('/commits/')) {
+      return { sha: 'preflight-commit-sha' } as T;
+    }
+    if (path.startsWith('/repos/') && path.split('/').length === 4) {
+      return this.repositoryMetadata as T;
+    }
+    return {} as T;
+  }
+
+  public async getText(path: string): Promise<string> {
+    this.calls.push(path);
+    return '';
+  }
+
+  public async download(path: string): Promise<Uint8Array> {
+    this.calls.push(path);
+    return new Uint8Array();
+  }
+
+  public async getJsonWithEtag<T>(): Promise<{ status: 'ok'; value: T; etag: undefined }> {
+    return { status: 'ok', value: {} as T, etag: undefined };
+  }
+}
+
+class StubTokenProvider implements TokenProvider {
+  public calls = 0;
+
+  public async getToken(): Promise<string | undefined> {
+    this.calls += 1;
+    return 'generic-token';
+  }
+}
+
+function source(id: string, owner: string, repo: string, type: HubSourceSpec['type'] = 'github'): HubSourceSpec {
+  return {
+    id,
+    name: id,
+    type,
+    url: `https://github.com/${owner}/${repo}`,
+    owner,
+    repo,
+    branch: 'main'
+  };
+}
+
+function targetFor(sourceSpec: HubSourceSpec): GitHubRepositoryTarget {
+  return { host: 'github.com', owner: sourceSpec.owner, repository: sourceSpec.repo };
+}
+
+describe('preflightGitHubSources', () => {
+  it('uses a generic credential for public sources without constructing an anonymous client', async () => {
+    const genericTokenProvider = new StubTokenProvider();
+    const categories: GitHubSourceAuthCategory[] = [];
+
+    const report = await preflightGitHubSources([source('public', 'org', 'repo')], {
+      genericTokenProvider,
+      clientFactory: (_target, category) => {
+        categories.push(category);
+        if (category === 'public-anonymous') {
+          throw new Error('anonymous GitHub access is forbidden in source-aware mode');
+        }
+        return new ScenarioApi(undefined, undefined, { private: false });
+      }
+    });
+
+    expect(report.valid).toBe(true);
+    expect(report.results[0]).toMatchObject({
+      category: 'public-generic',
+      credentialMode: 'generic'
+    });
+    expect(categories).toEqual(['public-generic']);
+    expect(genericTokenProvider.calls).toBe(1);
+  });
+
+  it('fails closed when no generic public credential is available without attempting anonymous access', async () => {
+    const categories: GitHubSourceAuthCategory[] = [];
+    const genericTokenProvider: TokenProvider = {
+      getToken: async () => undefined
+    };
+
+    const report = await preflightGitHubSources([source('public', 'org', 'repo')], {
+      genericTokenProvider,
+      clientFactory: (_target, category) => {
+        categories.push(category);
+        throw new Error('a GitHub client must not be constructed without a generic token');
+      }
+    });
+
+    expect(report.valid).toBe(false);
+    expect(report.results[0]).toMatchObject({
+      category: 'unresolved',
+      errorCode: 'GH_PUBLIC_GENERIC_TOKEN_UNAVAILABLE'
+    });
+    expect(categories).toEqual([]);
+  });
+
+  it('does not bypass the mandatory generic credential when an App provider is available', async () => {
+    const categories: GitHubSourceAuthCategory[] = [];
+    const genericTokenProvider: TokenProvider = {
+      getToken: async () => undefined
+    };
+
+    const report = await preflightGitHubSources([source('private', 'org', 'repo')], {
+      genericTokenProvider,
+      appTokenProvider: { getToken: async () => 'app-token' },
+      clientFactory: (_target, category) => {
+        categories.push(category);
+        throw new Error('App access must not bypass generic visibility evidence');
+      }
+    });
+
+    expect(report.valid).toBe(false);
+    expect(report.results[0]).toMatchObject({
+      category: 'unresolved',
+      errorCode: 'GH_PUBLIC_GENERIC_TOKEN_UNAVAILABLE'
+    });
+    expect(categories).toEqual([]);
+  });
+
+  it('classifies all sources from authenticated evidence and derives routes only for private candidates', async () => {
+    const publicSource = source('z-public', 'z-org', 'public');
+    const privateSource = source('a-private', 'a-org', 'private');
+    const unresolvedSource = source('m-unresolved', 'm-org', 'unresolved');
+    const appApi = new ScenarioApi();
+    const clients: { category: GitHubSourceAuthCategory; target: GitHubRepositoryTarget }[] = [];
+
+    const report = await preflightGitHubSources(
+      [publicSource, privateSource, unresolvedSource],
+      {
+        clientFactory: (target, category) => {
+          clients.push({ target, category });
+          if (target.repository === 'private' && category === 'public-generic') {
+            return new ScenarioApi('/repos/a-org/private', Object.assign(new Error('GitHub API error: 404'), { statusCode: 404 }));
+          }
+          if (target.repository === 'unresolved' && category === 'public-generic') {
+            return new ScenarioApi('/repos/m-org/unresolved', Object.assign(new Error('GitHub API error: 503'), { statusCode: 503 }));
+          }
+          if (category === 'public-generic') {
+            return new ScenarioApi(undefined, undefined, { private: false });
+          }
+          return appApi;
+        },
+        genericTokenProvider: new StubTokenProvider(),
+        appTokenProvider: { getToken: async () => 'app-token' }
+      }
+    );
+
+    expect(report.valid).toBe(false);
+    expect(report.results.map((result) => [result.sourceId, result.category])).toEqual([
+      ['a-private', 'app-authenticated'],
+      ['m-unresolved', 'unresolved'],
+      ['z-public', 'public-generic']
+    ]);
+    expect(report.appRoutes).toEqual(['github.com/a-org/*']);
+    expect(clients).toContainEqual({ target: targetFor(privateSource), category: 'app-authenticated' });
+    expect(report.results.find((result) => result.sourceId === 'm-unresolved')?.errorCode).toBe('GH_SOURCE_PREFLIGHT_UNRESOLVED');
+    expect(report.results.find((result) => result.sourceId === 'z-public')?.revision).toBe('preflight-commit-sha');
+  });
+
+  it('derives App routes before invoking the setup hook', async () => {
+    const privateSource = source('private', 'Org', 'repo');
+    const order: string[] = [];
+
+    const report = await preflightGitHubSources([privateSource], {
+      clientFactory: (_target, category) => {
+        order.push(`client:${category}`);
+        return category === 'public-generic'
+          ? new ScenarioApi('/repos/Org/repo', Object.assign(new Error('GitHub API error: 404'), { statusCode: 404 }))
+          : new ScenarioApi();
+      },
+      genericTokenProvider: new StubTokenProvider(),
+      appTokenProvider: { getToken: async () => 'app-token' },
+      prepareAppAuthentication: async (routes) => {
+        order.push(`setup:${routes.join(',')}`);
+      }
+    });
+
+    expect(report.valid).toBe(true);
+    expect(report.appRoutes).toEqual(['github.com/Org/*']);
+    expect(order).toEqual([
+      'client:public-generic',
+      'setup:github.com/Org/*',
+      'client:app-authenticated'
+    ]);
+  });
+
+  it('uses the generic provider for public visibility and source checks', async () => {
+    const publicSource = source('public', 'org', 'repo', 'awesome-copilot');
+    const genericTokenProvider = new StubTokenProvider();
+    const categories: GitHubSourceAuthCategory[] = [];
+    const clients = new Map<GitHubSourceAuthCategory, ScenarioApi>();
+
+    const report = await preflightGitHubSources([publicSource], {
+      publicAuthMode: 'generic',
+      genericTokenProvider,
+      clientFactory: (_target, category) => {
+        categories.push(category);
+        const api = clients.get(category) ?? new ScenarioApi();
+        if (category === 'public-generic' && api.calls.length === 0) {
+          return new ScenarioApi(undefined, undefined, { private: false });
+        }
+        clients.set(category, api);
+        return api;
+      }
+    });
+
+    expect(report.valid).toBe(true);
+    expect(report.results[0]?.category).toBe('public-generic');
+    expect(categories).toEqual(['public-generic']);
+    expect(genericTokenProvider.calls).toBe(1);
+  });
+
+  it('fails an authentication-required source when no App provider is available', async () => {
+    const privateSource = source('private', 'org', 'private');
+    const report = await preflightGitHubSources([privateSource], {
+      genericTokenProvider: new StubTokenProvider(),
+      clientFactory: (target, category) => category === 'public-generic'
+        ? new ScenarioApi('/repos/org/private', Object.assign(new Error('GitHub API error: 404'), { statusCode: 404 }))
+        : new ScenarioApi(),
+      onLog: () => undefined
+    });
+
+    expect(report.valid).toBe(false);
+    expect(report.results[0]).toMatchObject({
+      sourceId: 'private',
+      category: 'unresolved',
+      errorCode: 'GH_APP_AUTH_CONFIG_MISSING'
+    });
+  });
+
+  it('rejects explicit anonymous mode before making a request', async () => {
+    expect(() => createGitHubSourceAuthRuntime({
+      env: { AI_PRIMITIVES_HUB_GH_PUBLIC_AUTH_MODE: 'anonymous' },
+      http: {} as never
+    })).toThrowError(expect.objectContaining({ code: 'GH_PUBLIC_ANONYMOUS_DISABLED' }));
+  });
+
+  it('uses generic public authentication for every public source by default', async () => {
+    const sources = Array.from({ length: 20 }, (_, index) => source(
+      `source-${String(index).padStart(2, '0')}`,
+      'org',
+      `repo-${String(index).padStart(2, '0')}`
+    ));
+    const genericTokenProvider = new StubTokenProvider();
+    const categories: GitHubSourceAuthCategory[] = [];
+    const report = await preflightGitHubSources(sources, {
+      genericTokenProvider,
+      clientFactory: (_target, category) => {
+        categories.push(category);
+        return new ScenarioApi(undefined, undefined, { private: false });
+      }
+    });
+
+    expect(report.valid).toBe(true);
+    expect(report.results.every((result) => result.category === 'public-generic')).toBe(true);
+    expect(categories.filter((category) => category === 'public-generic')).toHaveLength(20);
+    expect(genericTokenProvider.calls).toBe(20);
+  });
+
+  it('reuses generic visibility evidence for duplicate source entries targeting one repository', async () => {
+    const apis: ScenarioApi[] = [];
+    const report = await preflightGitHubSources([
+      source('first-entry', 'org', 'repo'),
+      source('second-entry', 'org', 'repo')
+    ], {
+      clientFactory: () => {
+        const api = new ScenarioApi(undefined, undefined, { private: false });
+        apis.push(api);
+        return api;
+      },
+      genericTokenProvider: new StubTokenProvider()
+    });
+
+    const metadataCalls = apis.flatMap((api) => api.calls)
+      .filter((path) => path === '/repos/org/repo');
+    expect(report.valid).toBe(true);
+    expect(metadataCalls).toHaveLength(1);
+  });
+
+  it('uses generic metadata to establish public repository visibility', async () => {
+    const genericTokenProvider = new StubTokenProvider();
+    const categories: GitHubSourceAuthCategory[] = [];
+    const report = await preflightGitHubSources([source('public', 'org', 'repo')], {
+      genericTokenProvider,
+      clientFactory: (_target, category) => {
+        categories.push(category);
+        expect(category).toBe('public-generic');
+        return new ScenarioApi(undefined, undefined, { private: false });
+      }
+    });
+
+    expect(report).toMatchObject({
+      valid: true,
+      results: [{ category: 'public-generic' }]
+    });
+    expect(categories).toEqual(['public-generic']);
+    expect(genericTokenProvider.calls).toBe(1);
+  });
+
+  it('routes a generic metadata response marked private to the App path', async () => {
+    const genericTokenProvider = new StubTokenProvider();
+    const appTokenProvider: TokenProvider = { getToken: async () => 'app-token' };
+    const categories: GitHubSourceAuthCategory[] = [];
+    const report = await preflightGitHubSources([source('private', 'org', 'repo')], {
+      genericTokenProvider,
+      appTokenProvider,
+      clientFactory: (_target, category) => {
+        categories.push(category);
+        return category === 'public-generic'
+          ? new ScenarioApi(undefined, undefined, { private: true })
+          : new ScenarioApi();
+      },
+      prepareAppAuthentication: async () => undefined
+    });
+
+    expect(report.valid).toBe(true);
+    expect(report.results[0]).toMatchObject({ category: 'app-authenticated' });
+    expect(report.appRoutes).toEqual(['github.com/org/*']);
+    expect(categories).toEqual(['public-generic', 'app-authenticated']);
+  });
+
+  it('stops generic probes after the first rate-limit response', async () => {
+    const rateLimitError = Object.assign(new Error('GitHub API error: 403 - primary rate limit exceeded'), {
+      statusCode: 403,
+      headers: { 'x-ratelimit-remaining': '0' }
+    });
+    const apis: ScenarioApi[] = [];
+    const report = await preflightGitHubSources([
+      source('first', 'org', 'first'),
+      source('second', 'org', 'second'),
+      source('third', 'org', 'third')
+    ], {
+      genericTokenProvider: new StubTokenProvider(),
+      clientFactory: () => {
+        const api = new ScenarioApi('/repos/org/first', rateLimitError);
+        apis.push(api);
+        return api;
+      }
+    });
+
+    expect(report.valid).toBe(false);
+    expect(report.results).toHaveLength(3);
+    expect(report.results.every((result) => result.errorCode === 'GH_PUBLIC_GENERIC_RATE_LIMIT_UNSAFE')).toBe(true);
+    expect(apis).toHaveLength(1);
+    expect(apis[0].calls).toEqual(['/repos/org/first']);
+  });
+});

--- a/packages/infra/test/harvest/hub-config-parser.test.ts
+++ b/packages/infra/test/harvest/hub-config-parser.test.ts
@@ -290,4 +290,20 @@ sources:
     expect(result).toHaveLength(1);
     expect(result[0].owner).toBe('owner');
   });
+
+  it('rejects an enabled malformed remote source in strict mode', () => {
+    expect(() => parseHubConfig({
+      sources: [
+        { type: 'github', url: 'https://github.com/owner/repo/extra', enabled: true }
+      ]
+    }, { strict: true })).toThrow('invalid or non-GitHub repository URL');
+  });
+
+  it('does not reject local sources in strict mode because they are outside GitHub preflight scope', () => {
+    expect(parseHubConfig({
+      sources: [
+        { type: 'local', url: '/tmp/bundles', enabled: true }
+      ]
+    }, { strict: true })).toEqual([]);
+  });
 });

--- a/packages/infra/test/harvest/hub-harvester.test.ts
+++ b/packages/infra/test/harvest/hub-harvester.test.ts
@@ -1,7 +1,13 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type {
+  HttpClient,
+  HttpRequest,
+  HttpResponse,
   HubSourceSpec,
+  ProcessExecutor,
+  ProcessResult,
+  ProcessRunOptions,
 } from '@ai-primitives-hub/core';
 import {
   afterEach,
@@ -82,6 +88,44 @@ function spec(id: string, owner: string, repo: string): HubSourceSpec {
   };
 }
 
+class SourceAwareHarvestHttpClient implements HttpClient {
+  public constructor(
+    private readonly metadataStatus = 200,
+    private readonly repositoryPrivate = false
+  ) {}
+
+  public async fetch(request: HttpRequest): Promise<HttpResponse> {
+    const pathName = new URL(request.url).pathname;
+    let statusCode = 200;
+    let body: unknown = {};
+    if (pathName.endsWith('/owner/repo')) {
+      statusCode = request.headers?.Authorization === 'token generic-token' ? this.metadataStatus : 200;
+      body = { private: this.repositoryPrivate };
+    } else if (pathName.endsWith('/commits/main')) {
+      body = { sha: 'source-aware-sha' };
+    } else if (pathName.includes('/git/trees/')) {
+      body = { tree: [], truncated: false };
+    }
+    return {
+      statusCode,
+      body: new TextEncoder().encode(statusCode === 200 ? JSON.stringify(body) : '{}'),
+      finalUrl: request.url,
+      headers: {}
+    };
+  }
+}
+
+class RecordingAppProcessExecutor implements ProcessExecutor {
+  public readonly calls: { file: string; args: readonly string[]; options: ProcessRunOptions | undefined }[] = [];
+
+  public async execFile(file: string, args: readonly string[], options?: ProcessRunOptions): Promise<ProcessResult> {
+    this.calls.push({ file, args, options });
+    return args.includes('setup')
+      ? { stdout: '', stderr: '' }
+      : { stdout: 'installation-token\n', stderr: '' };
+  }
+}
+
 describe('hub-harvester', () => {
   it('harvests two sources in serial, records progress for each', async () => {
     const promptBytes = Buffer.from('---\ntitle: Hello\ndescription: hi\n---\n\n# Hello\n', 'utf8');
@@ -109,6 +153,49 @@ describe('hub-harvester', () => {
       { sourceId: 'src-1', state: 'indexed', primitives: 1, revision: 'sha-o1r1' },
       { sourceId: 'src-2', state: 'indexed', primitives: 1, revision: 'sha-o2r2' }
     ]);
+  });
+
+  it('uses a separate client from the factory for each source', async () => {
+    const promptBytes = Buffer.from('---\ntitle: Hello\n---\n# Hello\n', 'utf8');
+    const promptSha = computeGitBlobSha(promptBytes);
+    const client = new FakeGitHubApi();
+    seedRepo(client, 'o1', 'r1', 'sha-o1r1', [{ path: 'prompts/a.prompt.md', sha: promptSha, size: promptBytes.length }], new Map([[promptSha, promptBytes]]));
+    seedRepo(client, 'o2', 'r2', 'sha-o2r2', [{ path: 'prompts/b.prompt.md', sha: promptSha, size: promptBytes.length }], new Map([[promptSha, promptBytes]]));
+    const created: string[] = [];
+    const cache = new BlobCache(path.join(tmp, 'blobs'));
+
+    const result = await new HubHarvester({
+      sources: [spec('src-1', 'o1', 'r1'), spec('src-2', 'o2', 'r2')],
+      client,
+      clientFactory: (source) => {
+        created.push(source.id);
+        return new RecordingGitHubApi(client);
+      },
+      cache,
+      progressFile: path.join(tmp, 'progress.jsonl'),
+      concurrency: 2
+    }).run();
+
+    expect(result.done).toBe(2);
+    expect(created.toSorted()).toEqual(['src-1', 'src-2']);
+  });
+
+  it('reuses a source-aware preflight commit revision', async () => {
+    const client = new FakeGitHubApi();
+    seedRepo(client, 'o', 'r', 'preflight-sha', [], new Map());
+    const recording = new RecordingGitHubApi(client);
+    const result = await new HubHarvester({
+      sources: [spec('src-1', 'o', 'r')],
+      client: recording,
+      sourcePreflightRevisions: new Map([['src-1', 'preflight-sha']]),
+      cache: new BlobCache(path.join(tmp, 'blobs')),
+      progressFile: path.join(tmp, 'progress.jsonl'),
+      concurrency: 1,
+      dryRun: true
+    }).run();
+
+    expect(result.skip).toBe(1);
+    expect(recording.calls.filter((call) => call.pathOrUrl.includes('/commits/'))).toHaveLength(0);
   });
 
   it('skips unchanged sources on a second run (smart rebuild)', async () => {
@@ -487,6 +574,158 @@ items:
       });
 
       expect(result.tokenSource).toBe('none');
+    });
+
+    it('runs generic source-aware preflight and harvests with category-bound clients', async () => {
+      const configFile = path.join(tmp, 'hub-config.yml');
+      fs.writeFileSync(configFile, [
+        'sources:',
+        '  - id: public-source',
+        '    type: github',
+        '    url: https://github.com/owner/repo',
+        'profiles: []',
+        ''
+      ].join('\n'));
+
+      const result = await harvestHub({
+        hubConfigFile: configFile,
+        dryRun: true,
+        httpClient: new SourceAwareHarvestHttpClient(),
+        outFile: path.join(tmp, 'source-aware-index.json'),
+        progressFile: path.join(tmp, 'source-aware-progress.jsonl'),
+        cacheDir: path.join(tmp, 'source-aware-cache')
+      }, {
+        AI_PRIMITIVES_HUB_GH_APP_AUTH_ENABLED: 'true',
+        GH_TOKEN: 'generic-token'
+      });
+
+      expect(result.tokenSource).toBe('source-aware');
+      expect(result.totals.error).toBe(0);
+      expect(result).toHaveProperty('sourcePreflight');
+      expect((result as { sourcePreflight?: { valid: boolean; results: { sourceId: string; category: string }[] } }).sourcePreflight).toMatchObject({
+        valid: true,
+        results: [{ sourceId: 'public-source', category: 'public-generic' }]
+      });
+      expect(result.sourceCoverage).toEqual([{
+        sourceId: 'public-source',
+        state: 'skipped',
+        revision: 'source-aware-sha',
+        authenticationCategory: 'public-generic',
+        message: 'dry-run'
+      }]);
+    });
+
+    it('provisions an ephemeral App config from pipeline inputs before authenticated harvest', async () => {
+      const configFile = path.join(tmp, 'private-bootstrap-config.yml');
+      fs.writeFileSync(configFile, [
+        'sources:',
+        '  - id: private-source',
+        '    type: github',
+        '    url: https://github.com/owner/repo',
+        '    owner: owner',
+        '    repo: repo',
+        '    branch: main',
+        'profiles: []',
+        ''
+      ].join('\n'));
+      const executor = new RecordingAppProcessExecutor();
+      const result = await harvestHub({
+        hubConfigFile: configFile,
+        dryRun: true,
+        githubAppId: '123',
+        githubAppKeyFile: '/tmp/app-key.pem',
+        processExecutor: executor,
+        httpClient: new SourceAwareHarvestHttpClient(404),
+        outFile: path.join(tmp, 'private-bootstrap-index.json'),
+        progressFile: path.join(tmp, 'private-bootstrap-progress.jsonl'),
+        cacheDir: path.join(tmp, 'private-bootstrap-cache')
+      }, {
+        GH_TOKEN: 'generic-token'
+      });
+
+      expect(result.tokenSource).toBe('source-aware');
+      expect(result.sourceCoverage).toEqual([{
+        sourceId: 'private-source',
+        state: 'skipped',
+        revision: 'source-aware-sha',
+        authenticationCategory: 'app-authenticated',
+        message: 'dry-run'
+      }]);
+      expect(executor.calls).toHaveLength(2);
+      expect(executor.calls[0]?.args).toContain('github.com/owner/*');
+      expect(executor.calls[1]?.args).toContain('github.com/owner/repo');
+      const configPath = executor.calls[0]?.options?.env?.GH_APP_AUTH_CONFIG;
+      expect(configPath).toBeDefined();
+      expect(fs.existsSync(configPath!)).toBe(false);
+    });
+
+    it('fails source-aware harvest when a private source has no App configuration', async () => {
+      const configFile = path.join(tmp, 'private-hub-config.yml');
+      fs.writeFileSync(configFile, [
+        'sources:',
+        '  - id: private-source',
+        '    type: github',
+        '    url: https://github.com/owner/repo',
+        'profiles: []',
+        ''
+      ].join('\n'));
+
+      await expect(harvestHub({
+        hubConfigFile: configFile,
+        dryRun: true,
+        httpClient: new SourceAwareHarvestHttpClient(404),
+        outFile: path.join(tmp, 'private-index.json'),
+        progressFile: path.join(tmp, 'private-progress.jsonl'),
+        cacheDir: path.join(tmp, 'private-cache')
+      }, {
+        AI_PRIMITIVES_HUB_GH_APP_AUTH_ENABLED: 'true',
+        GH_TOKEN: 'generic-token'
+      })).rejects.toMatchObject({
+        code: 'GH_SOURCE_PREFLIGHT_FAILED',
+        report: {
+          valid: false,
+          results: [{
+            sourceId: 'private-source',
+            errorCode: 'GH_APP_AUTH_CONFIG_MISSING'
+          }]
+        }
+      });
+    });
+
+    it('preserves the complete source preflight report on a fail-closed harvest error', async () => {
+      const configFile = path.join(tmp, 'structured-preflight-config.yml');
+      fs.writeFileSync(configFile, [
+        'sources:',
+        '  - id: private-source',
+        '    type: github',
+        '    url: https://github.com/owner/repo',
+        'profiles: []',
+        ''
+      ].join('\n'));
+
+      await expect(harvestHub({
+        hubConfigFile: configFile,
+        dryRun: true,
+        httpClient: new SourceAwareHarvestHttpClient(404, true),
+        outFile: path.join(tmp, 'structured-preflight-index.json'),
+        progressFile: path.join(tmp, 'structured-preflight-progress.jsonl'),
+        cacheDir: path.join(tmp, 'structured-preflight-cache')
+      }, {
+        AI_PRIMITIVES_HUB_GH_APP_AUTH_ENABLED: 'true',
+        GH_TOKEN: 'generic-token'
+      })).rejects.toMatchObject({
+        code: 'GH_SOURCE_PREFLIGHT_FAILED',
+        report: {
+          valid: false,
+          appRoutes: ['github.com/owner/*'],
+          results: [{
+            sourceId: 'private-source',
+            category: 'unresolved',
+            errorCode: 'GH_APP_AUTH_CONFIG_MISSING',
+            operations: ['repository metadata']
+          }]
+        }
+      });
     });
   });
 });

--- a/packages/infra/test/http/github-api-client.test.ts
+++ b/packages/infra/test/http/github-api-client.test.ts
@@ -1,4 +1,6 @@
 import type {
+  GitHubRepositoryTarget,
+  GitHubSourceAuthCategory,
   HttpClient,
   HttpRequest,
   HttpResponse,
@@ -35,12 +37,23 @@ class FakeHttpClient implements HttpClient {
 
 class StaticTokenProvider implements TokenProvider {
   public lastHost: string | undefined;
+  public lastTarget: GitHubRepositoryTarget | undefined;
 
   public constructor(private readonly token: string | undefined) {}
 
-  public async getToken(host: string): Promise<string | undefined> {
+  public async getToken(host: string, target?: GitHubRepositoryTarget): Promise<string | undefined> {
     this.lastHost = host;
+    this.lastTarget = target;
     return this.token;
+  }
+}
+
+class CountingTokenProvider implements TokenProvider {
+  public calls = 0;
+
+  public async getToken(): Promise<string | undefined> {
+    this.calls += 1;
+    return 'should-not-be-used';
   }
 }
 
@@ -95,6 +108,19 @@ describe('GitHubApiClient', () => {
     const client = new GitHubApiClient(http, { tokenProvider: new StaticTokenProvider(undefined) });
     await client.getJson('/repos/o/r');
     expect(http.lastRequest?.headers?.Authorization).toBeUndefined();
+  });
+
+  it('does not make an anonymous request for a public-generic source when its token is unavailable', async () => {
+    const http = new FakeHttpClient(jsonResponse({ ok: true }));
+    const client = new GitHubApiClient(http, {
+      tokenProvider: new StaticTokenProvider(undefined),
+      authenticationCategory: 'public-generic'
+    });
+
+    await expect(client.getJson('/repos/o/r')).rejects.toMatchObject({
+      code: 'GH_PUBLIC_GENERIC_TOKEN_UNAVAILABLE'
+    });
+    expect(http.requests).toHaveLength(0);
   });
 
   it('parses the JSON body on success', async () => {
@@ -160,6 +186,42 @@ describe('GitHubApiClient', () => {
     const tokenProvider = new StaticTokenProvider('secret-token');
     await new GitHubApiClient(http, { tokenProvider }).getText('https://raw.githubusercontent.com/o/r/main/manifest.yml');
     expect(tokenProvider.lastHost).toBe('raw.githubusercontent.com');
+  });
+
+  it('passes the source repository target while preserving the request host', async () => {
+    const http = new FakeHttpClient(jsonResponse({ ok: true }));
+    const tokenProvider = new StaticTokenProvider('secret-token');
+    const target: GitHubRepositoryTarget = {
+      host: 'github.com',
+      owner: 'owner',
+      repository: 'repo'
+    };
+    const client = new GitHubApiClient(http, { tokenProvider, repositoryTarget: target });
+
+    await client.getText('https://raw.githubusercontent.com/owner/repo/main/file.txt');
+
+    expect(tokenProvider.lastHost).toBe('raw.githubusercontent.com');
+    expect(tokenProvider.lastTarget).toEqual(target);
+  });
+
+  it('does not invoke a token provider for a public-anonymous source', async () => {
+    const http = new FakeHttpClient(jsonResponse({ ok: true }));
+    const tokenProvider = new CountingTokenProvider();
+    const category: GitHubSourceAuthCategory = 'public-anonymous';
+    const client = new GitHubApiClient(http, {
+      tokenProvider,
+      authenticationCategory: category,
+      repositoryTarget: {
+        host: 'github.com',
+        owner: 'owner',
+        repository: 'repo'
+      }
+    });
+
+    await client.getJson('/repos/owner/repo');
+
+    expect(tokenProvider.calls).toBe(0);
+    expect(http.lastRequest?.headers?.Authorization).toBeUndefined();
   });
 
   describe('retry / backoff', () => {

--- a/packages/infra/test/http/github-repository-target.test.ts
+++ b/packages/infra/test/http/github-repository-target.test.ts
@@ -1,0 +1,51 @@
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  parseGitHubRepositoryTarget,
+} from '../../src/http/github-repository-target';
+
+describe('parseGitHubRepositoryTarget', () => {
+  it.each([
+    'https://github.com/owner/repository',
+    'https://github.com/owner/repository.git',
+    'https://github.com/owner/repository/',
+    'git@github.com:owner/repository.git',
+    'owner/repository',
+    'github.com/owner/repository',
+    'github.com/owner/repository/'
+  ])('normalizes %s', (value) => {
+    expect(parseGitHubRepositoryTarget(value)).toEqual({
+      host: 'github.com',
+      owner: 'owner',
+      repository: 'repository'
+    });
+  });
+
+  it('preserves a supported GitHub host from an HTTPS URL', () => {
+    expect(parseGitHubRepositoryTarget('https://api.github.com/owner/repository')).toEqual({
+      host: 'api.github.com',
+      owner: 'owner',
+      repository: 'repository'
+    });
+  });
+
+  it.each([
+    'http://github.com/owner/repository',
+    'https://user:password@github.com/owner/repository',
+    'https://github.com/owner/repository?ref=main',
+    'https://github.com/owner/repository?',
+    'https://github.com/owner/repository#fragment',
+    'https://github.com/owner/repository#',
+    'https://github.com/owner/repository/extra',
+    'https://github.com/owner',
+    'https://example.com/owner/repository',
+    'git@github.com:owner/repository/extra.git',
+    'owner/repository/extra',
+    'owner/repo name'
+  ])('rejects unsafe or malformed repository input %s', (value) => {
+    expect(() => parseGitHubRepositoryTarget(value)).toThrow();
+  });
+});

--- a/packages/infra/test/hub/hub-resolver.test.ts
+++ b/packages/infra/test/hub/hub-resolver.test.ts
@@ -2,6 +2,7 @@
  * Tests for infra/hub/hub-resolver.ts.
  */
 import type {
+  GitHubRepositoryTarget,
   HttpClient,
   HttpRequest,
   HttpResponse,
@@ -38,6 +39,17 @@ function fakeHttpClient(responses: (req: HttpRequest) => HttpResponse): HttpClie
 
 function fakeTokenProvider(token: string | undefined = undefined): TokenProvider {
   return { getToken: (): Promise<string | undefined> => Promise.resolve(token) };
+}
+
+function recordingTokenProvider(
+  targetRef: { value: GitHubRepositoryTarget | undefined }
+): TokenProvider {
+  return {
+    getToken: (_host: string, target?: GitHubRepositoryTarget): Promise<string | undefined> => {
+      targetRef.value = target;
+      return Promise.resolve('token');
+    }
+  };
 }
 
 describe('LocalHubResolver', () => {
@@ -129,6 +141,46 @@ describe('GitHubHubResolver', () => {
 
     const calledUrl = fetchSpy.mock.calls[0][0].url;
     expect(calledUrl).toContain('/owner/repo/develop/hub-config.yml');
+  });
+
+  it('passes the hub repository target separately from the raw-content request host', async () => {
+    const http = fakeHttpClient(() => ({ statusCode: 200, body: new TextEncoder().encode(VALID_YAML), finalUrl: '', headers: {} }));
+    const targetRef: { value: GitHubRepositoryTarget | undefined } = { value: undefined };
+    const resolver = new GitHubHubResolver(http, recordingTokenProvider(targetRef));
+
+    await resolver.resolve({ type: 'github', location: 'owner/repo' });
+
+    expect(targetRef.value).toEqual({ host: 'github.com', owner: 'owner', repository: 'repo' });
+  });
+
+  it('tries the generic hub read before repository-scoped App authentication', async () => {
+    const requests: HttpRequest[] = [];
+    let genericAttempt = true;
+    const http: HttpClient = {
+      fetch: (request): Promise<HttpResponse> => {
+        requests.push(request);
+        if (genericAttempt) {
+          genericAttempt = false;
+          return Promise.resolve({ statusCode: 404, body: new Uint8Array(), finalUrl: request.url, headers: {} });
+        }
+        return Promise.resolve({ statusCode: 200, body: new TextEncoder().encode(VALID_YAML), finalUrl: request.url, headers: {} });
+      }
+    };
+    const appProvider: TokenProvider = {
+      getToken: async (_host, target) => target === undefined ? undefined : 'app-token'
+    };
+    const resolver = new GitHubHubResolver(http, fakeTokenProvider('generic-token'), {
+      sourceAware: {
+        genericTokenProvider: fakeTokenProvider('generic-token'),
+        appTokenProvider: appProvider
+      }
+    });
+
+    await resolver.resolve({ type: 'github', location: 'owner/repo' });
+
+    expect(requests).toHaveLength(2);
+    expect(requests[0].headers?.Authorization).toBe('token generic-token');
+    expect(requests[1].headers?.Authorization).toBe('token app-token');
   });
 });
 

--- a/packages/infra/test/process/node-process-executor.test.ts
+++ b/packages/infra/test/process/node-process-executor.test.ts
@@ -1,0 +1,33 @@
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  NodeProcessExecutor,
+} from '../../src/process/node-process-executor';
+
+describe('NodeProcessExecutor', () => {
+  it('passes arguments literally without shell interpretation', async () => {
+    const result = await new NodeProcessExecutor().execFile(
+      process.execPath,
+      ['-e', 'process.stdout.write(process.argv[1])', 'literal value; not a command']
+    );
+
+    expect(result.stdout).toBe('literal value; not a command');
+  });
+
+  it('merges environment values and strips dynamic-loader injection variables', async () => {
+    const result = await new NodeProcessExecutor().execFile(
+      process.execPath,
+      ['-e', "process.stdout.write([process.env.FOO, process.env.LD_PRELOAD, process.env.DYLD_INSERT_LIBRARIES].join('|'))"],
+      { env: { FOO: 'bar', LD_PRELOAD: '/unsafe.so', DYLD_INSERT_LIBRARIES: '/unsafe.dylib' } }
+    );
+
+    expect(result.stdout).toBe('bar||');
+  });
+
+  it('rejects when the executable exits non-zero', async () => {
+    await expect(new NodeProcessExecutor().execFile(process.execPath, ['-e', 'process.exit(1)'])).rejects.toThrow();
+  });
+});

--- a/packages/infra/test/resolvers/source-dispatcher.test.ts
+++ b/packages/infra/test/resolvers/source-dispatcher.test.ts
@@ -1,0 +1,42 @@
+import type {
+  FileSystem,
+  GitHubApi,
+  RegistrySource,
+} from '@ai-primitives-hub/core';
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  SourceDispatcher,
+} from '../../src/resolvers/resolver-registry';
+
+const fs = {} as FileSystem;
+const api = {} as GitHubApi;
+
+const source: RegistrySource = {
+  id: 'source',
+  name: 'Source',
+  type: 'github',
+  url: 'https://github.com/owner/repo',
+  enabled: true,
+  priority: 0
+};
+
+describe('SourceDispatcher', () => {
+  it('uses a source-bound API factory for remote resolvers', () => {
+    const seen: RegistrySource[] = [];
+    const dispatcher = new SourceDispatcher({
+      githubApi: api,
+      fs,
+      githubApiFactory: (configuredSource) => {
+        seen.push(configuredSource);
+        return api;
+      }
+    });
+
+    expect(dispatcher.resolverFor(source)).not.toBeNull();
+    expect(seen).toEqual([source]);
+  });
+});


### PR DESCRIPTION
## Description

Adds opt-in, source-aware GitHub App authentication for CLI hub validation, harvesting, installation, update, and profile flows. Sources are classified from authenticated generic evidence; public sources use a generic credential, authentication-required sources use repository-scoped App installation tokens, and unresolved sources fail closed. Anonymous source-aware access is rejected.

The change also adds repository-target propagation across API/raw/asset requests, argv-safe App setup/token execution, ephemeral setup cleanup, per-repository in-memory token caching, structured preflight reporting, generic rate-limit circuit breaking, install dependency reuse, and harvest revision reuse.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [x] ♻️ Code refactoring (no functional changes)
- [x] ⚡ Performance improvement
- [x] 🧪 Test coverage improvement
- [ ] 🔧 Configuration/build changes

## Related Issues

None specified.

## Changes Made

- Added core repository-target/authentication types and an argv-safe process port.
- Added generic public-token and repository-scoped GitHub App-token providers with validation, timeout, single-flight, conservative in-memory caching, and stable errors.
- Added authenticated source preflight, dynamic App route derivation, category-isolated clients, fail-closed anonymous/rate-limit behavior, and sanitized structured reports.
- Integrated source-aware authentication into hub validation, index harvest, install, update, profile activation, source adapters, hub resolution, and bundle downloads.
- Reused command-scoped install dependencies and verified harvest revisions to reduce duplicate requests and App-token processes.
- Added contributor authentication documentation and ADR-0007.

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

### Manual Testing Steps

1. Built and smoke-tested the Linux SEA CLI, including help/version and source-aware bootstrap flags.
2. Ran source-aware preflight and harvest against the clean 47-source benchmark scope; verified structured source results and fail-closed behavior.
3. Verified temporary App configuration cleanup, no-anonymous behavior, repository-scoped token arguments, cache reuse, rate-limit circuit breaking, and secret/path scans.

### Tested On

- [ ] macOS
- [ ] Windows
- [x] Linux

- [ ] VS Code Stable
- [x] VS Code Insiders

## Screenshots

Not applicable.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors — validation completed without errors; the repository lint pass still reports warnings.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published — the source-aware CLI changes require a compatible CLI release before external hub CI can enable the new flags.

## Documentation

- [ ] README.md updated
- [x] JSDoc comments added/updated
- [ ] No documentation changes needed

Contributor authentication guidance and ADR-0007 were added under `docs/contributor-guide/architecture/`.

## Additional Notes

- Main package validation passed: core 251 tests, infra 837 tests, app 605 tests, and CLI 322 tests; package builds, extension compilation/test compilation, SEA build, website build, and fixing lint completed without errors.
- The full original hub remains dependent on external GitHub App installation/repository-permission fixes for eight sources; those are not bypassed by this implementation.
- VS Code authentication is intentionally outside this first source-aware CLI/CI scope.
- A companion GitHub Actions workflow is dealt with separately in the hub-configuration repository; it is not part of this pull request.

## Reviewer Guidelines

Please pay special attention to:

- Generic/App category isolation, mandatory authenticated visibility evidence, and the absence of anonymous or personal-token fallback for App-authenticated sources.
- Repository-target propagation across API, raw-content, codeload, and release-asset hosts, including route/installation failure handling.
- Ephemeral App setup cleanup, argv-safe process execution, in-memory-only token caching, sanitized reports, and rate-limit fail-closed behavior.
- Backward compatibility of the non-opt-in developer path and the evidence supporting request/process reductions.

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
