### PR TITLE
fix(search): enable true semantic recall for hybrid/multi ranking

### DIFF
--- a/packages/infra/src/search/primitive-index.ts
+++ b/packages/infra/src/search/primitive-index.ts
@@ -418,6 +418,23 @@ export class PrimitiveIndex {
   }
 
   /**
+   * Whether the query carries embedding vectors for semantic ranking.
+   * When true, every filtered candidate must be scored so a semantically
+   * similar primitive can be retrieved even with no lexical token overlap.
+   * @param query Search query.
+   * @returns True if hybrid/multi query embeddings are present.
+   */
+  private hasEmbeddingQuery(query: SearchQuery): boolean {
+    if (query.ranking === 'hybrid') {
+      return !!query.queryEmbedding;
+    }
+    if (query.ranking === 'multi') {
+      return !!query.queryEmbeddings && Object.keys(query.queryEmbeddings).length > 0;
+    }
+    return false;
+  }
+
+  /**
    * Populate zero scores for filtered candidates.
    * @param scores Map of record indices to scores.
    * @param candidates Set of candidate record indices.
@@ -478,7 +495,8 @@ export class PrimitiveIndex {
       for (const name of streams) {
         const weight = providedWeights[name] ?? defaultStreamWeight;
         const qe = query.queryEmbeddings[name];
-        finalScore += weight * cosine(recordEmbeddings[name], qe);
+        // Clamp to [0, 1]: a negative cosine means "unrelated", not "penalise".
+        finalScore += weight * Math.max(0, cosine(recordEmbeddings[name], qe));
       }
       return finalScore;
     }
@@ -489,7 +507,8 @@ export class PrimitiveIndex {
     if (useHybrid) {
       const embedding = recordEmbedding ?? recordEmbeddings?.combined;
       if (embedding && query.queryEmbedding) {
-        hybridScore += (1 - alpha) * cosine(embedding, query.queryEmbedding);
+        // Clamp to [0, 1]: a negative cosine means "unrelated", not "penalise".
+        hybridScore += (1 - alpha) * Math.max(0, cosine(embedding, query.queryEmbedding));
       }
     }
     return hybridScore;
@@ -551,7 +570,12 @@ export class PrimitiveIndex {
     const qTokens = query.q ? tokenize(query.q) : [];
     const { scores, explanations } = this.bm25.score(qTokens, candidates, !!query.explain);
 
-    if (qTokens.length === 0) {
+    // BM25 only inserts docs that matched a query term. For semantic ranking
+    // we must additionally seed every filtered candidate with a zero base
+    // score so a doc that is embedding-similar but shares no lexical token can
+    // still be retrieved — otherwise the dense signal can only re-rank BM25
+    // hits and true semantic recall is impossible.
+    if (qTokens.length === 0 || this.hasEmbeddingQuery(query)) {
       this.populateZeroScores(scores, candidates);
     }
 

--- a/packages/infra/src/search/tokenizer.ts
+++ b/packages/infra/src/search/tokenizer.ts
@@ -35,8 +35,14 @@ export function stem(token: string): string {
   if (token.length <= 3) {
     return token;
   }
+  // Normalise -ies/-ied to -y first so singular/plural (and verb) pairs unify:
+  // queries↔query, studied↔study. Without this, `queries` stemmed to `quer`
+  // while `query` stayed `query`, so the two never matched.
+  if (token.length > 4 && (token.endsWith('ies') || token.endsWith('ied'))) {
+    return `${token.slice(0, -3)}y`;
+  }
   // Order matters: longer suffixes first.
-  const suffixes = ['ingly', 'edly', 'ing', 'ers', 'ier', 'ied', 'ies', 'ed', 'er', 'es', 'ly', 's'];
+  const suffixes = ['ingly', 'edly', 'ing', 'ers', 'ier', 'ed', 'er', 'es', 'ly', 's'];
   for (const suf of suffixes) {
     if (token.length > suf.length + 2 && token.endsWith(suf)) {
       return token.slice(0, -suf.length);

--- a/packages/infra/test/search/primitive-index-embeddings.test.ts
+++ b/packages/infra/test/search/primitive-index-embeddings.test.ts
@@ -67,6 +67,29 @@ describe('PrimitiveIndex embeddings', () => {
     expect(res.hits[0].score).toBeGreaterThan(0);
   });
 
+  it('retrieves a semantically-similar primitive that shares no query keyword', async () => {
+    const idx = await buildEmbeddedIndex();
+    const json = idx.toJSON() as {
+      primitives: { id: string; embedding?: number[] }[];
+    };
+    const target = json.primitives.find((p) => p.embedding && p.embedding.length === 384);
+    expect(target).toBeTruthy();
+
+    // Query text deliberately shares no stemmed token with any document, so
+    // BM25 matches nothing. The query embedding is the target's own vector
+    // (cosine ~= 1), so a working semantic layer must still retrieve it.
+    const queryEmbedding = new Float32Array(target!.embedding!);
+    const res = idx.search({
+      q: 'zzqqxx wvbnkq',
+      ranking: 'hybrid',
+      queryEmbedding,
+      limit: 10
+    });
+
+    const ids = res.hits.map((h) => h.primitive.id);
+    expect(ids).toContain(target!.id);
+  });
+
   it('round-trips embeddings through saveIndex/loadIndex', async () => {
     const idx = await buildEmbeddedIndex();
     const file = path.join(os.tmpdir(), `pi-embed-${Date.now()}.json`);

--- a/packages/infra/test/search/tokenizer.test.ts
+++ b/packages/infra/test/search/tokenizer.test.ts
@@ -40,6 +40,14 @@ describe('tokenizer', () => {
     expect(stem('rs')).toBe('rs');
   });
 
+  it('stem() unifies -ies/-ied plurals with their -y singular', () => {
+    expect(stem('queries')).toBe('query');
+    expect(stem('query')).toBe('query');
+    expect(stem('studied')).toBe('study');
+    // A document term and its query variant now tokenise identically.
+    expect(tokenize('queries')).toStrictEqual(tokenize('query'));
+  });
+
   it('keepStopwords honours caller intent', () => {
     const out = tokenize('for the module', { keepStopwords: true, stem: false });
     expect(out.includes('for')).toBe(true);


### PR DESCRIPTION
Semantic  ranking could only re-rank BM25 keyword hits: a primitive that was embedding-similar but shared no query token could never be retrieved, because the scoring candidate set was seeded only from BM25 term matches. Seed every filtered candidate when the query carries embeddings so the dense signal drives recall, not just re-ordering.

Also:
- Clamp cosine contributions to [0, 1] so an unrelated (negative-cosine) embedding cannot penalise a hit below its BM25 score.
- Unify -ies/-ied plurals with their -y singular in the stemmer (queries<->query, studied<->study), which previously never matched.

Adds focused tests for pure-semantic recall and stemmer unification.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark relevant items with an [x] -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔧 Configuration/build changes

## Related Issues

<!-- Link to related issues using #issue_number -->

Closes #
Fixes #
Relates to #

## Changes Made

<!-- Provide a detailed list of changes -->

- 
- 
- 

## Testing

<!-- Describe the testing you've done -->

### Test Coverage

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

### Manual Testing Steps

1. 
2. 
3. 

### Tested On

- [ ] macOS
- [ ] Windows
- [ ] Linux

- [ ] VS Code Stable
- [ ] VS Code Insiders

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->

## Checklist

<!-- Mark completed items with an [x] -->

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Documentation

<!-- Describe any documentation changes needed -->

- [ ] README.md updated
- [ ] JSDoc comments added/updated
- [ ] No documentation changes needed

## Additional Notes

<!-- Add any additional notes for reviewers -->

## Reviewer Guidelines

<!-- For reviewers: What should they focus on? -->

Please pay special attention to:

- 
- 

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
