### PR TITLE
fix(schema): update schema URL in example.collection.template.yml for scaffolds

### DIFF
--- a/apps/vscode-extension/templates/scaffolds/github/collections/example.collection.template.yml
+++ b/apps/vscode-extension/templates/scaffolds/github/collections/example.collection.template.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/AmadeusITGroup/prompt-registry/refs/heads/main/schemas/collection.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/AmadeusITGroup/ai-primitives-hub/refs/heads/main/packages/core/src/public/schemas/collection.schema.json
 id: {{collectionId}}
 name: {{projectName}}
 description: Example collection for {{projectName}}


### PR DESCRIPTION
## Description

When user tried to create the scaffold this example collection is pointing to old collection and Agents tries to generate new collection with same schema.
So update the schema URL in the example.collection.template.yml file to point to the correct location.

## Type of Change

- [x] 📝 Reference fix
- [x] 📝 Documentation update

## Related Issues

Closes #

## Changes Made

- Updated schema URL in example.collection.template.yml

## Testing

### Test Coverage

- [x] Manual testing completed
- [x] All existing tests pass

### Manual Testing Steps

1. Verify the schema URL in example.collection.template.yml and accessible

### Tested On

- [x] macOS
- [] Windows
- [] Linux

- [x] VS Code Stable

## Additional Notes

## Reviewer Guidelines

Please pay special attention to:

- The correctness of the new schema URL
- Any potential impacts on related functionality

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**

