### PR TITLE
feat: configure renovate for dependency management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,7 @@ post-compile-fixes-cross-platform.js
 # Profile files (user-created profiles in workspace)
 /*.json
 !package.json
+!renovate.json
 !tsconfig*.json
 .c8_output/
 

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,16 @@
   "labels": [
     "renovate"
   ],
+  "github-actions": {
+    "managerFilePatterns": [
+      "apps/vscode-extension/templates/scaffolds/**/workflows/*.yml"
+    ]
+  },
+  "npm": {
+    "managerFilePatterns": [
+      "apps/vscode-extension/templates/scaffolds/**/package.template.json"
+    ]
+  },
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": [
@@ -106,8 +116,8 @@
       "matchManagers": [
         "npm"
       ],
-      "matchPackagePatterns": [
-        "^@o3r/"
+      "matchPackageNames": [
+        "/^@o3r//"
       ],
       "groupName": "Otter packages"
     },
@@ -179,6 +189,17 @@
       "addLabels": [
         "workspace:website"
       ]
+    },
+    {
+      "description": "Group scaffold template updates into their own PR, separate from the repo's own dependencies",
+      "matchFileNames": [
+        "apps/vscode-extension/templates/scaffolds/**"
+      ],
+      "groupName": "scaffold templates",
+      "addLabels": [
+        "scaffold-templates"
+      ],
+      "automerge": false
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -5,23 +5,23 @@
     ":dependencyDashboard",
     ":semanticCommits"
   ],
-  "prConcurrentLimit": 10,
-  "prHourlyLimit": 2,
-  "labels": ["dependencies"],
+  "labels": [
+    "renovate"
+  ],
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["before 5am on monday"]
+    "schedule": [
+      "before 5am on monday"
+    ]
   },
   "customManagers": [
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "package.json",
         ".github/workflows/*.yml",
         ".github/workflows/*.yaml"
       ],
       "matchStrings": [
-        "\"node\"\\s*:\\s*\">=(?<currentValue>\\d+\\.\\d+\\.\\d+)\"",
         "NODE_VERSION:\\s*\"(?<currentValue>\\d+)\""
       ],
       "datasourceTemplate": "node-version",
@@ -31,94 +31,154 @@
   ],
   "packageRules": [
     {
-      "description": "Group npm minor updates",
-      "matchManagers": ["npm"],
-      "matchUpdateTypes": ["minor"],
+      "description": "Group all minor dependency updates into a single PR",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchUpdateTypes": [
+        "minor"
+      ],
       "groupName": "npm minor dependencies",
       "automerge": false
     },
     {
-      "description": "Group and automerge npm patch updates",
-      "matchManagers": ["npm"],
-      "matchUpdateTypes": ["patch"],
+      "description": "Group and auto-merge all patch dependency updates",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ],
       "groupName": "npm patch dependencies",
       "automerge": true
     },
     {
-      "description": "Keep major updates separate",
-      "matchManagers": ["npm"],
-      "matchUpdateTypes": ["major"]
+      "description": "Create individual PRs for major updates across all managers to allow careful review",
+      "matchUpdateTypes": [
+        "major"
+      ]
     },
     {
-      "description": "Delay and isolate @types/vscode updates",
-      "matchManagers": ["npm"],
-      "matchPackageNames": ["@types/vscode"],
+      "description": "Delay @types/vscode updates by 8 months to stay aligned with the VS Code engine target",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchPackageNames": [
+        "@types/vscode"
+      ],
       "groupName": "@types/vscode",
       "minimumReleaseAge": "8 months",
       "prCreation": "not-pending",
       "automerge": false
     },
     {
-      "description": "Keep axios updates separate",
-      "matchManagers": ["npm"],
-      "matchPackageNames": ["axios"],
+      "description": "Isolate axios updates for manual review due to breaking change history",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchPackageNames": [
+        "axios"
+      ],
       "groupName": "axios"
     },
     {
-      "description": "Keep ESLint updates separate",
-      "matchManagers": ["npm"],
-      "matchPackageNames": ["eslint"],
+      "description": "Isolate ESLint core updates to avoid config breakage",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchPackageNames": [
+        "eslint"
+      ],
       "groupName": "eslint"
     },
     {
-      "description": "Keep TypeScript ESLint updates separate",
-      "matchManagers": ["npm"],
-      "matchPackageNames": ["typescript-eslint"],
+      "description": "Isolate typescript-eslint updates to review rule changes separately",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchPackageNames": [
+        "typescript-eslint"
+      ],
       "groupName": "typescript-eslint"
     },
     {
-      "description": "Keep Otter package updates separate",
-      "matchManagers": ["npm"],
-      "matchPackagePatterns": ["^@o3r/"],
+      "description": "Group all @o3r/ Otter packages together since they share a release cadence",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchPackagePatterns": [
+        "^@o3r/"
+      ],
       "groupName": "Otter packages"
     },
     {
-      "description": "Keep pnpm package manager updates separate",
-      "matchManagers": ["npm"],
-      "matchDepTypes": ["packageManager"],
-      "matchPackageNames": ["pnpm"],
+      "description": "Isolate pnpm package manager updates to validate workspace compatibility",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchDepTypes": [
+        "packageManager"
+      ],
+      "matchPackageNames": [
+        "pnpm"
+      ],
       "groupName": "pnpm"
     },
     {
-      "description": "Keep Node.js runtime updates separate and aligned",
-      "matchManagers": ["custom.regex"],
-      "matchDepNames": ["node"],
+      "description": "Group Node.js runtime version updates across package.json and CI workflows",
+      "matchManagers": [
+        "npm",
+        "custom.regex"
+      ],
+      "matchDepNames": [
+        "node"
+      ],
       "groupName": "Node.js runtime"
     },
     {
-      "description": "Label package workspace updates",
-      "matchFileNames": ["packages/*/package.json"],
-      "addLabels": ["workspace:packages"]
+      "description": "Add workspace label for packages/ updates",
+      "matchFileNames": [
+        "packages/*/package.json"
+      ],
+      "addLabels": [
+        "workspace:packages"
+      ]
     },
     {
-      "description": "Label application workspace updates",
-      "matchFileNames": ["apps/*/package.json"],
-      "addLabels": ["workspace:apps"]
+      "description": "Add workspace label for apps/ updates",
+      "matchFileNames": [
+        "apps/*/package.json"
+      ],
+      "addLabels": [
+        "workspace:apps"
+      ]
     },
     {
-      "description": "Label GitHub Actions workspace updates",
-      "matchFileNames": ["github-actions/*/package.json"],
-      "addLabels": ["workspace:github-actions"]
+      "description": "Add workspace label for github-actions/ updates",
+      "matchFileNames": [
+        "github-actions/*/package.json"
+      ],
+      "addLabels": [
+        "workspace:github-actions"
+      ]
     },
     {
-      "description": "Label library workspace updates",
-      "matchFileNames": ["lib/package.json"],
-      "addLabels": ["workspace:lib"]
+      "description": "Add workspace label for lib/ updates",
+      "matchFileNames": [
+        "lib/package.json"
+      ],
+      "addLabels": [
+        "workspace:lib"
+      ]
     },
     {
-      "description": "Label website workspace updates",
-      "matchFileNames": ["website/package.json"],
-      "addLabels": ["workspace:website"]
+      "description": "Add workspace label for website/ updates",
+      "matchFileNames": [
+        "website/package.json"
+      ],
+      "addLabels": [
+        "workspace:website"
+      ]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -31,10 +31,17 @@
   ],
   "packageRules": [
     {
-      "description": "Group non-major npm updates across the workspace",
+      "description": "Group npm minor updates",
       "matchManagers": ["npm"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "pnpm workspace non-major dependencies",
+      "matchUpdateTypes": ["minor"],
+      "groupName": "npm minor dependencies",
+      "automerge": false
+    },
+    {
+      "description": "Group and automerge npm patch updates",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["patch"],
+      "groupName": "npm patch dependencies",
       "automerge": true
     },
     {
@@ -43,7 +50,47 @@
       "matchUpdateTypes": ["major"]
     },
     {
-      "description": "Keep Node.js runtime declarations aligned",
+      "description": "Delay and isolate @types/vscode updates",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@types/vscode"],
+      "groupName": "@types/vscode",
+      "minimumReleaseAge": "8 months",
+      "prCreation": "not-pending",
+      "automerge": false
+    },
+    {
+      "description": "Keep axios updates separate",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["axios"],
+      "groupName": "axios"
+    },
+    {
+      "description": "Keep ESLint updates separate",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["eslint"],
+      "groupName": "eslint"
+    },
+    {
+      "description": "Keep TypeScript ESLint updates separate",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["typescript-eslint"],
+      "groupName": "typescript-eslint"
+    },
+    {
+      "description": "Keep Otter package updates separate",
+      "matchManagers": ["npm"],
+      "matchPackagePatterns": ["^@o3r/"],
+      "groupName": "Otter packages"
+    },
+    {
+      "description": "Keep pnpm package manager updates separate",
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["packageManager"],
+      "matchPackageNames": ["pnpm"],
+      "groupName": "pnpm"
+    },
+    {
+      "description": "Keep Node.js runtime updates separate and aligned",
       "matchManagers": ["custom.regex"],
       "matchDepNames": ["node"],
       "groupName": "Node.js runtime"

--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    ":dependencyDashboard",
-    ":semanticCommits"
+    "local>mvgadagi/renovate-config",
+    "local>mvgadagi/renovate-config:node"
   ],
   "labels": [
     "renovate"

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>mvgadagi/renovate-config",
-    "local>mvgadagi/renovate-config:node"
+    "local>AmadeusITGroup/renovate-config",
+    "local>AmadeusITGroup/renovate-config:node"
   ],
   "github-actions": {
     "managerFilePatterns": [

--- a/renovate.json
+++ b/renovate.json
@@ -4,9 +4,6 @@
     "local>mvgadagi/renovate-config",
     "local>mvgadagi/renovate-config:node"
   ],
-  "labels": [
-    "renovate"
-  ],
   "github-actions": {
     "managerFilePatterns": [
       "apps/vscode-extension/templates/scaffolds/**/workflows/*.yml"
@@ -17,56 +14,7 @@
       "apps/vscode-extension/templates/scaffolds/**/package.template.json"
     ]
   },
-  "lockFileMaintenance": {
-    "enabled": true,
-    "schedule": [
-      "before 5am on monday"
-    ]
-  },
-  "customManagers": [
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        ".github/workflows/*.yml",
-        ".github/workflows/*.yaml"
-      ],
-      "matchStrings": [
-        "NODE_VERSION:\\s*\"(?<currentValue>\\d+)\""
-      ],
-      "datasourceTemplate": "node-version",
-      "depNameTemplate": "node",
-      "versioningTemplate": "node"
-    }
-  ],
   "packageRules": [
-    {
-      "description": "Group all minor dependency updates into a single PR",
-      "matchManagers": [
-        "npm"
-      ],
-      "matchUpdateTypes": [
-        "minor"
-      ],
-      "groupName": "npm minor dependencies",
-      "automerge": false
-    },
-    {
-      "description": "Group and auto-merge all patch dependency updates",
-      "matchManagers": [
-        "npm"
-      ],
-      "matchUpdateTypes": [
-        "patch"
-      ],
-      "groupName": "npm patch dependencies",
-      "automerge": true
-    },
-    {
-      "description": "Create individual PRs for major updates across all managers to allow careful review",
-      "matchUpdateTypes": [
-        "major"
-      ]
-    },
     {
       "description": "Delay @types/vscode updates by 8 months to stay aligned with the VS Code engine target",
       "matchManagers": [
@@ -79,70 +27,6 @@
       "minimumReleaseAge": "8 months",
       "prCreation": "not-pending",
       "automerge": false
-    },
-    {
-      "description": "Isolate axios updates for manual review due to breaking change history",
-      "matchManagers": [
-        "npm"
-      ],
-      "matchPackageNames": [
-        "axios"
-      ],
-      "groupName": "axios"
-    },
-    {
-      "description": "Isolate ESLint core updates to avoid config breakage",
-      "matchManagers": [
-        "npm"
-      ],
-      "matchPackageNames": [
-        "eslint"
-      ],
-      "groupName": "eslint"
-    },
-    {
-      "description": "Isolate typescript-eslint updates to review rule changes separately",
-      "matchManagers": [
-        "npm"
-      ],
-      "matchPackageNames": [
-        "typescript-eslint"
-      ],
-      "groupName": "typescript-eslint"
-    },
-    {
-      "description": "Group all @o3r/ Otter packages together since they share a release cadence",
-      "matchManagers": [
-        "npm"
-      ],
-      "matchPackageNames": [
-        "/^@o3r//"
-      ],
-      "groupName": "Otter packages"
-    },
-    {
-      "description": "Isolate pnpm package manager updates to validate workspace compatibility",
-      "matchManagers": [
-        "npm"
-      ],
-      "matchDepTypes": [
-        "packageManager"
-      ],
-      "matchPackageNames": [
-        "pnpm"
-      ],
-      "groupName": "pnpm"
-    },
-    {
-      "description": "Group Node.js runtime version updates across package.json and CI workflows",
-      "matchManagers": [
-        "npm",
-        "custom.regex"
-      ],
-      "matchDepNames": [
-        "node"
-      ],
-      "groupName": "Node.js runtime"
     },
     {
       "description": "Add workspace label for packages/ updates",
@@ -190,15 +74,35 @@
       ]
     },
     {
-      "description": "Group scaffold template updates into their own PR, separate from the repo's own dependencies",
+      "description": "Group non-major scaffold template updates into their own PR, separate from the repo's own dependencies",
       "matchFileNames": [
         "apps/vscode-extension/templates/scaffolds/**"
       ],
-      "groupName": "scaffold templates",
-      "addLabels": [
-        "scaffold-templates"
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "digest",
+        "pin",
+        "pinDigest",
+        "lockFileMaintenance"
       ],
-      "automerge": false
+      "groupName": "scaffolds non-major",
+      "addLabels": [
+        "workspace:apps:scaffolds"
+      ]
+    },
+    {
+      "description": "Keep major scaffold template updates as individual PRs (do not group them)",
+      "matchFileNames": [
+        "apps/vscode-extension/templates/scaffolds/**"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "scaffolds major",
+      "addLabels": [
+        "workspace:apps:scaffolds"
+      ]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -99,7 +99,7 @@
       "matchUpdateTypes": [
         "major"
       ],
-      "groupName": "scaffolds major",
+      "groupName": null,
       "addLabels": [
         "workspace:apps:scaffolds"
       ]

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits"
+  ],
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 2,
+  "labels": ["dependencies"],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 5am on monday"]
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "package.json",
+        ".github/workflows/*.yml",
+        ".github/workflows/*.yaml"
+      ],
+      "matchStrings": [
+        "\"node\"\\s*:\\s*\">=(?<currentValue>\\d+\\.\\d+\\.\\d+)\"",
+        "NODE_VERSION:\\s*\"(?<currentValue>\\d+)\""
+      ],
+      "datasourceTemplate": "node-version",
+      "depNameTemplate": "node",
+      "versioningTemplate": "node"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Group non-major npm updates across the workspace",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "pnpm workspace non-major dependencies",
+      "automerge": true
+    },
+    {
+      "description": "Keep major updates separate",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["major"]
+    },
+    {
+      "description": "Keep Node.js runtime declarations aligned",
+      "matchManagers": ["custom.regex"],
+      "matchDepNames": ["node"],
+      "groupName": "Node.js runtime"
+    },
+    {
+      "description": "Label package workspace updates",
+      "matchFileNames": ["packages/*/package.json"],
+      "addLabels": ["workspace:packages"]
+    },
+    {
+      "description": "Label application workspace updates",
+      "matchFileNames": ["apps/*/package.json"],
+      "addLabels": ["workspace:apps"]
+    },
+    {
+      "description": "Label GitHub Actions workspace updates",
+      "matchFileNames": ["github-actions/*/package.json"],
+      "addLabels": ["workspace:github-actions"]
+    },
+    {
+      "description": "Label library workspace updates",
+      "matchFileNames": ["lib/package.json"],
+      "addLabels": ["workspace:lib"]
+    },
+    {
+      "description": "Label website workspace updates",
+      "matchFileNames": ["website/package.json"],
+      "addLabels": ["workspace:website"]
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Adds a `renovate.json` configuration to automate dependency update PRs via [Renovate](https://docs.renovatebot.com/). This replaces manual dependency tracking with an opinionated, low-noise setup tailored to the monorepo structure.

## Prerequisites

This PR only lands the `renovate.json` file in the repo. Renovate does **not** run just because the config is merged — the following org-level setup must be completed first, otherwise the config is inert. These are prerequisites for this PR to have any effect:

### 1. Shared config repository — `AmadeusITGroup/renovate-config`

Create a repository named `renovate-config` under the `AmadeusITGroup` org. Renovate resolves the shorthand preset `local>AmadeusITGroup/renovate-config` to a repo with exactly this name, so it becomes the canonical home for org-wide Renovate presets. Other repositories can then share policy with:

```json
{ "extends": ["local>AmadeusITGroup/renovate-config"] }
```

- Owner: `AmadeusITGroup`
- Name: `renovate-config` (exact — required by Renovate's `local>org/renovate-config` shorthand)
- Contents: a `default.json` preset (org defaults) plus any named presets, e.g. `default.json`, `automerge.json`.
- Visibility must allow the Renovate App/token to read it (internal or private with the App installed on it).

### 2. Renovate GitHub App / installation

Renovate must be installed on the org (or at least this repo) and granted access. Two supported paths:

- **Self-hosted GitHub App**: register a GitHub App with the permissions below, install it on the org, and run the Renovate CLI/action against it.

Required permissions per Renovate's [Security & Permissions docs](https://docs.renovatebot.com/security-and-permissions/):

| Permission | Mend Renovate App | Forking Renovate | Why |
|---|:---:|:---:|---|
| Dependabot alerts | read | read | Create vulnerability fix PRs |
| Administration | read | read | Read branch protections, assign teams to PRs |
| Metadata | read | read | Mandatory for all apps |
| Checks | read & write | n/a | Read and write status checks |
| Contents (Code) | read & write | read | Read repo content, write to create branches |
| Commit statuses | read & write | read & write | Commit statuses for Renovate PRs |
| Issues | read & write | read & write | Dependency Dashboard / config-warning issues |
| Pull Requests | read & write | read & write | Create update PRs |
| Workflows | read & write | n/a | Update `.github/workflows/*` files |

Note: the custom manager in this config edits `NODE_VERSION` in `.github/workflows/*.yml`, so **Workflows: read & write** is not optional here — without it those update PRs fail.

## Type of Change

- [x] 🔧 Configuration/build changes

## Changes Made

### Renovate configuration (`renovate.json`)

- **Base presets:** extends `config:recommended`, `:dependencyDashboard`, and `:semanticCommits` for sensible defaults and conventional commit messages.
- **Lock file maintenance:** scheduled weekly (Monday before 5am) to keep `pnpm-lock.yaml` fresh.
- **Custom manager:** regex-based manager to track `NODE_VERSION` in GitHub Actions workflow YAML files alongside `package.json` engine constraints.

### Grouping strategy

- **Patch updates:** grouped and auto-merged — low risk, high volume.
- **Minor updates:** grouped into a single PR for manual review.
- **Major updates:** individual PRs across all managers (npm, GitHub Actions, Docker, custom regex) to allow careful review of breaking changes.

### Isolated packages (individual PRs)

| Package | Reason |
|---------|--------|
| `@types/vscode` | Delayed 8 months to stay aligned with the VS Code engine target |
| `axios` | History of breaking changes across majors |
| `eslint` | Config breakage risk |
| `typescript-eslint` | Rule changes need separate review |
| `@o3r/*` (Otter) | Grouped together — shared release cadence |
| `pnpm` | Package manager updates need workspace compatibility validation |
| `node` | Grouped across `package.json` and CI workflows via custom regex manager |

### Workspace labeling

PRs are auto-labeled by monorepo area (`workspace:packages`, `workspace:apps`, `workspace:github-actions`, `workspace:lib`, `workspace:website`) for easy filtering.

### `.gitignore` update

Added `!renovate.json` exception so the config is tracked (the repo ignores `/*.json` by default).

## Testing
- Renovate config https://github.com/mvgadagi/renovate-config
- PRs from Renovate https://github.com/mvgadagi/ai-primitives-hub/pulls


### Test Coverage

- [x] Manual testing completed
- [x] All existing tests pass

### Manual Testing Steps

1. Validated JSON schema against `https://docs.renovatebot.com/renovate-schema.json`
2. Verified the `.gitignore` exception correctly tracks `renovate.json`
3. Reviewed package rules against the current dependency landscape

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] No documentation changes needed

## Reviewer Guidelines

Please pay special attention to:

- Whether the `@types/vscode` 8-month delay aligns with the current VS Code engine target policy
- Whether any additional packages should be isolated or grouped differently
- Whether auto-merge on patch updates is acceptable for the CI/review workflow

Closes : https://github.com/AmadeusITGroup/ai-primitives-hub/issues/401
---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
