### PR TITLE
feat: jfrog artifactory storage backend

### DIFF
--- a/apps/vscode-extension/src/adapters/infra-adapter-factory.ts
+++ b/apps/vscode-extension/src/adapters/infra-adapter-factory.ts
@@ -21,15 +21,22 @@ import type {
   SourceAdapterFactoryDeps,
 } from '@ai-primitives-hub/app';
 import type {
+  HttpCredentialProvider,
   SourceAdapter,
+  SourceRequestContext,
+  TokenProvider,
 } from '@ai-primitives-hub/core';
 import {
   GhCliTokenProvider,
   NodeFileSystem,
   NodeHttpClient,
   NodeProcessRunner,
+  normalizeSourceRoot,
   SystemClock,
 } from '@ai-primitives-hub/infra';
+import {
+  SourceTokenVault,
+} from '../services/source-token-vault';
 import type {
   RegistrySource,
 } from '../types/registry';
@@ -39,6 +46,31 @@ import {
 import {
   VsCodeSessionTokenProvider,
 } from './vscode-session-token-provider';
+
+class VaultTokenProvider implements TokenProvider {
+  public constructor(private readonly vault: SourceTokenVault, private readonly sourceId: string) {}
+  public async getToken(_host: string): Promise<string | undefined> {
+    return await this.vault.get(this.sourceId);
+  }
+}
+
+/** SecretStorage-backed Artifactory credentials scoped to one source root. */
+export class SourceVaultCredentialProvider implements HttpCredentialProvider {
+  public constructor(private readonly vault: SourceTokenVault, private readonly source: RegistrySource) {}
+
+  public async headersFor(url: string, context: SourceRequestContext): Promise<Readonly<Record<string, string>>> {
+    const root = normalizeSourceRoot(this.source.url);
+    const target = new URL(url);
+    const rootPath = root.pathname;
+    if (root.origin !== target.origin || !target.pathname.startsWith(rootPath)
+      || context.sourceId !== root.href || context.trustedOrigin !== root.origin
+      || context.trustedPathPrefix !== rootPath) {
+      throw new Error('Credential request is outside the configured source root.');
+    }
+    const token = await this.vault.get(this.source.id);
+    return token ? { Authorization: `Bearer ${token}` } : {};
+  }
+}
 
 const fs = new NodeFileSystem();
 const clock = new SystemClock();
@@ -66,17 +98,26 @@ const silentDeps: SourceAdapterFactoryDeps = {
  * Build the `infra`-backed adapter for a `RegistrySource`, matching the
  * shape of the extension's own `IRepositoryAdapter`.
  * @param source - The source to build an adapter for.
+ * @param vault
  */
-export function createRegistryAdapter(source: RegistrySource): IRepositoryAdapter {
-  return createCoreRegistryAdapter(source) as IRepositoryAdapter;
+export function createRegistryAdapter(source: RegistrySource, vault?: SourceTokenVault): IRepositoryAdapter {
+  return createCoreRegistryAdapter(source, vault) as IRepositoryAdapter;
 }
 
 /**
  * Build the shared core adapter for services that consume the app/infra
  * ports directly, such as primitive indexing.
  * @param source - The source to build an adapter for.
+ * @param vault
  */
-export function createCoreRegistryAdapter(source: RegistrySource): SourceAdapter {
-  const deps = source.type === 'skills' ? silentDeps : promptingDeps;
+export function createCoreRegistryAdapter(source: RegistrySource, vault?: SourceTokenVault): SourceAdapter {
+  const baseDeps = source.type === 'skills' ? silentDeps : promptingDeps;
+  const deps: SourceAdapterFactoryDeps = vault === undefined
+    ? baseDeps
+    : {
+      ...baseDeps,
+      fallbackTokenProviders: [new VaultTokenProvider(vault, source.id), ...baseDeps.fallbackTokenProviders],
+      artifactoryCredentialFactory: (currentSource) => new SourceVaultCredentialProvider(vault, currentSource)
+    };
   return createSourceAdapter(source, deps);
 }

--- a/apps/vscode-extension/src/adapters/infra-adapter-factory.ts
+++ b/apps/vscode-extension/src/adapters/infra-adapter-factory.ts
@@ -35,6 +35,7 @@ import {
   SystemClock,
 } from '@ai-primitives-hub/infra';
 import {
+  HubTokenVault,
   SourceTokenVault,
 } from '../services/source-token-vault';
 import type {
@@ -55,6 +56,21 @@ class VaultTokenProvider implements TokenProvider {
 }
 
 /** SecretStorage-backed Artifactory credentials scoped to one source root. */
+export class HubVaultCredentialProvider implements HttpCredentialProvider {
+  public constructor(private readonly vault: HubTokenVault, private readonly credentialRef: string, private readonly sourceRoot: string) {}
+  public async headersFor(url: string, context: SourceRequestContext): Promise<Readonly<Record<string, string>>> {
+    const root = normalizeSourceRoot(this.sourceRoot);
+    const target = new URL(url);
+    if (root.origin !== target.origin || !target.pathname.startsWith(root.pathname)
+      || context.sourceId !== root.href || context.trustedOrigin !== root.origin
+      || context.trustedPathPrefix !== root.pathname) {
+      throw new Error('Credential request is outside the configured hub root.');
+    }
+    const token = await this.vault.get(this.credentialRef);
+    return token ? { Authorization: `Bearer ${token}` } : {};
+  }
+}
+
 export class SourceVaultCredentialProvider implements HttpCredentialProvider {
   public constructor(private readonly vault: SourceTokenVault, private readonly source: RegistrySource) {}
 

--- a/apps/vscode-extension/src/commands/hub-commands.ts
+++ b/apps/vscode-extension/src/commands/hub-commands.ts
@@ -12,6 +12,9 @@ import {
   RegistryManager,
 } from '../services/registry-manager';
 import {
+  HubTokenVault,
+} from '../services/source-token-vault';
+import {
   HubReference,
 } from '../types/hub';
 import {
@@ -24,7 +27,7 @@ import {
 interface HubSourceOption {
   label: string;
   description: string;
-  value: 'github' | 'url' | 'local';
+  value: 'github' | 'url' | 'local' | 'artifactory';
 }
 
 /**
@@ -134,18 +137,18 @@ export class HubCommands {
   /**
    * Select hub source type
    */
-  private async selectSourceType(): Promise<'github' | 'url' | 'local' | undefined> {
+  private async selectSourceType(): Promise<'github' | 'url' | 'local' | 'artifactory' | undefined> {
     const options: HubSourceOption[] = [
       {
         label: '$(github) GitHub Repository',
         description: 'Import from a GitHub repository',
         value: 'github'
       },
-      // {
-      //     label: '$(link) HTTPS URL',
-      //     description: 'Import from a direct URL',
-      //     value: 'url'
-      // },
+      {
+        label: '$(server) Artifactory Hub',
+        description: 'Import a private hub from Artifactory',
+        value: 'artifactory'
+      },
       {
         label: '$(file) Local File',
         description: 'Import from a local hub-config.yml file',
@@ -165,7 +168,7 @@ export class HubCommands {
    * Get hub reference based on source type
    * @param sourceType
    */
-  private async getHubReference(sourceType: 'github' | 'url' | 'local'): Promise<HubReference | undefined> {
+  private async getHubReference(sourceType: 'github' | 'url' | 'local' | 'artifactory'): Promise<HubReference | undefined> {
     switch (sourceType) {
       case 'github': {
         const location = await vscode.window.showInputBox({
@@ -195,6 +198,47 @@ export class HubCommands {
           location,
           ref: ref || undefined
         };
+      }
+
+      case 'artifactory': {
+        const location = await vscode.window.showInputBox({
+          prompt: 'Enter HTTPS Artifactory hub root URL',
+          placeHolder: 'https://artifactory.example/repository/hub/',
+          validateInput: (value) => value.startsWith('https://') ? null : 'Please enter a valid HTTPS URL',
+          ignoreFocusOut: true
+        });
+        if (!location) {
+          return undefined;
+        }
+        const configFile = await vscode.window.showInputBox({ prompt: 'Config file path', value: 'hub-config.yml', ignoreFocusOut: true });
+        const auth = await vscode.window.showQuickPick(['anonymous', 'bearer'], { placeHolder: 'Artifactory authentication', ignoreFocusOut: true });
+        if (!auth) {
+          return undefined;
+        }
+        let credentialRef: string | undefined;
+        if (auth === 'bearer') {
+          credentialRef = await vscode.window.showInputBox({
+            prompt: 'SecretStorage credential reference',
+            placeHolder: 'PRIVATE_HUB',
+            ignoreFocusOut: true,
+            validateInput: (value) => /^[A-Z_][A-Z0-9_]*$/.test(value)
+              ? undefined
+              : 'Use an environment-style name such as PRIVATE_HUB'
+          });
+          if (!credentialRef) {
+            return undefined;
+          }
+          const token = await vscode.window.showInputBox({
+            prompt: 'Enter Artifactory Bearer token',
+            password: true,
+            ignoreFocusOut: true
+          });
+          if (!token) {
+            return undefined;
+          }
+          await new HubTokenVault(this.context.secrets).set(credentialRef, token);
+        }
+        return { type: 'artifactory', location, configFile: configFile || 'hub-config.yml', authMode: auth as 'anonymous' | 'bearer', credentialRef };
       }
 
       case 'url': {

--- a/apps/vscode-extension/src/commands/hub-commands.ts
+++ b/apps/vscode-extension/src/commands/hub-commands.ts
@@ -225,7 +225,7 @@ export class HubCommands {
         }
         const trimmedLocation = location.trim();
         if (new URL(trimmedLocation).protocol === 'http:') {
-          await vscode.window.showWarningMessage('Loopback HTTP is intended only for local Artifactory testing; use HTTPS for shared or production hubs.');
+          void vscode.window.showWarningMessage('Loopback HTTP is intended only for local Artifactory testing; use HTTPS for shared or production hubs.');
         }
         const configFile = await vscode.window.showInputBox({
           prompt: 'Hub config path relative to the repository root (usually hub-config.yml)',

--- a/apps/vscode-extension/src/commands/hub-commands.ts
+++ b/apps/vscode-extension/src/commands/hub-commands.ts
@@ -256,17 +256,24 @@ export class HubCommands {
 
       case 'url': {
         const location = await vscode.window.showInputBox({
-          prompt: 'Enter HTTPS URL to hub-config.yml',
+          prompt: 'Enter HTTPS URL to hub-config.yml (or loopback HTTP for local testing)',
           placeHolder: 'https://example.com/hub-config.yml',
           validateInput: (value) => {
-            if (!value || !value.startsWith('https://')) {
-              return 'Please enter a valid HTTPS URL';
+            try {
+              const url = new URL(value);
+              const loopback = url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '[::1]';
+              return url.protocol === 'https:' || (url.protocol === 'http:' && loopback)
+                ? undefined
+                : 'Please enter an HTTPS URL, or loopback HTTP for local testing';
+            } catch {
+              return 'Please enter a valid hub configuration URL';
             }
-            return null;
           },
           ignoreFocusOut: true
         });
-
+        if (location && new URL(location).protocol === 'http:') {
+          await vscode.window.showWarningMessage('Loopback HTTP is intended only for local hub testing; use HTTPS for shared or production hubs.');
+        }
         return location ? { type: 'url', location } : undefined;
       }
 

--- a/apps/vscode-extension/src/commands/hub-commands.ts
+++ b/apps/vscode-extension/src/commands/hub-commands.ts
@@ -252,18 +252,19 @@ export class HubCommands {
         let credentialRef: string | undefined;
         if (auth === 'bearer') {
           credentialRef = await vscode.window.showInputBox({
-            prompt: 'SecretStorage credential reference',
-            placeHolder: 'PRIVATE_HUB',
+            prompt: 'Credential label for VS Code SecretStorage (not an environment variable or token)',
+            placeHolder: 'ARTIFACTORY_READER_TOKEN',
             ignoreFocusOut: true,
             validateInput: (value) => /^[A-Z_][A-Z0-9_]*$/.test(value)
               ? undefined
-              : 'Use an environment-style name such as PRIVATE_HUB'
+              : 'Use an uppercase label such as ARTIFACTORY_READER_TOKEN; do not paste the token here'
           });
           if (!credentialRef) {
             return undefined;
           }
           const token = await vscode.window.showInputBox({
-            prompt: 'Enter Artifactory Bearer token',
+            prompt: 'Paste the Artifactory access token (stored securely in VS Code SecretStorage)',
+            placeHolder: 'Token value only; do not include the Bearer prefix',
             password: true,
             ignoreFocusOut: true
           });

--- a/apps/vscode-extension/src/commands/hub-commands.ts
+++ b/apps/vscode-extension/src/commands/hub-commands.ts
@@ -202,8 +202,8 @@ export class HubCommands {
 
       case 'artifactory': {
         const location = await vscode.window.showInputBox({
-          prompt: 'Enter HTTPS Artifactory hub root URL',
-          placeHolder: 'https://artifactory.example/repository/hub/',
+          prompt: 'Enter the Artifactory repository root containing hub-config.yml (do not include hub-config.yml or /ui/native)',
+          placeHolder: 'http://127.0.0.1:8081/artifactory/<repository-key>/<hub-prefix>',
           validateInput: (value) => {
             try {
               const url = new URL(value);
@@ -223,8 +223,22 @@ export class HubCommands {
         if (new URL(location).protocol === 'http:') {
           await vscode.window.showWarningMessage('Loopback HTTP is intended only for local Artifactory testing; use HTTPS for shared or production hubs.');
         }
-        const configFile = await vscode.window.showInputBox({ prompt: 'Config file path', value: 'hub-config.yml', ignoreFocusOut: true });
-        const auth = await vscode.window.showQuickPick(['anonymous', 'bearer'], { placeHolder: 'Artifactory authentication', ignoreFocusOut: true });
+        const configFile = await vscode.window.showInputBox({
+          prompt: 'Hub config path relative to the repository root (usually hub-config.yml)',
+          value: 'hub-config.yml',
+          ignoreFocusOut: true
+        });
+        const root = configFile || 'hub-config.yml';
+        const anonymousReference: HubReference = {
+          type: 'artifactory', location, configFile: root, authMode: 'anonymous'
+        };
+        const publicHub = await this.hubManager.verifyHubAvailability(anonymousReference);
+        if (publicHub) {
+          await vscode.window.showInformationMessage('The Artifactory hub is publicly readable; no credential is required.');
+          return anonymousReference;
+        }
+        await vscode.window.showWarningMessage('The hub is not anonymously readable or is unavailable. Configure a Bearer token if this is a private hub.');
+        const auth = await vscode.window.showQuickPick(['bearer', 'anonymous'], { placeHolder: 'Artifactory authentication', ignoreFocusOut: true });
         if (!auth) {
           return undefined;
         }

--- a/apps/vscode-extension/src/commands/hub-commands.ts
+++ b/apps/vscode-extension/src/commands/hub-commands.ts
@@ -244,7 +244,7 @@ export class HubCommands {
           await vscode.window.showInformationMessage('The Artifactory hub is publicly readable; no credential is required.');
           return anonymousReference;
         }
-        await vscode.window.showWarningMessage('The hub is not anonymously readable or is unavailable. Configure a Bearer token if this is a private hub.');
+        void vscode.window.showWarningMessage('The hub is not anonymously readable or is unavailable. Configure a Bearer token if this is a private hub.');
         const auth = await vscode.window.showQuickPick(['bearer', 'anonymous'], { placeHolder: 'Artifactory authentication', ignoreFocusOut: true });
         if (!auth) {
           return undefined;

--- a/apps/vscode-extension/src/commands/hub-commands.ts
+++ b/apps/vscode-extension/src/commands/hub-commands.ts
@@ -204,11 +204,24 @@ export class HubCommands {
         const location = await vscode.window.showInputBox({
           prompt: 'Enter HTTPS Artifactory hub root URL',
           placeHolder: 'https://artifactory.example/repository/hub/',
-          validateInput: (value) => value.startsWith('https://') ? null : 'Please enter a valid HTTPS URL',
+          validateInput: (value) => {
+            try {
+              const url = new URL(value);
+              const loopback = url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '[::1]';
+              return url.protocol === 'https:' || (url.protocol === 'http:' && loopback)
+                ? undefined
+                : 'Please enter an HTTPS URL, or loopback HTTP for local testing';
+            } catch {
+              return 'Please enter a valid Artifactory URL';
+            }
+          },
           ignoreFocusOut: true
         });
         if (!location) {
           return undefined;
+        }
+        if (new URL(location).protocol === 'http:') {
+          await vscode.window.showWarningMessage('Loopback HTTP is intended only for local Artifactory testing; use HTTPS for shared or production hubs.');
         }
         const configFile = await vscode.window.showInputBox({ prompt: 'Config file path', value: 'hub-config.yml', ignoreFocusOut: true });
         const auth = await vscode.window.showQuickPick(['anonymous', 'bearer'], { placeHolder: 'Artifactory authentication', ignoreFocusOut: true });

--- a/apps/vscode-extension/src/commands/hub-commands.ts
+++ b/apps/vscode-extension/src/commands/hub-commands.ts
@@ -206,6 +206,9 @@ export class HubCommands {
           placeHolder: 'http://127.0.0.1:8081/artifactory/<repository-key>/<hub-prefix>',
           validateInput: (value) => {
             try {
+              if (/\s/u.test(value)) {
+                return 'Remove spaces; use the repository root URL as one continuous value';
+              }
               const url = new URL(value);
               const loopback = url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '[::1]';
               return url.protocol === 'https:' || (url.protocol === 'http:' && loopback)
@@ -220,7 +223,8 @@ export class HubCommands {
         if (!location) {
           return undefined;
         }
-        if (new URL(location).protocol === 'http:') {
+        const trimmedLocation = location.trim();
+        if (new URL(trimmedLocation).protocol === 'http:') {
           await vscode.window.showWarningMessage('Loopback HTTP is intended only for local Artifactory testing; use HTTPS for shared or production hubs.');
         }
         const configFile = await vscode.window.showInputBox({
@@ -230,9 +234,12 @@ export class HubCommands {
         });
         const root = configFile || 'hub-config.yml';
         const anonymousReference: HubReference = {
-          type: 'artifactory', location, configFile: root, authMode: 'anonymous'
+          type: 'artifactory', location: trimmedLocation, configFile: root, authMode: 'anonymous'
         };
-        const publicHub = await this.hubManager.verifyHubAvailability(anonymousReference);
+        const publicHub = await Promise.race([
+          this.hubManager.verifyHubAvailability(anonymousReference),
+          new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), 5000))
+        ]);
         if (publicHub) {
           await vscode.window.showInformationMessage('The Artifactory hub is publicly readable; no credential is required.');
           return anonymousReference;
@@ -265,7 +272,7 @@ export class HubCommands {
           }
           await new HubTokenVault(this.context.secrets).set(credentialRef, token);
         }
-        return { type: 'artifactory', location, configFile: configFile || 'hub-config.yml', authMode: auth as 'anonymous' | 'bearer', credentialRef };
+        return { type: 'artifactory', location: trimmedLocation, configFile: root, authMode: auth as 'anonymous' | 'bearer', credentialRef };
       }
 
       case 'url': {

--- a/apps/vscode-extension/src/commands/hub-profile-commands.ts
+++ b/apps/vscode-extension/src/commands/hub-profile-commands.ts
@@ -33,7 +33,7 @@ export class HubProfileCommands {
     const storagePath = context.globalStorageUri.fsPath;
     this.hubStorage = new HubStorage(storagePath);
     const validator = new SchemaValidator(context.extensionPath);
-    this.hubManager = new HubManager(this.hubStorage, validator, context.extensionPath);
+    this.hubManager = new HubManager(this.hubStorage, validator, context.extensionPath, undefined, undefined, context.secrets);
 
     this.registerCommands(context);
   }

--- a/apps/vscode-extension/src/commands/source-commands.ts
+++ b/apps/vscode-extension/src/commands/source-commands.ts
@@ -142,6 +142,25 @@ export class SourceCommands {
         return uris && uris.length > 0 ? uris[0].fsPath : undefined;
       }
 
+      case 'artifactory': {
+        return await vscode.window.showInputBox({
+          prompt: 'Enter credential-free Artifactory source root URL',
+          placeHolder: 'https://artifactory.example.com/artifactory/prompt-registry/',
+          validateInput: (value) => {
+            try {
+              const url = new URL(value);
+              if (url.protocol !== 'https:') {
+                return 'Please enter an HTTPS Artifactory source root URL';
+              }
+              return undefined;
+            } catch {
+              return 'Please enter a valid HTTPS URL';
+            }
+          },
+          ignoreFocusOut: true
+        });
+      }
+
       case 'azure-devops': {
         return await vscode.window.showInputBox({
           prompt: 'Enter Azure DevOps repository URL',
@@ -225,6 +244,10 @@ export class SourceCommands {
    * @param sourceId
    */
   private async configureToken(sourceId: string): Promise<void> {
+    const source = (await this.registryManager.listSources()).find((item) => item.id === sourceId);
+    if (!source) {
+      return;
+    }
     const token = await vscode.window.showInputBox({
       prompt: 'Enter access token (leave empty to remove)',
       password: true,
@@ -235,7 +258,8 @@ export class SourceCommands {
     if (token !== undefined) {
       await this.registryManager.updateSource(sourceId, {
         token: token.trim() || undefined,
-        private: !!token.trim()
+        private: !!token.trim(),
+        ...(source.type === 'artifactory' ? { config: { ...source.config, authMode: token.trim() ? 'bearer' : 'anonymous' } } : {})
       });
       vscode.window.showInformationMessage('Token configuration updated');
     }
@@ -348,6 +372,11 @@ export class SourceCommands {
             label: '$(azure) Azure DevOps',
             description: 'Azure DevOps Git repository (cloud) with .collection.yml bundles',
             value: 'azure-devops'
+          },
+          {
+            label: '$(cloud) Artifactory',
+            description: 'Credential-free or Bearer-authenticated Artifactory source root',
+            value: 'artifactory'
           }
         ],
         {
@@ -440,6 +469,16 @@ export class SourceCommands {
 
           break;
         }
+        case 'artifactory': {
+          const indexFile = await vscode.window.showInputBox({
+            prompt: 'Enter Artifactory index file (or press Enter for "index-v1.json")',
+            placeHolder: 'index-v1.json',
+            value: 'index-v1.json',
+            ignoreFocusOut: true
+          });
+          config = { indexFile: indexFile || 'index-v1.json' };
+          break;
+        }
         case 'azure-devops': {
           const branch = await vscode.window.showInputBox({
             prompt: 'Enter branch name (or press Enter for "main")',
@@ -485,7 +524,8 @@ export class SourceCommands {
         || sourceType.value === 'local-awesome-copilot'
         || sourceType.value === 'local-apm'
         || sourceType.value === 'local-skills'
-        || sourceType.value === 'azure-devops';
+        || sourceType.value === 'azure-devops'
+        || sourceType.value === 'artifactory';
 
       if (!isTokenSkipped) {
         isPrivate = await vscode.window.showQuickPick(

--- a/apps/vscode-extension/src/commands/source-commands.ts
+++ b/apps/vscode-extension/src/commands/source-commands.ts
@@ -143,22 +143,27 @@ export class SourceCommands {
       }
 
       case 'artifactory': {
-        return await vscode.window.showInputBox({
+        const location = await vscode.window.showInputBox({
           prompt: 'Enter credential-free Artifactory source root URL',
           placeHolder: 'https://artifactory.example.com/artifactory/prompt-registry/',
           validateInput: (value) => {
             try {
               const url = new URL(value);
-              if (url.protocol !== 'https:') {
-                return 'Please enter an HTTPS Artifactory source root URL';
+              const loopback = url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '[::1]';
+              if (url.protocol !== 'https:' && !(url.protocol === 'http:' && loopback)) {
+                return 'Please enter an HTTPS URL, or loopback HTTP for local testing';
               }
               return undefined;
             } catch {
-              return 'Please enter a valid HTTPS URL';
+              return 'Please enter a valid Artifactory URL';
             }
           },
           ignoreFocusOut: true
         });
+        if (location && new URL(location).protocol === 'http:') {
+          await vscode.window.showWarningMessage('Loopback HTTP is intended only for local Artifactory testing; use HTTPS for shared or production sources.');
+        }
+        return location;
       }
 
       case 'azure-devops': {

--- a/apps/vscode-extension/src/commands/source-commands.ts
+++ b/apps/vscode-extension/src/commands/source-commands.ts
@@ -254,9 +254,9 @@ export class SourceCommands {
       return;
     }
     const token = await vscode.window.showInputBox({
-      prompt: 'Enter access token (leave empty to remove)',
+      prompt: 'Paste access token (leave empty to remove)',
       password: true,
-      placeHolder: 'Access token',
+      placeHolder: 'Token value (stored securely)',
       ignoreFocusOut: true
     });
 

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -325,7 +325,7 @@ export class PromptRegistryExtension {
     const hubValidator = new SchemaValidator(this.context.extensionPath);
     // Pass BundleInstaller from RegistryManager to enable bundle installation during profile activation
     const bundleInstaller = this.registryManager.getBundleInstaller();
-    this.hubManager = new HubManager(hubStorage, hubValidator, this.context.extensionPath, bundleInstaller, this.registryManager);
+    this.hubManager = new HubManager(hubStorage, hubValidator, this.context.extensionPath, bundleInstaller, this.registryManager, this.context.secrets);
 
     // Connect HubManager to RegistryManager for profile integration
     this.registryManager.setHubManager(this.hubManager);

--- a/apps/vscode-extension/src/services/bundle-installer.ts
+++ b/apps/vscode-extension/src/services/bundle-installer.ts
@@ -842,7 +842,8 @@ export class BundleInstaller {
       resolver,
       downloader,
       extractor,
-      writerFactory: () => writer
+      writerFactory: () => writer,
+      skipManifestIdValidation: sourceType === 'artifactory'
     });
 
     try {

--- a/apps/vscode-extension/src/services/hub-manager.ts
+++ b/apps/vscode-extension/src/services/hub-manager.ts
@@ -34,6 +34,8 @@ import type {
   ProfileLifecycleSync,
 } from '@ai-primitives-hub/core';
 import {
+  AnonymousCredentialProvider,
+  ArtifactoryHubResolver,
   CompositeHubResolver,
   CompositeTokenProvider,
   GhCliTokenProvider,
@@ -44,6 +46,9 @@ import {
   UrlHubResolver,
 } from '@ai-primitives-hub/infra';
 import * as vscode from 'vscode';
+import {
+  HubVaultCredentialProvider,
+} from '../adapters/infra-adapter-factory';
 import {
   VsCodeSessionTokenProvider,
 } from '../adapters/vscode-session-token-provider';
@@ -74,6 +79,9 @@ import {
   SchemaValidator,
   ValidationResult,
 } from './schema-validator';
+import {
+  HubTokenVault,
+} from './source-token-vault';
 
 /**
  * Resolved bundle with its download URL
@@ -154,7 +162,8 @@ export class HubManager {
     validator: SchemaValidator,
     extensionPath: string,
     private readonly bundleInstaller?: any,
-    private readonly registryManager?: any
+    private readonly registryManager?: any,
+    secrets?: vscode.SecretStorage
   ) {
     if (!storage) {
       throw new Error('storage is required');
@@ -199,7 +208,16 @@ export class HubManager {
     const resolver = new CompositeHubResolver(
       new GitHubHubResolver(httpClient, tokenProvider),
       new LocalHubResolver(new NodeFileSystem()),
-      new UrlHubResolver(httpClient, tokenProvider)
+      new UrlHubResolver(httpClient, tokenProvider),
+      new ArtifactoryHubResolver(httpClient, (reference, root) => {
+        if (reference.authMode !== 'bearer') {
+          return new AnonymousCredentialProvider();
+        }
+        if (!secrets || !reference.credentialRef) {
+          throw new Error('Artifactory Bearer authentication requires a SecretStorage credentialRef.');
+        }
+        return new HubVaultCredentialProvider(new HubTokenVault(secrets), reference.credentialRef, root);
+      })
     );
 
     this.appHubManager = new AppHubManager({

--- a/apps/vscode-extension/src/services/hub-manager.ts
+++ b/apps/vscode-extension/src/services/hub-manager.ts
@@ -130,7 +130,27 @@ export interface SetActiveHubOptions {
 
 /**
  * HubManager orchestrates all hub-related operations
+ * @param sources
+ * @param reference
+ * @param secrets
  */
+async function hydrateArtifactorySources(
+  sources: CoreHubConfig['sources'],
+  reference: HubReference,
+  secrets?: vscode.SecretStorage
+): Promise<CoreHubConfig['sources']> {
+  if (reference.type !== 'artifactory' || reference.authMode !== 'bearer'
+    || !reference.credentialRef || !secrets) {
+    return sources;
+  }
+  const token = await new HubTokenVault(secrets).get(reference.credentialRef);
+  return token
+    ? sources.map((source) => source.type === 'artifactory' && !source.token
+      ? { ...source, token }
+      : source)
+    : sources;
+}
+
 export class HubManager {
   private readonly storage: HubStorage;
   private readonly validator: SchemaValidator;
@@ -163,7 +183,7 @@ export class HubManager {
     extensionPath: string,
     private readonly bundleInstaller?: any,
     private readonly registryManager?: any,
-    secrets?: vscode.SecretStorage
+    private readonly secrets?: vscode.SecretStorage
   ) {
     if (!storage) {
       throw new Error('storage is required');
@@ -342,14 +362,6 @@ export class HubManager {
     return resolvedHubId;
   }
 
-  /**
-   * Import a hub and immediately start progressive source loading/syncing.
-   * Returns handles so callers can unblock early (`onFirstSettled`) or wait
-   * for the full batch (`onComplete`).
-   * @param reference Hub reference (GitHub, URL, or local path)
-   * @param hubId Optional hub identifier (auto-generated if not provided)
-   * @returns Hub identifier and progressive-load handles
-   */
   public async importHubProgressively(
     reference: HubReference,
     hubId?: string
@@ -365,9 +377,10 @@ export class HubManager {
     }
 
     const hubData = await this.storage.loadHub(resolvedHubId);
+    const sources = await hydrateArtifactorySources(hubData.config.sources ?? [], hubData.reference, this.secrets);
     const result = loadHubSourcesProgressively(
       resolvedHubId,
-      hubData.config.sources ?? [],
+      sources,
       {
         listSources: () => this.registryManager.listSources(),
         addSource: (s) => this.registryManager.addSource(s),
@@ -619,7 +632,7 @@ export class HubManager {
       // the background so the marketplace/tree fill in progressively.
       if (this.registryManager && options?.loadSources !== false) {
         const hubData = await this.storage.loadHub(hubId);
-        const sources = hubData.config.sources ?? [];
+        const sources = await hydrateArtifactorySources(hubData.config.sources ?? [], hubData.reference, this.secrets);
         const { onComplete } = loadHubSourcesProgressively(
           hubId,
           sources,
@@ -680,7 +693,7 @@ export class HubManager {
 
     try {
       const hubData = await this.storage.loadHub(hubId);
-      const hubSources = hubData.config.sources || [];
+      const hubSources = await hydrateArtifactorySources(hubData.config.sources || [], hubData.reference, this.secrets);
 
       await appLoadHubSources(
         hubId,

--- a/apps/vscode-extension/src/services/registry-manager.ts
+++ b/apps/vscode-extension/src/services/registry-manager.ts
@@ -122,6 +122,9 @@ import {
   LockfileManager,
 } from './lockfile-manager';
 import {
+  SourceTokenVault,
+} from './source-token-vault';
+import {
   VersionConsolidator,
 } from './version-consolidator';
 
@@ -164,6 +167,7 @@ export class RegistryManager {
   }
 
   private readonly storage: RegistryStorage;
+  private readonly tokenVault: SourceTokenVault;
   private hubManager?: HubManager;
   private _autoUpdateService?: AutoUpdateService;
   private readonly installer: BundleInstaller;
@@ -216,6 +220,11 @@ export class RegistryManager {
 
   private constructor(private readonly context: vscode.ExtensionContext) {
     this.storage = new RegistryStorage(context);
+    this.tokenVault = new SourceTokenVault(context.secrets ?? {
+      get: async () => undefined,
+      store: async () => undefined,
+      delete: async () => undefined
+    });
     this.installer = new BundleInstaller(context);
     this.logger = Logger.getInstance();
 
@@ -301,6 +310,10 @@ export class RegistryManager {
    * @param source
    */
   private enrichSourceWithGlobalToken(source: RegistrySource): RegistrySource {
+    // The deprecated setting is a GitHub-only compatibility fallback.
+    if (source.type !== 'github') {
+      return source;
+    }
     // If source already has a token, don't override it
     if (source.token && source.token.trim().length > 0) {
       return source;
@@ -331,8 +344,8 @@ export class RegistryManager {
     for (const source of sources) {
       if (source.enabled) {
         try {
-          const enrichedSource = this.enrichSourceWithGlobalToken(source);
-          const adapter = createRegistryAdapter(enrichedSource);
+          const enrichedSource = this.enrichSourceWithGlobalToken({ ...source, token: await this.tokenVault.get(source.id) });
+          const adapter = createRegistryAdapter(enrichedSource, this.tokenVault);
           this.adapters.set(source.id, adapter);
         } catch (error) {
           this.logger.error(`Failed to create adapter for source '${source.id}'`, error as Error);
@@ -392,7 +405,7 @@ export class RegistryManager {
 
     if (!adapter) {
       const enrichedSource = this.enrichSourceWithGlobalToken(source);
-      adapter = createRegistryAdapter(enrichedSource);
+      adapter = createRegistryAdapter(enrichedSource, this.tokenVault);
       this.adapters.set(source.id, adapter);
     }
 
@@ -801,6 +814,11 @@ export class RegistryManager {
   public async initialize(): Promise<void> {
     this.logger.info('Initializing AI Primitives Hub...');
     await this.storage.initialize();
+    const config = await this.storage.loadConfig();
+    const sanitizedSources = await this.tokenVault.migrateLegacyTokens(config.sources);
+    if (sanitizedSources.some((source, index) => source.token !== config.sources[index]?.token)) {
+      await this.storage.saveConfig({ ...config, sources: sanitizedSources });
+    }
     await this.loadAdapters();
     this.logger.info('AI Primitives Hub initialized successfully');
   }
@@ -844,23 +862,27 @@ export class RegistryManager {
   public async addSource(source: RegistrySource): Promise<void> {
     this.logger.info(`Adding source: ${source.name}`);
 
-    // Validate source (with global token if applicable)
-    const enrichedSource = this.enrichSourceWithGlobalToken(source);
-    const adapter = createRegistryAdapter(enrichedSource);
+    if (source.token?.trim()) {
+      await this.tokenVault.set(source.id, source.token.trim());
+    }
+    const sourceWithoutToken = { ...source, token: undefined };
+    // Validate source (with global GitHub token compatibility only)
+    const enrichedSource = this.enrichSourceWithGlobalToken(sourceWithoutToken);
+    const adapter = createRegistryAdapter(enrichedSource, this.tokenVault);
     const validation = await adapter.validate();
 
     if (!validation.valid) {
       throw new Error(`Source validation failed: ${validation.errors.join(', ')}`);
     }
 
-    await this.storage.addSource(source);
+    await this.storage.addSource(sourceWithoutToken);
     this.adapters.set(source.id, adapter);
 
     // Update cache
     this.sourcesCache = await this.storage.getSources();
     this.invalidatePrimitiveIndexKeyCache();
 
-    this._onSourceAdded.fire(source);
+    this._onSourceAdded.fire(sourceWithoutToken);
     this.logger.info(`Source '${source.name}' added successfully`);
   }
 
@@ -872,6 +894,7 @@ export class RegistryManager {
     this.logger.info(`Removing source: ${sourceId}`);
 
     await this.storage.removeSource(sourceId);
+    await this.tokenVault.delete(sourceId);
     this.adapters.delete(sourceId);
 
     // Update cache
@@ -928,7 +951,11 @@ export class RegistryManager {
   public async updateSource(sourceId: string, updates: Partial<RegistrySource>): Promise<void> {
     this.logger.info(`Updating source: ${sourceId}`);
 
-    await this.storage.updateSource(sourceId, updates);
+    if ('token' in updates) {
+      await (updates.token?.trim() ? this.tokenVault.set(sourceId, updates.token.trim()) : this.tokenVault.delete(sourceId));
+    }
+    const { token: _token, ...persistedUpdates } = updates;
+    await this.storage.updateSource(sourceId, persistedUpdates);
 
     // Reload adapter if source was updated
     this.adapters.delete(sourceId);
@@ -940,7 +967,7 @@ export class RegistryManager {
 
     if (updatedSource && updatedSource.enabled) {
       const enrichedSource = this.enrichSourceWithGlobalToken(updatedSource);
-      const adapter = createRegistryAdapter(enrichedSource);
+      const adapter = createRegistryAdapter(enrichedSource, this.tokenVault);
       this.adapters.set(sourceId, adapter);
     }
 
@@ -1065,7 +1092,7 @@ export class RegistryManager {
           return [{
             sourceId: source.id,
             provider: new SourceAdapterBundleProvider({
-              adapter: createCoreRegistryAdapter(enrichedSource),
+              adapter: createCoreRegistryAdapter(enrichedSource, this.tokenVault),
               // Installation state is deliberately applied at query time so the
               // persisted semantic index remains reusable after install changes.
               isInstalled: () => false
@@ -1172,8 +1199,12 @@ export class RegistryManager {
    * @param source
    */
   public async validateSource(source: RegistrySource): Promise<ValidationResult> {
-    const enrichedSource = this.enrichSourceWithGlobalToken(source);
-    const adapter = createRegistryAdapter(enrichedSource);
+    if (source.token?.trim()) {
+      await this.tokenVault.set(source.id, source.token.trim());
+    }
+    const sourceWithoutToken = { ...source, token: undefined };
+    const enrichedSource = this.enrichSourceWithGlobalToken(sourceWithoutToken);
+    const adapter = createRegistryAdapter(enrichedSource, this.tokenVault);
     return await adapter.validate();
   }
 

--- a/apps/vscode-extension/src/services/source-token-vault.ts
+++ b/apps/vscode-extension/src/services/source-token-vault.ts
@@ -35,3 +35,24 @@ export class SourceTokenVault {
     return `${SourceTokenVault.KEY_PREFIX}${encodeURIComponent(sourceId)}`;
   }
 }
+
+/** Hub-scoped SecretStorage for Artifactory credentials. */
+export class HubTokenVault {
+  private static readonly KEY_PREFIX = 'promptregistry.hub-token.';
+  public constructor(private readonly secrets: vscode.SecretStorage) {}
+  public async get(credentialRef: string): Promise<string | undefined> {
+    return await this.secrets.get(HubTokenVault.key(credentialRef));
+  }
+
+  public async set(credentialRef: string, token: string): Promise<void> {
+    await this.secrets.store(HubTokenVault.key(credentialRef), token);
+  }
+
+  public async delete(credentialRef: string): Promise<void> {
+    await this.secrets.delete(HubTokenVault.key(credentialRef));
+  }
+
+  public static key(credentialRef: string): string {
+    return `${HubTokenVault.KEY_PREFIX}${encodeURIComponent(credentialRef)}`;
+  }
+}

--- a/apps/vscode-extension/src/services/source-token-vault.ts
+++ b/apps/vscode-extension/src/services/source-token-vault.ts
@@ -1,0 +1,37 @@
+import type * as vscode from 'vscode';
+import type {
+  RegistrySource,
+} from '../types/registry';
+
+/** Source-scoped secret storage for credentials that must never be serialized. */
+export class SourceTokenVault {
+  private static readonly KEY_PREFIX = 'promptregistry.source-token.';
+
+  public constructor(private readonly secrets: vscode.SecretStorage) {}
+
+  public async get(sourceId: string): Promise<string | undefined> {
+    return await this.secrets.get(SourceTokenVault.key(sourceId));
+  }
+
+  public async set(sourceId: string, token: string): Promise<void> {
+    await this.secrets.store(SourceTokenVault.key(sourceId), token);
+  }
+
+  public async delete(sourceId: string): Promise<void> {
+    await this.secrets.delete(SourceTokenVault.key(sourceId));
+  }
+
+  public async migrateLegacyTokens(sources: readonly RegistrySource[]): Promise<RegistrySource[]> {
+    return await Promise.all(sources.map(async (source) => {
+      if (source.token && source.token.trim()) {
+        await this.set(source.id, source.token.trim());
+      }
+      const { token: _token, ...sanitized } = source;
+      return sanitized;
+    }));
+  }
+
+  public static key(sourceId: string): string {
+    return `${SourceTokenVault.KEY_PREFIX}${encodeURIComponent(sourceId)}`;
+  }
+}

--- a/apps/vscode-extension/src/storage/registry-storage.ts
+++ b/apps/vscode-extension/src/storage/registry-storage.ts
@@ -142,9 +142,13 @@ export class RegistryStorage {
   }
 
   private async writeConfig(config: RegistryConfig): Promise<void> {
-    const data = JSON.stringify(config, null, 2);
+    const sanitizedConfig: RegistryConfig = {
+      ...config,
+      sources: config.sources.map(({ token: _token, ...source }) => source)
+    };
+    const data = JSON.stringify(sanitizedConfig, null, 2);
     await writeFile(this.paths.config, data, 'utf8');
-    this.configCache = config;
+    this.configCache = sanitizedConfig;
   }
 
   private async enqueueConfigMutation(mutation: () => Promise<void>): Promise<void> {

--- a/apps/vscode-extension/src/types/hub.ts
+++ b/apps/vscode-extension/src/types/hub.ts
@@ -25,13 +25,22 @@ export {
  */
 export interface HubReference {
   /** Type of hub source */
-  type: 'github' | 'local' | 'url';
+  type: 'github' | 'local' | 'url' | 'artifactory';
 
   /** Location of the hub (repo, path, or URL) */
   location: string;
 
   /** Git ref for GitHub sources (branch, tag, or commit) */
   ref?: string;
+
+  /** Relative config path within an Artifactory hub root */
+  configFile?: string;
+
+  /** Artifactory authentication mode */
+  authMode?: 'anonymous' | 'bearer';
+
+  /** SecretStorage/environment credential reference, never a raw token */
+  credentialRef?: string;
 
   /** Whether to automatically sync this hub */
   autoSync?: boolean;

--- a/apps/vscode-extension/src/types/hub.ts
+++ b/apps/vscode-extension/src/types/hub.ts
@@ -39,7 +39,7 @@ export interface HubReference {
   /** Artifactory authentication mode */
   authMode?: 'anonymous' | 'bearer';
 
-  /** SecretStorage/environment credential reference, never a raw token */
+  /** SecretStorage key in VS Code; CLI interprets the same field as an environment variable name. Never a raw token. */
   credentialRef?: string;
 
   /** Whether to automatically sync this hub */

--- a/apps/vscode-extension/src/types/registry.ts
+++ b/apps/vscode-extension/src/types/registry.ts
@@ -9,7 +9,7 @@ import {
 /**
  * Registry source types
  */
-export type SourceType = 'github' | 'local' | 'awesome-copilot' | 'local-awesome-copilot' | 'apm' | 'local-apm' | 'skills' | 'local-skills' | 'azure-devops';
+export type SourceType = 'github' | 'local' | 'awesome-copilot' | 'local-awesome-copilot' | 'apm' | 'local-apm' | 'skills' | 'local-skills' | 'azure-devops' | 'artifactory';
 
 /**
  * Installation scope

--- a/apps/vscode-extension/test/adapters/infra-adapter-factory.test.ts
+++ b/apps/vscode-extension/test/adapters/infra-adapter-factory.test.ts
@@ -8,7 +8,11 @@ import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import {
   createRegistryAdapter,
+  SourceVaultCredentialProvider,
 } from '../../src/adapters/infra-adapter-factory';
+import {
+  SourceTokenVault,
+} from '../../src/services/source-token-vault';
 import {
   RegistrySource,
 } from '../../src/types/registry';
@@ -53,7 +57,8 @@ suite('createRegistryAdapter', () => {
     ['github', 'https://github.com/owner/repo'],
     ['skills', 'https://github.com/owner/repo'],
     ['awesome-copilot', 'https://github.com/owner/repo'],
-    ['apm', 'https://github.com/owner/repo']
+    ['apm', 'https://github.com/owner/repo'],
+    ['artifactory', 'https://artifactory.example/repository/']
   ];
 
   for (const [type, url] of cases) {
@@ -62,6 +67,25 @@ suite('createRegistryAdapter', () => {
       assert.strictEqual(adapter.type, type);
     });
   }
+
+  test('uses source-scoped Bearer credentials for Artifactory only within the source root', async () => {
+    const secrets = new Map<string, string>([[SourceTokenVault.key('test-source'), 'artifactory-secret']]);
+    const vault = new SourceTokenVault({
+      get: async (key: string) => secrets.get(key),
+      store: async (key: string, value: string) => {
+        secrets.set(key, value);
+      },
+      delete: async (key: string) => {
+        secrets.delete(key);
+      }
+    } as any);
+    const source = makeSource({ type: 'artifactory', url: 'https://artifactory.example/repository' });
+    const provider = new SourceVaultCredentialProvider(vault, source);
+    const context = { sourceId: 'https://artifactory.example/repository/', trustedOrigin: 'https://artifactory.example', trustedPathPrefix: '/repository/' };
+
+    assert.deepStrictEqual(await provider.headersFor(`${source.url}/index.json`, context), { Authorization: 'Bearer artifactory-secret' });
+    await assert.rejects(provider.headersFor('https://artifactory.example/other/index.json', context));
+  });
 
   test('throws a descriptive error for an unknown source type', () => {
     assert.throws(

--- a/apps/vscode-extension/test/services/source-token-vault.test.ts
+++ b/apps/vscode-extension/test/services/source-token-vault.test.ts
@@ -1,0 +1,45 @@
+import * as assert from 'node:assert';
+import {
+  SourceTokenVault,
+} from '../../src/services/source-token-vault';
+
+suite('SourceTokenVault', () => {
+  test('stores tokens under source-scoped SecretStorage keys', async () => {
+    const values = new Map<string, string>();
+    const secrets = {
+      get: async (key: string) => values.get(key),
+      store: async (key: string, value: string) => {
+        values.set(key, value);
+      },
+      delete: async (key: string) => {
+        values.delete(key);
+      }
+    } as any;
+    const vault = new SourceTokenVault(secrets);
+
+    await vault.set('artifactory-source', 'secret-token');
+
+    assert.strictEqual(await vault.get('artifactory-source'), 'secret-token');
+    assert.strictEqual(values.size, 1);
+    assert.ok([...values.keys()][0].includes('artifactory-source'));
+  });
+
+  test('migrates legacy plaintext source tokens and returns sanitized sources', async () => {
+    const values = new Map<string, string>();
+    const vault = new SourceTokenVault({
+      get: async (key: string) => values.get(key),
+      store: async (key: string, value: string) => {
+        values.set(key, value);
+      },
+      delete: async (key: string) => {
+        values.delete(key);
+      }
+    } as any);
+    const sources = [{ id: 'legacy', token: 'legacy-secret' } as any];
+
+    const sanitized = await vault.migrateLegacyTokens(sources);
+
+    assert.strictEqual(await vault.get('legacy'), 'legacy-secret');
+    assert.strictEqual(sanitized[0].token, undefined);
+  });
+});

--- a/apps/vscode-extension/test/vscode-mock.js
+++ b/apps/vscode-extension/test/vscode-mock.js
@@ -3,6 +3,11 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 module.exports = {
+  secrets: {
+    get: async () => undefined,
+    store: async () => undefined,
+    delete: async () => undefined
+  },
   workspace: {
     getConfiguration: (section) => ({
       get: (key, defaultValue) => {

--- a/apps/vscode-extension/tsconfig.json
+++ b/apps/vscode-extension/tsconfig.json
@@ -9,11 +9,6 @@
     "sourceMap": true,
     "rootDir": "src",
     "strict": true,
-    "moduleResolution": "node",
-    "baseUrl": "./",
-    "paths": {
-      "*": ["node_modules/*"]
-    },
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@ Marketplace and registry for Copilot prompt bundles in VS Code.
   - [MCP Integration](contributor-guide/architecture/mcp-integration.md)
   - [Scaffolding](contributor-guide/architecture/scaffolding.md)
   - [Validation](contributor-guide/architecture/validation.md)
+  - [Architecture decisions](contributor-guide/architecture/adr/adr-index.md)
 - **[Core Flows](contributor-guide/core-flows.md)** — Key system flows
 - **[Testing](contributor-guide/testing.md)** — Testing strategy
 - **[Testing SSH Remote](contributor-guide/testing/ssh-remote.md)** — SSH testing

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,6 +58,7 @@ Marketplace and registry for Copilot prompt bundles in VS Code.
 - **[Settings](reference/settings.md)** — Extension settings
 - **[Adapter API](reference/adapter-api.md)** — Custom adapters
 - **[Hub Schema](reference/hub-schema.md)** — Hub configuration
+- **[Hub Replication](reference/hub-replication.md)** — Replicating GitHub release bundles to Artifactory
 
 ---
 

--- a/docs/author-guide/publishing.md
+++ b/docs/author-guide/publishing.md
@@ -33,6 +33,14 @@ If you're contributing a collection to a source you don't own:
    **AI Primitives Hub: Validate Collections**
 6. Create a new branch, commit, and open a **Pull Request** against the upstream source repository
 
+## Publishing to Artifactory
+
+Artifactory publishing is supported through a generic repository with a hub-owned static index. Publish the bundle manifest, ZIP archive, optional README, and an `index-v1.json` describing those objects. Every object path must be relative to the configured source root and include its exact byte size and lowercase SHA-256 digest.
+
+Keep publication and consumption credentials separate. Publishers need repository deploy/write permission but should not retain delete permission after setup. Consumers need read permission only. Configure consumers with a credential reference rather than embedding a token in the index, URL, hub configuration, or lockfile. Qualify a publication by checking anonymous/private index access, archive download, digest and size verification, ETag refresh, traversal rejection, and reader/publisher permissions.
+
+The CLI uses an environment variable for the configured credential reference; VS Code stores the entered token in SecretStorage. Both clients use the same source-root and integrity checks.
+
 ## Creating a New Source (GitHub Recommended)
 
 ### Setup

--- a/docs/contributor-guide/architecture/adr/0008-artifactory-hub-tree-distribution-channel.md
+++ b/docs/contributor-guide/architecture/adr/0008-artifactory-hub-tree-distribution-channel.md
@@ -1,0 +1,226 @@
+# ADR-0008: Generic Artifactory Hub Tree as an Explicit Distribution Channel
+
+**Status:** Proposed
+
+## Context
+
+AI Primitives Hub currently treats GitHub as the primary runtime source for
+published bundle metadata and release assets. Enterprise consumers may need to
+consume the same governed artifacts from JFrog Artifactory because GitHub is
+unavailable, restricted, or not approved as the runtime binary-distribution
+channel. The consumer must still receive the existing AI Primitives Hub bundle
+contract: deployment manifests, ZIP archives, optional READMEs, metadata,
+checksums, and reproducible lockfile behavior.
+
+JFrog offers native Agent Packages/APM, Skills, and Agent Plugins surfaces, but
+those contracts are beta or scope-limited, use package layouts that differ from
+AI Primitives Hub bundles, and do not represent every supported primitive kind
+as one atomic installable bundle. Artifactory repository listing, AQL, or
+recursive Storage API discovery would add provider-specific permissions,
+N+1 requests, and topology coupling.
+
+The feature also crosses the shared architecture boundary. It needs domain
+validation and ports in `packages/core`, HTTP and credential adapters in
+`packages/infra`, use-case composition in `packages/app`, and thin delivery
+wiring in the CLI and VS Code extension. Private hub consumption additionally
+requires a consistent credential policy: CLI credentials must be supplied by a
+host environment, VS Code token values must remain in SecretStorage, and
+neither delivery may silently reuse GitHub credentials for an Artifactory host.
+
+The repository's study and implementation identify a complete Artifactory hub
+tree as the supported private topology:
+
+```text
+<hub-root>/hub-config.yml
+<hub-root>/sources/<source-id>/index-v1.json
+<hub-root>/sources/<source-id>/bundles/<bundle-id>/<version>/deployment-manifest.yml
+<hub-root>/sources/<source-id>/bundles/<bundle-id>/<version>/<bundle-id>-<version>.zip
+<hub-root>/sources/<source-id>/bundles/<bundle-id>/<version>/README.md
+```
+
+The architectural choice should be recorded separately from the implementation
+so that the generic repository/static-index model, source identity, trust
+boundary, and fallback policy are not defined only by the current branch or PR.
+
+## Decision
+
+1. **Use a generic Artifactory repository with an AI Primitives Hub static index
+   for the MVP.**
+
+   Each Artifactory source has a configured source root and a versioned
+   `index-v1.json` catalog. The index contains normalized bundle metadata,
+   immutable relative object paths, sizes, SHA-256 digests, and optional
+   provenance fields. The existing `deployment-manifest.yml`, ZIP archive, and
+   installation contracts remain authoritative for installed content.
+
+2. **Model Artifactory as an explicit source type and distribution channel.**
+
+   Hub and lockfile schemas, source identity, adapters, resolvers, and delivery
+   commands recognize `artifactory` directly. Artifactory and GitHub sources
+   retain provider-specific identities in the MVP. Equivalent content exposed
+   by both providers is therefore selected explicitly rather than implicitly
+   deduplicated or merged.
+
+3. **Support a complete private hub tree so runtime consumption does not require
+   GitHub access.**
+
+   A private Artifactory hub reference resolves `hub-config.yml` from the
+   configured repository root. The imported configuration points to Artifactory
+   source roots containing their indexes and bundle objects. A successful
+   source-index request alone is not considered sufficient: hub configuration,
+   index, manifest, archive, install/update, and exact-version lockfile replay
+   must all be supported by the same configured channel.
+
+4. **Use source-scoped Bearer credentials with delivery-specific secret
+   providers.**
+
+   The source configuration stores only an opaque credential reference and an
+   authentication mode. The CLI resolves the reference through the process
+   environment or its injected host credential provider. The VS Code extension
+   stores the token value only in `ExtensionContext.secrets` and persists the
+   reference/label in non-secret state. Credentials are attached only when the
+   request matches the configured Artifactory origin and confined path prefix;
+   unsafe redirects receive no credential. GitHub token providers are never a
+   fallback for Artifactory requests. Basic authentication is deferred unless a
+   qualified target requires it.
+
+5. **Put provider behavior in shared layers and keep deliveries thin.**
+
+   - `core` owns source/index shapes, validation rules, integrity policy, error
+     contracts, and credential ports without HTTP, filesystem, or VS Code
+     dependencies.
+   - `infra` owns the Artifactory HTTP client, static-index adapter, hub
+     resolver, bundle downloader, credential implementations, and publication
+     adapters.
+   - `app` composes adapters and orchestrates source, hub, install, lockfile,
+     and replication workflows.
+   - The CLI parses options, resolves environment-backed credentials, and
+     formats output; it does not implement provider rules.
+   - The VS Code extension owns prompts, SecretStorage wiring, notifications,
+     and delivery-specific UX; it does not duplicate Artifactory business
+     logic.
+
+   This preserves ADR-0001's one shared domain across the CLI and extension and
+   follows the repository's strangler-fig migration boundary.
+
+6. **Fail closed and verify integrity before installation.**
+
+   Artifactory index responses are bounded and schema-validated. Object paths
+   must be safe relative paths confined to the source root; duplicate bundle
+   identities are invalid. The client verifies the downloaded archive's size
+   and SHA-256 before extraction, then reuses the existing root-manifest,
+   archive-safety, file-integrity, and writer-verification pipeline. Manifest
+   identity/version disagreement, path violations, malformed data, checksum
+   mismatches, and 401/403 responses are terminal errors and never trigger
+   GitHub fallback.
+
+7. **Keep publication separate from consumption and publish complete trees in a
+   safe order.**
+
+   GitHub remains the canonical authoring and provenance channel. Replication or
+   other CI tooling may copy verified release bytes into Artifactory, but
+   clients do not publish directly. A publication run writes immutable bundle
+   objects first, verifies or reuses same-digest existing objects, publishes a
+   complete source index second, and publishes `hub-config.yml` last. Dry-run
+   and explicit review acknowledgement are required before writes in the CLI.
+   Conflicting or unverifiable existing objects stop the operation by default.
+
+8. **Defer native JFrog package contracts, transparent fallback, and signing.**
+
+   Native Agent Packages/APM, Skills, and Agent Plugins integrations remain
+   separate future adapters. Automatic GitHub/Artifactory fallback is deferred
+   until a separate channel-identity and policy ADR defines its provenance,
+   lockfile, and failure semantics. The MVP's unsigned index is an integrity
+   and consistency mechanism, not an independent proof of publisher identity;
+   signing/evidence requires a future trust-root and verification decision.
+
+## Alternatives considered
+
+- **Keep GitHub as the only runtime distribution channel:** rejected because it
+  does not support private-network and approved-enterprise-repository use cases.
+- **Use native JFrog Agent Packages/APM:** rejected for MVP because the surface
+  is beta, has a different package-root contract, and does not preserve the
+  existing complete bundle model without conversion.
+- **Use native Skills or Agent Plugins repositories:** rejected because these
+  split a collection across primitive families and cannot represent every
+  supported primitive kind as one atomic bundle.
+- **Use Artifactory listing, Storage API, or AQL for discovery:** rejected
+  because it introduces provider-specific permissions, N+1 requests, and
+  topology/version coupling; one validated static index is deterministic and
+  portable.
+- **Proxy GitHub through Artifactory:** rejected as the primary contract because
+  it retains mutable source-repository semantics and does not provide a
+  governed immutable bundle catalog.
+- **Merge Artifactory and GitHub behind transparent fallback:** deferred because
+  authentication, integrity, provenance, source identity, and lockfile replay
+  failures must not silently change providers.
+- **Persist Artifactory tokens in hub configuration or shared application
+  state:** rejected because it violates the secret boundary; only references
+  and non-secret configuration may be persisted.
+
+## Consequences
+
+- **Positive:** existing bundle ZIPs and deployment manifests remain usable
+  without conversion, so all current primitive kinds share one installation
+  pipeline.
+- **Positive:** catalog synchronization requires one bounded index request per
+  source and does not require AQL or recursive repository listing.
+- **Positive:** CLI and VS Code use the same source adapter, resolver, integrity
+  checks, and lockfile semantics while retaining their native credential UX.
+- **Positive:** a complete private hub tree can operate without private GitHub
+  runtime access, and explicit provider identity makes policy and provenance
+  observable.
+- **Positive:** immutable object paths, checksums, and ordered publication make
+  interrupted or resumed replication safer and keep incomplete content out of
+  advertised indexes.
+- **Negative:** the project owns the index schema, publisher behavior, and
+  compatibility policy instead of delegating discovery to native JFrog package
+  APIs.
+- **Negative:** Artifactory and GitHub versions of equivalent content are not
+  transparently deduplicated in the MVP; users must choose the source/channel
+  explicitly.
+- **Negative:** a static index with SHA-256 detects corruption and mismatch but
+  does not independently establish publisher identity. Signing/evidence remains
+  a future security decision.
+- **Negative:** real Artifactory qualification is required for endpoint routing,
+  ETag behavior, repository topology, token scopes, and least-privilege
+  publisher permissions. The publisher must not retain delete permission for
+  production sign-off.
+- **Unaffected:** GitHub remains the default source and existing GitHub/local/
+  APM/Skills/Azure workflows retain their current contracts. Existing identifier
+  compatibility rules and the XDG/AppStorage decisions from ADR-0004 through
+  ADR-0006 remain in force.
+
+## Implementation implications
+
+1. Keep `artifactory` in core source unions, hub/lockfile schemas, source ID
+   normalization, and public validation paths.
+2. Keep `index-v1.json` validation strict: bounded input, safe relative paths,
+   valid SemVer, unique `(id, version)` entries, object metadata, and matching
+   configured source identity.
+3. Bind Artifactory credentials to the exact normalized origin and path prefix;
+   strip them on cross-origin or out-of-prefix redirects and never include
+   values in URLs, logs, caches, snapshots, lockfiles, or serialized output.
+4. Use the injected storage ports for validated index cache metadata and follow
+   ADR-0005/0006; credentials are not cache artifacts.
+5. Preserve exact source/object paths and archive checksums in lockfile entries so
+   replay does not re-evaluate a mutable `latest` index.
+6. Keep replication as an explicit app use case with a thin CLI command and a
+   separate publisher port. Require dry-run/review gates, request budgets,
+   bounded concurrency, cache/resume behavior, conflict checks, and ordered
+   publication.
+7. Test both deliveries against shared fixtures and mock external HTTP/auth
+   boundaries. Add live qualification only with approved disposable prefixes
+   and separate read-only consumer and deploy-only publisher principals.
+8. Update source, command, publishing, replication, schema, testing, and
+   security documentation when behavior or operational requirements change.
+9. Revisit this ADR before adding native JFrog package adapters, transparent
+   cross-provider fallback, Basic authentication, or signed/evidence-backed
+   publication.
+
+## Related decisions
+
+- [ADR-0001: Ports & Adapters Across the CLI and the VS Code Extension](./0001-ports-and-adapters-for-cli-and-extension.md)
+- [ADR-0005: Universal, XDG-Based Application Storage Port](./0005-universal-xdg-based-app-storage.md)
+- [ADR-0006: Shared Semantic Cache and Client-Owned State](./0006-shared-semantic-cache-and-client-owned-state.md)
+- [ADR-0007: Source-Aware GitHub App Authentication for CLI Workflows](./0007-source-aware-github-app-authentication.md)

--- a/docs/contributor-guide/architecture/adr/adr-index.md
+++ b/docs/contributor-guide/architecture/adr/adr-index.md
@@ -14,6 +14,7 @@ focused on one decision.
 | [0005](./0005-universal-xdg-based-app-storage.md) | Universal, XDG-Based Application Storage Port | Accepted |
 | [0006](./0006-shared-semantic-cache-and-client-owned-state.md) | Shared Semantic Cache and Client-Owned State | Accepted |
 | [0007](./0007-source-aware-github-app-authentication.md) | Source-Aware GitHub App Authentication for CLI Workflows | Accepted |
+| [0008](./0008-artifactory-hub-tree-distribution-channel.md) | Generic Artifactory Hub Tree as an Explicit Distribution Channel | Proposed |
 
 ## When to add a new ADR
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -2,6 +2,16 @@
 
 This document lists all VS Code commands provided by the AI Primitives Hub extension.
 
+## Hub Replication (CLI)
+
+`ai-primitives-hub hub replicate --source-hub owner/repo --target-root https://artifactory.example/repo`
+
+Replication reads the source `hub-config.yml` at `--source-ref` and initially processes only enabled `type: github` sources. It resolves release assets containing a deployment manifest and ZIP archive, derives the stable ID `<owner>-<repo>[-<manifest.id>]`, and accepts only SemVer versions. `--mode latest` (the default) selects the newest stable version requested by profiles; `--mode all` retains every verified release. Unresolved profile selections are warnings and are omitted from the generated profiles.
+
+The command is metadata-only by default: it never downloads archives or publishes. Add `--publish --review` to opt into publication. The destination is exactly `<target-root>/sources/replicated`; objects are checked with HEAD and SHA-256 before upload, then `index-v1.json`, then `hub-config.yml` are written. Existing objects with the same digest are resumed/skipped. Conflicting or unverifiable objects fail closed unless `--allow-unverified-existing` is explicitly approved. Only bounded transient HTTP retries are used; rate-limit failures include a rerun/cache diagnostic. Credentials are supplied by the named environment variable (`--target-credential-ref`) and never appear in logs, cache keys, URLs, or generated configuration.
+
+`--cache-dir`, `--workers`, and `--request-budget` control persistent metadata/archive reuse, concurrency, and the GitHub request ceiling. Cache files are atomically written with directory mode 700 and file mode 600. No GitHub fallback client or `gh` CLI is used by production replication.
+
 ## Bundle Management
 
 | Command | Title | Description |

--- a/docs/reference/hub-replication.md
+++ b/docs/reference/hub-replication.md
@@ -1,0 +1,93 @@
+# Hub replication reference
+
+`hub replicate` copies selected bundles from a GitHub-backed hub into a unified Artifactory-hosted hub tree.
+
+## Scope
+
+The initial implementation processes enabled sources of type `github` and GitHub release assets containing both `deployment-manifest.yml` (or JSON/YAML equivalent) and a `.zip` archive. Other source types are reported or omitted; they are not silently converted through another provider.
+
+The generated tree is:
+
+```text
+<target-root>/hub-config.yml
+<target-root>/sources/replicated/index-v1.json
+<target-root>/sources/replicated/bundles/<stable-id>/<version>/deployment-manifest.yml
+<target-root>/sources/replicated/bundles/<stable-id>/<version>/<stable-id>-<version>.zip
+```
+
+GitHub remains provenance metadata only. Consumers of the generated hub use Artifactory URLs and do not need access to the source GitHub organization.
+
+## Command
+
+```bash
+ai-primitives-hub hub replicate \
+  --source-hub Amadeus-xDLC/genai.prompt-registry-config \
+  --source-ref main \
+  --target-root https://artifactory.example.com/artifactory/repo/team-hub \
+  --mode latest \
+  --cache-dir "$HOME/.cache/ai-primitives-hub-replication"
+```
+
+Important options:
+
+| Option | Default | Meaning |
+|---|---|---|
+| `--source-hub` | required | GitHub `owner/repository` containing `hub-config.yml` |
+| `--source-ref` | `main` | GitHub branch/tag/commit |
+| `--target-root` | required | Credential-free Artifactory hub-tree root |
+| `--mode` | `latest` | Select profile-resolved latest versions or every available version |
+| `--cache-dir` | local cache | Persistent release/manifest/archive cache |
+| `--workers` | `4` | Bounded source-processing concurrency |
+| `--request-budget` | `600` | Maximum uncached GitHub API requests |
+| `--target-auth` | `bearer` | Authentication mode recorded for the generated target source |
+| `--target-credential-ref` | `ARTIFACTORY_READER_TOKEN` | Consumer credential reference recorded in generated hub config |
+| `--publisher-credential-ref` | `ARTIFACTORY_PUBLISHER_TOKEN` | Environment variable used only for publication |
+| `--dry-run` | false | Explicitly request metadata-only behavior |
+| `--publish` | false | Enable Artifactory writes; requires `--review` |
+| `--review` | false | Acknowledges the publication review gate |
+| `--allow-unverified-existing` | false | Allows skipping existing objects whose remote checksum cannot be verified; never overwrites them |
+
+The command is metadata-only unless both `--publish` and `--review` are provided. `--dry-run` and `--publish` cannot be combined.
+
+## Selection semantics
+
+`latest` reads bundle references from source profiles and selects the highest stable SemVer for each requested stable bundle ID. An explicitly pinned profile version is selected exactly. `all` selects every valid GitHub release candidate and deduplicates by stable bundle ID/version.
+
+Stable IDs have the form `<owner>-<repository>-<manifest.id>` when the manifest declares an ID, or `<owner>-<repository>` otherwise. The version remains a separate index coordinate. Unresolved profile references are warnings and are not emitted into generated profiles.
+
+## Publication and resume
+
+Publication is ordered to avoid advertising incomplete content:
+
+1. download and verify each manifest/archive;
+2. publish bundle objects;
+3. publish `index-v1.json`;
+4. publish `hub-config.yml`.
+
+Before each write, the publisher uses `HEAD` and Artifactory checksum metadata. An existing object with the same SHA-256 is skipped. A conflicting or unverifiable object stops the operation by default. Re-running with the same cache and target root resumes completed work.
+
+Transient Artifactory failures may be retried with a bounded budget. Authentication, permission, conflict, schema, and integrity failures are not retried or redirected to GitHub.
+
+## Credentials
+
+Source GitHub credentials are supplied through the CLI token provider and are never copied into the target. Artifactory publication uses the environment variable named by `--publisher-credential-ref`. The generated consumer hub config contains only `--target-credential-ref`, never its token value.
+
+For example:
+
+```bash
+read -r -s -p 'Publisher token: ' ARTIFACTORY_PUBLISHER_TOKEN
+printf '\n' >&2
+export ARTIFACTORY_PUBLISHER_TOKEN
+ai-primitives-hub hub replicate ... --publish --review
+unset ARTIFACTORY_PUBLISHER_TOKEN
+```
+
+Do not place credentials in command arguments, URLs, cache keys, generated YAML/JSON, logs, or lockfiles.
+
+## Failure and review gates
+
+Before publication, review the dry-run output, unresolved references, expected archive count/bytes, GitHub request budget, target prefix, publisher permissions, and target consumer credential reference. A failed run must not publish a new index or hub config advertising unverified objects.
+
+After publication, import the generated hub using `hub add --type artifactory`, verify the catalog and profiles, install a bundle, and replay its lockfile with only the Artifactory consumer credential. Compare source/target IDs, versions, bytes, SHA-256 values, provenance, and profile selections.
+
+The command does not delete or mutate source GitHub releases. Target cleanup and publisher-role hardening are separate administrative operations.

--- a/docs/reference/hub-replication.md
+++ b/docs/reference/hub-replication.md
@@ -72,6 +72,8 @@ Transient Artifactory failures may be retried with a bounded budget. Authenticat
 
 Source GitHub credentials are supplied through the CLI token provider and are never copied into the target. Artifactory publication uses the environment variable named by `--publisher-credential-ref`. The generated consumer hub config contains only `--target-credential-ref`, never its token value.
 
+For the CLI, each credential reference is an environment-variable name and must be present before the CLI process starts. For VS Code, the same-looking reference is only a SecretStorage label; the extension prompts for the token and stores it in VS Code SecretStorage, so the environment variable does not need to be set before launching VS Code. Artifactory supplies the opaque access-token value through its Administration UI or release-specific Access token API. Pass the complete value without a `Bearer ` prefix; the clients send it as `Authorization: Bearer <token>`. There is no portable token regex or fixed prefix to validate against.
+
 For example:
 
 ```bash

--- a/docs/reference/hub-replication.md
+++ b/docs/reference/hub-replication.md
@@ -34,7 +34,7 @@ Important options:
 |---|---|---|
 | `--source-hub` | required | GitHub `owner/repository` containing `hub-config.yml` |
 | `--source-ref` | `main` | GitHub branch/tag/commit |
-| `--target-root` | required | Credential-free Artifactory hub-tree root |
+| `--target-root` | required | Credential-free Artifactory hub-tree root; loopback HTTP is allowed for local testing with a warning |
 | `--mode` | `latest` | Select profile-resolved latest versions or every available version |
 | `--cache-dir` | local cache | Persistent release/manifest/archive cache |
 | `--workers` | `4` | Bounded source-processing concurrency |

--- a/docs/user-guide/sources.md
+++ b/docs/user-guide/sources.md
@@ -21,11 +21,31 @@ If you select a hub during first-run setup, all sources defined in that hub are 
 | `local-apm` | Local APM packages | Active |
 | `skills` | GitHub repository with skills | Active |
 | `local-skills` | Local filesystem skills directory | Active |
+| `artifactory` | Static bundle index and ZIP archives in a generic JFrog Artifactory repository | Active |
+
+### Artifactory sources
+
+An Artifactory source uses a credential-free HTTPS repository root and a static `index-v1.json` file by default. The index references each bundle's manifest and ZIP archive with a relative path, size, and lowercase SHA-256 digest. Custom index paths can be configured with `indexFile`.
+
+Do not put credentials in the source URL, hub configuration, index, or lockfile. For private sources, configure Bearer authentication with a source-scoped credential reference. The CLI resolves that reference as an environment-variable name; the VS Code extension stores the token in SecretStorage. Authentication failures are reported and do not fall back to GitHub.
 
 ## Adding a Source
 
 Open the Command Palette (`Ctrl+Shift+P` on Windows/Linux or `Cmd+Shift+P` on
-macOS) and run **AI Primitives Hub: Add Source**.
+macOS) and run **AI Primitives Hub: Add Source**. Choose **Artifactory** to enter the source root, index file, and optional Bearer token; the token is stored in VS Code SecretStorage.
+
+CLI users can add the same source without storing a token in configuration:
+
+```bash
+export ARTIFACTORY_TOKEN='your-token'
+ai-primitives-hub source add \
+  --type artifactory \
+  --url https://artifactory.example.com/artifactory/prompt-registry \
+  --auth bearer \
+  --credential-ref ARTIFACTORY_TOKEN
+```
+
+Use `--index-file <relative-path>` for an index other than `index-v1.json`. The credential reference is only a name; the token value is read from the environment when the CLI accesses the source.
 
 ## Managing Sources
 

--- a/docs/user-guide/sources.md
+++ b/docs/user-guide/sources.md
@@ -25,7 +25,7 @@ If you select a hub during first-run setup, all sources defined in that hub are 
 
 ### Artifactory sources
 
-An Artifactory source uses a credential-free HTTPS repository root and a static `index-v1.json` file by default. The index references each bundle's manifest and ZIP archive with a relative path, size, and lowercase SHA-256 digest. Custom index paths can be configured with `indexFile`.
+An Artifactory source uses a credential-free HTTPS repository root and a static `index-v1.json` file by default. For local development only, `http://localhost`, `http://127.0.0.1`, and `http://[::1]` are accepted with a warning; non-loopback HTTP remains rejected. The index references each bundle's manifest and ZIP archive with a relative path, size, and lowercase SHA-256 digest. Custom index paths can be configured with `indexFile`.
 
 Do not put credentials in the source URL, hub configuration, index, or lockfile. For private sources, configure Bearer authentication with a source-scoped credential reference. The CLI resolves that reference as an environment-variable name; the VS Code extension stores the token in SecretStorage. Authentication failures are reported and do not fall back to GitHub.
 

--- a/docs/user-guide/sources.md
+++ b/docs/user-guide/sources.md
@@ -27,12 +27,14 @@ If you select a hub during first-run setup, all sources defined in that hub are 
 
 An Artifactory source uses a credential-free HTTPS repository root and a static `index-v1.json` file by default. For local development only, `http://localhost`, `http://127.0.0.1`, and `http://[::1]` are accepted with a warning; non-loopback HTTP remains rejected. The index references each bundle's manifest and ZIP archive with a relative path, size, and lowercase SHA-256 digest. Custom index paths can be configured with `indexFile`.
 
-Do not put credentials in the source URL, hub configuration, index, or lockfile. For private sources, configure Bearer authentication with a source-scoped credential reference. The CLI resolves that reference as an environment-variable name; the VS Code extension stores the token in SecretStorage. Authentication failures are reported and do not fall back to GitHub.
+Do not put credentials in the source URL, hub configuration, index, or lockfile. For private sources, configure Bearer authentication with a source-scoped credential reference. The CLI resolves that reference as an environment-variable name; the VS Code extension treats it only as a label/key and stores the token in SecretStorage. Authentication failures are reported and do not fall back to GitHub.
+
+Artifactory tokens are created in the Artifactory Administration UI (user profile/User Management) or through the Access token API supported by your Artifactory release. Use an access token with repository read permission for consumption. The token is an opaque, release-dependent string: copy the complete value returned by Artifactory, without adding `Bearer `; AI Primitives Hub adds that prefix to the HTTP `Authorization` header. The credential reference is not the token. In VS Code it does not need to exist as an environment variable, and you do not need to restart VS Code after entering the token.
 
 ## Adding a Source
 
 Open the Command Palette (`Ctrl+Shift+P` on Windows/Linux or `Cmd+Shift+P` on
-macOS) and run **AI Primitives Hub: Add Source**. Choose **Artifactory** to enter the source root, index file, and optional Bearer token; the token is stored in VS Code SecretStorage.
+macOS) and run **AI Primitives Hub: Add Source**. Choose **Artifactory** to enter the source root, index file, and token. When prompted, enter a label such as `ARTIFACTORY_READER_TOKEN` first, then paste the Artifactory token value in the password field. The label is only a SecretStorage key; it is not an environment variable and is not the token. The token is stored in VS Code SecretStorage.
 
 CLI users can add the same source without storing a token in configuration:
 

--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -23,6 +23,7 @@ export * from './update';
 export * from './registry';
 export * from './search';
 export * from './transform';
+export * from './replicate/replicate';
 
 /**
  * Phase 1 scaffolding marker, kept until `cli` has real code of its own

--- a/packages/app/src/install/pipeline.ts
+++ b/packages/app/src/install/pipeline.ts
@@ -61,6 +61,7 @@ export interface InstallPipelineOptions {
   extractor: BundleExtractor;
   /** Factory that returns the appropriate writer for a given target. */
   writerFactory: (target: Target) => TargetWriter;
+  skipManifestIdValidation?: boolean;
   onEvent?: (event: PipelineEvent) => void;
 }
 
@@ -163,7 +164,7 @@ export class InstallPipeline {
     let manifest;
     try {
       manifest = validateManifest(files, {
-        expectedId: spec.bundleId,
+        expectedId: this.opts.skipManifestIdValidation ? undefined : spec.bundleId,
         expectedVersion: spec.bundleVersion
       });
     } catch (validateError) {

--- a/packages/app/src/registry/create-source-adapter.ts
+++ b/packages/app/src/registry/create-source-adapter.ts
@@ -28,13 +28,17 @@ import type {
   GitHubRepositoryTarget,
   GitHubSourceAuthCategory,
   HttpClient,
+  HttpCredentialProvider,
   ProcessRunner,
   RegistrySource,
   SourceAdapter,
   TokenProvider,
 } from '@ai-primitives-hub/core';
 import {
+  AnonymousCredentialProvider,
   ApmAdapter,
+  ArtifactoryHttpClient,
+  ArtifactorySourceAdapter,
   AwesomeCopilotAdapter,
   AzureDevOpsAdapter,
   AzureDevOpsApiClient,
@@ -62,6 +66,8 @@ export interface SourceAdapterFactoryDeps {
    * the CLI itself.
    */
   fallbackTokenProviders: readonly TokenProvider[];
+  /** Builds a source-scoped Artifactory credential provider; GitHub providers are never used for Artifactory. */
+  artifactoryCredentialFactory?: (source: RegistrySource) => HttpCredentialProvider;
   /** Optional preflight authentication decisions, keyed by source id. */
   sourceAuthentication?: ReadonlyMap<string, SourceAuthenticationContext>;
 }
@@ -160,6 +166,10 @@ export function createSourceAdapter(source: RegistrySource, deps: SourceAdapterF
         buildAzureDevOpsApi(buildSourceTokenProvider(source, deps), deps),
         deps.clock
       );
+    }
+    case 'artifactory': {
+      const credentials = deps.artifactoryCredentialFactory?.(source) ?? new AnonymousCredentialProvider();
+      return new ArtifactorySourceAdapter(source, new ArtifactoryHttpClient(deps.httpClient, credentials, source.url));
     }
     default: {
       throw new Error(`No adapter for source type: ${String(source.type)}`);

--- a/packages/app/src/registry/hub-manager.ts
+++ b/packages/app/src/registry/hub-manager.ts
@@ -130,6 +130,27 @@ export class HubManager {
         // Local path validation is done during fetch.
         break;
       }
+      case 'artifactory': {
+        try {
+          const url = new URL(reference.location);
+          if (url.protocol !== 'https:') {
+            errors.push('Only HTTPS URLs are allowed for Artifactory hubs');
+          }
+        } catch {
+          errors.push('Invalid Artifactory URL format');
+        }
+        const configFile = reference.configFile ?? 'hub-config.yml';
+        if (!configFile || configFile.startsWith('/') || configFile.includes('\\') || configFile.includes('..')) {
+          errors.push('Artifactory configFile must be a confined relative path');
+        }
+        if (reference.authMode !== undefined && reference.authMode !== 'anonymous' && reference.authMode !== 'bearer') {
+          errors.push('Invalid Artifactory authentication mode');
+        }
+        if (reference.authMode === 'bearer' && !reference.credentialRef) {
+          errors.push('Artifactory Bearer authentication requires credentialRef');
+        }
+        break;
+      }
       default: {
         errors.push(`Unsupported reference type: ${String(reference.type)}`);
       }

--- a/packages/app/src/registry/hub-manager.ts
+++ b/packages/app/src/registry/hub-manager.ts
@@ -29,6 +29,7 @@ import type {
 } from '@ai-primitives-hub/core';
 import {
   DEFAULT_LOCAL_HUB_ID,
+  isLoopbackHostname,
   sanitizeHubId,
 } from '@ai-primitives-hub/core';
 import type {
@@ -103,6 +104,7 @@ export class HubManager {
 
   private async validateReference(reference: HubReference): Promise<ValidationResult> {
     const errors: string[] = [];
+    const warnings: string[] = [];
 
     if (!reference.type) {
       errors.push('Reference type is required');
@@ -133,8 +135,12 @@ export class HubManager {
       case 'artifactory': {
         try {
           const url = new URL(reference.location);
-          if (url.protocol !== 'https:') {
+          const loopbackHttp = url.protocol === 'http:' && isLoopbackHostname(url.hostname);
+          if (url.protocol !== 'https:' && !loopbackHttp) {
             errors.push('Only HTTPS URLs are allowed for Artifactory hubs');
+          }
+          if (loopbackHttp) {
+            warnings.push('Loopback HTTP is for local development/testing only; use HTTPS for shared or production Artifactory hubs.');
           }
         } catch {
           errors.push('Invalid Artifactory URL format');
@@ -156,7 +162,7 @@ export class HubManager {
       }
     }
 
-    return Promise.resolve({ valid: errors.length === 0, errors, warnings: [] });
+    return Promise.resolve({ valid: errors.length === 0, errors, warnings });
   }
 
   /**

--- a/packages/app/src/registry/load-hub-sources.ts
+++ b/packages/app/src/registry/load-hub-sources.ts
@@ -102,6 +102,14 @@ export function findDuplicateSource(
       return false;
     }
 
+    if (source.type === 'artifactory') {
+      const existingIndexFile = existingConfig.indexFile ?? 'index-v1.json';
+      const sourceIndexFile = sourceConfig.indexFile ?? 'index-v1.json';
+      if (existingIndexFile !== sourceIndexFile) {
+        return false;
+      }
+    }
+
     return true;
   });
 }
@@ -190,7 +198,8 @@ export async function loadHubSources(
     // bundles installed from it.
     const sourceId = generateSourceId(hubSource.type, hubSource.url, {
       branch: hubSource.config?.branch,
-      collectionsPath: hubSource.config?.collectionsPath
+      collectionsPath: hubSource.config?.collectionsPath,
+      indexFile: hubSource.config?.indexFile
     });
     protectedSourceIds.add(sourceId);
 

--- a/packages/app/src/replicate/replicate.ts
+++ b/packages/app/src/replicate/replicate.ts
@@ -1,0 +1,94 @@
+/* eslint-disable @stylistic/max-len, @stylistic/max-statements-per-line, @typescript-eslint/no-base-to-string, jsdoc/require-description -- orchestration adapter */
+import {
+  createHash,
+} from 'node:crypto';
+import type {
+  HubConfig,
+  ReplicationCandidate,
+  ReplicationPublisherPort,
+  ReplicationResult,
+  ReplicationSourcePort,
+} from '@ai-primitives-hub/core';
+import {
+  makeReplicatedEntry,
+  requestsFromHubConfig,
+  selectReplications,
+} from '@ai-primitives-hub/core';
+
+export interface ReplicateOptions {
+  sourceHub: string;
+  sourceRef: string;
+  targetRoot: string;
+  mode: 'latest' | 'all';
+  publish?: boolean;
+  allowUnverifiedExisting?: boolean;
+  workers?: number;
+  targetAuth?: 'anonymous' | 'bearer';
+  targetCredentialRef?: string;
+}
+const sha256 = (data: Uint8Array): string => createHash('sha256').update(data).digest('hex');
+const sourceUrl = (source: Record<string, unknown>): string => String(source.url ?? '');
+const repoFromUrl = (url: string): { owner: string; repo: string } => {
+  const value = url.replace(/^https?:\/\/github\.com\//, '').replace(/\.git$/, '').replace(/^\/+|\/+$/g, ''); const [owner, repo] = value.split('/'); if (!owner || !repo || value.includes('?') || value.includes('#')) {
+    throw new Error(`Invalid GitHub source URL: ${url}`);
+  } return { owner, repo };
+};
+
+/**
+ *
+ * @param options
+ * @param source
+ * @param publisher
+ */
+export async function replicateHub(options: ReplicateOptions, source: ReplicationSourcePort, publisher?: ReplicationPublisherPort): Promise<ReplicationResult> {
+  const raw = await source.getHubConfig(options.sourceHub, options.sourceRef);
+  const enabled = (Array.isArray(raw.sources) ? raw.sources : []).filter((item): item is Record<string, unknown> => !!item && typeof item === 'object' && item.enabled !== false && item.type === 'github' && typeof item.id === 'string');
+  const groups: ReplicationCandidate[][] = []; const workers = Math.max(1, Math.floor(options.workers ?? 4));
+  for (let offset = 0; offset < enabled.length; offset += workers) {
+    const batch = enabled.slice(offset, offset + workers); groups.push(...await Promise.all(batch.map(async (item) => {
+      const repo = repoFromUrl(sourceUrl(item)); return source.listReleaseCandidates(repo.owner, repo.repo, String(item.id));
+    })));
+  }
+  const candidates = groups.flat(); const selection = selectReplications(candidates, requestsFromHubConfig(raw), options.mode); const warnings = selection.unresolved.map((item) => `Unresolved profile bundle: ${item}`);
+  const entries = []; const verified = new Set<string>();
+  for (const candidate of selection.selected) {
+    const manifestPath = `bundles/${candidate.bundleId}/${candidate.version}/deployment-manifest.yml`; const archivePath = `bundles/${candidate.bundleId}/${candidate.version}/${candidate.bundleId}-${candidate.version}.zip`;
+    if (options.publish) {
+      if (!publisher) {
+        throw new Error('Publisher is required when --publish is enabled');
+      }
+      const archive = await source.downloadArchive(candidate); if (archive.byteLength === 0) {
+        throw new Error(`Empty release archive for ${candidate.bundleId}@${candidate.version}`);
+      }
+      await publisher.publish(manifestPath, candidate.manifestBytes, 'application/yaml'); await publisher.publish(archivePath, archive, 'application/zip');
+      entries.push(makeReplicatedEntry(candidate, manifestPath, archivePath, archive, sha256)); verified.add(`${candidate.sourceId}\0${candidate.bundleId}\0${candidate.version}`);
+    } else {
+      const placeholder = new Uint8Array(candidate.archiveSize); entries.push(makeReplicatedEntry(candidate, manifestPath, archivePath, placeholder, () => '0'.repeat(64)));
+    }
+  }
+  const updatedAt = new Date().toISOString(); const index = { formatVersion: 1 as const, source: { id: 'replicated', name: 'Replicated GitHub hub', description: 'Bundles replicated from GitHub releases', updatedAt }, bundles: entries };
+  if (options.publish && publisher) {
+    await publisher.publish('index-v1.json', new TextEncoder().encode(JSON.stringify(index, null, 2) + '\n'), 'application/json');
+    const profiles = (Array.isArray(raw.profiles) ? raw.profiles : []).filter((profile): profile is Record<string, unknown> => !!profile && typeof profile === 'object').map((profile) => ({ ...profile, bundles: (Array.isArray(profile.bundles) ? profile.bundles : []).filter((bundle): bundle is Record<string, unknown> => {
+      const b = bundle as Record<string, unknown>; return verified.has(`${String(b.source)}\0${String(b.id)}\0${String(b.version)}`) || (String(b.version) === 'latest' && [...verified].some((key) => key.startsWith(`${String(b.source)}\0${String(b.id)}\0`)));
+    }).map((bundle) => ({ ...bundle, source: 'replicated' })) }));
+    const targetAuth = options.targetAuth ?? 'bearer';
+    const config: HubConfig = {
+      version: typeof raw.version === 'string' ? raw.version : '1',
+      metadata: { name: 'Replicated GitHub hub', description: 'Bundles replicated from GitHub releases', maintainer: 'ai-primitives-hub', updatedAt },
+      sources: [{
+        id: 'replicated', name: 'Replicated GitHub hub', type: 'artifactory',
+        url: `${options.targetRoot.replace(/\/$/, '')}/sources/replicated`, enabled: true, priority: 0,
+        private: targetAuth === 'bearer',
+        config: {
+          indexFile: 'index-v1.json', authMode: targetAuth,
+          ...(targetAuth === 'bearer' && options.targetCredentialRef ? { credentialRef: options.targetCredentialRef } : {})
+        }
+      }],
+      profiles: profiles as HubConfig['profiles']
+    };
+    await publisher.publish('hub-config.yml', new TextEncoder().encode(JSON.stringify(config, null, 2) + '\n'), 'application/yaml');
+    return { index, hubConfig: config, warnings, selected: selection.selected };
+  }
+  return { index, hubConfig: { version: '1', metadata: { name: 'Replicated GitHub hub', description: '', maintainer: '', updatedAt }, sources: [], profiles: [] }, warnings, selected: selection.selected };
+}

--- a/packages/app/src/stores/json-lockfile-store.ts
+++ b/packages/app/src/stores/json-lockfile-store.ts
@@ -105,6 +105,12 @@ export interface LockfileSourceEntry {
   branch?: string;
   /** Optional collections subdirectory, for `awesome-copilot`-type sources. */
   collectionsPath?: string;
+  /** Optional Artifactory index file. */
+  indexFile?: string;
+  /** Optional Artifactory authentication mode. */
+  authMode?: 'anonymous' | 'bearer';
+  /** Optional external Artifactory credential reference; never a secret. */
+  credentialRef?: string;
 }
 
 /**

--- a/packages/app/test/install/pipeline.test.ts
+++ b/packages/app/test/install/pipeline.test.ts
@@ -73,6 +73,27 @@ describe('InstallPipeline', () => {
     expect(outcome.write.written).toContain('/out/deployment-manifest.yml');
   });
 
+  it('accepts a source-authoritative bundle ID when manifest ID validation is skipped', async () => {
+    const pipeline = new InstallPipeline({
+      resolver: okResolver,
+      downloader: okDownloader,
+      extractor: {
+        extract: async (): Promise<ExtractedFiles> => new Map([
+          ['deployment-manifest.yml', new TextEncoder().encode('id: workflow-nevio\nversion: 2.0.8\nname: Task Driven Workflow\n')]
+        ])
+      },
+      writerFactory: () => okWriter,
+      skipManifestIdValidation: true
+    });
+
+    const outcome = await pipeline.run({
+      bundleId: 'amadeus-airlines-solutions-workflow-instructions-workflow-nevio',
+      bundleVersion: '2.0.8'
+    }, TARGET);
+
+    expect(outcome.manifest.id).toBe('workflow-nevio');
+  });
+
   it('emits events for every stage in order', async () => {
     const events: PipelineEvent['kind'][] = [];
     const pipeline = new InstallPipeline({

--- a/packages/app/test/registry/create-source-adapter.test.ts
+++ b/packages/app/test/registry/create-source-adapter.test.ts
@@ -3,6 +3,7 @@ import type {
   GitHubRepositoryTarget,
   GitHubSourceAuthCategory,
   HttpClient,
+  HttpCredentialProvider,
   HttpRequest,
   HttpResponse,
   ProcessResult,
@@ -14,6 +15,7 @@ import {
   describe,
   expect,
   it,
+  vi,
 } from 'vitest';
 import {
   createSourceAdapter,
@@ -122,7 +124,8 @@ describe('createSourceAdapter', () => {
     ['github', 'https://github.com/owner/repo'],
     ['skills', 'https://github.com/owner/repo'],
     ['awesome-copilot', 'https://github.com/owner/repo'],
-    ['apm', 'https://github.com/owner/repo']
+    ['apm', 'https://github.com/owner/repo'],
+    ['artifactory', 'https://artifactory.example/repository']
   ] as const)('builds a %s adapter with the matching .type', (type, url) => {
     const adapter = createSourceAdapter(makeSource({ type, url }), makeDeps());
     expect(adapter.type).toBe(type);
@@ -132,6 +135,24 @@ describe('createSourceAdapter', () => {
     expect(() => createSourceAdapter(makeSource({ type: 'nonexistent' as never }), makeDeps())).toThrow(
       'No adapter for source type: nonexistent'
     );
+  });
+
+  describe('Artifactory auth wiring', () => {
+    it('uses the provider-neutral credential factory and never the GitHub fallback chain', () => {
+      const credentials: HttpCredentialProvider = { headersFor: async () => ({}) };
+      const factory = vi.fn(() => credentials);
+      const fallback = new CountingTokenProvider();
+      const source = makeSource({ type: 'artifactory', url: 'https://artifactory.example/repository', config: { indexFile: 'catalog.json' } });
+
+      const adapter = createSourceAdapter(source, makeDeps({
+        artifactoryCredentialFactory: factory,
+        fallbackTokenProviders: [fallback]
+      }));
+
+      expect(adapter.type).toBe('artifactory');
+      expect(factory).toHaveBeenCalledWith(source);
+      expect(fallback.calls).toBe(0);
+    });
   });
 
   describe('GitHub-hosted auth wiring', () => {

--- a/packages/app/test/registry/load-hub-sources.test.ts
+++ b/packages/app/test/registry/load-hub-sources.test.ts
@@ -132,6 +132,19 @@ describe('findDuplicateSource', () => {
     const result = findDuplicateSource(makeHubSource({ config: undefined }), existing);
     expect(result).toBe(existing[0]);
   });
+
+  it('does not match Artifactory sources with different index files', () => {
+    const existing = [makeRegistrySource({
+      type: 'artifactory',
+      url: 'https://artifactory.example/repository',
+      config: { indexFile: 'index-v1.json' }
+    })];
+    expect(findDuplicateSource(makeHubSource({
+      type: 'artifactory',
+      url: 'https://artifactory.example/repository',
+      config: { indexFile: 'catalog.json' }
+    }), existing)).toBeUndefined();
+  });
 });
 
 describe('loadHubSources', () => {
@@ -139,6 +152,20 @@ describe('loadHubSources', () => {
 
   beforeEach(() => {
     ports = makePorts();
+  });
+
+  it('includes an Artifactory indexFile in the generated source identity', async () => {
+    const source = makeHubSource({
+      type: 'artifactory',
+      url: 'https://artifactory.example/repository',
+      config: { indexFile: 'catalog.json' }
+    });
+
+    await loadHubSources('hub-a', [source], ports);
+
+    expect(ports.addSource).toHaveBeenCalledWith(expect.objectContaining({
+      id: generateSourceId('artifactory', source.url, { indexFile: 'catalog.json' })
+    }));
   });
 
   it('adds enabled sources as new RegistrySource entries', async () => {

--- a/packages/app/test/replicate.test.ts
+++ b/packages/app/test/replicate.test.ts
@@ -1,0 +1,21 @@
+/* eslint-disable @stylistic/max-len, @stylistic/max-statements-per-line, @typescript-eslint/unbound-method -- focused use-case fixture */
+import type {
+  ReplicationCandidate,
+  ReplicationSourcePort,
+} from '@ai-primitives-hub/core';
+import {
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import {
+  replicateHub,
+} from '../src';
+
+const c: ReplicationCandidate = { sourceId: 's', repo: 'owner/repo', tag: 'v1.0.0', publishedAt: '', releaseName: 'One', manifest: { id: 'bundle', version: '1.0.0' }, manifestBytes: new Uint8Array([1]), manifestName: 'deployment-manifest.yml', archiveUrl: 'https://example.invalid/a.zip', archiveSize: 10, version: '1.0.0', bundleId: 'owner-repo-bundle' };
+describe('replicateHub', () => {
+  it('does not download archives during dry-run and reports unresolved profiles', async () => {
+    const source: ReplicationSourcePort = { getHubConfig: vi.fn(async () => ({ sources: [{ id: 's', type: 'github', url: 'https://github.com/owner/repo' }], profiles: [{ id: 'p', bundles: [{ source: 's', id: 'missing', version: 'latest' }] }] })), listReleaseCandidates: vi.fn(async () => [c]), downloadArchive: vi.fn() }; const result = await replicateHub({ sourceHub: 'owner/hub', sourceRef: 'main', targetRoot: 'https://artifactory.invalid/root', mode: 'latest' }, source); expect(source.downloadArchive).not.toHaveBeenCalled(); expect(result.warnings).toContain('Unresolved profile bundle: s:missing');
+  });
+});

--- a/packages/cli/src/commands/hub-replicate.ts
+++ b/packages/cli/src/commands/hub-replicate.ts
@@ -1,0 +1,110 @@
+/* eslint-disable @stylistic/max-len, @stylistic/max-statements-per-line -- thin CLI option wiring */
+import {
+  replicateHub,
+} from '@ai-primitives-hub/app';
+import type {
+  HttpClient,
+  TokenProvider,
+} from '@ai-primitives-hub/core';
+import {
+  ArtifactoryEnvCredentialProvider,
+  ArtifactoryReplicationPublisher,
+  defaultTokenProvider,
+  FileReplicationCache,
+  GitHubApiClient,
+  GitHubReleaseSource,
+  NodeHttpClient,
+} from '@ai-primitives-hub/infra';
+import {
+  Command,
+  Option,
+} from 'clipanion';
+import {
+  formatOutput,
+  RegistryError,
+  renderError,
+} from '../framework';
+import type {
+  Context,
+} from '../framework';
+
+export class HubReplicateCommand extends Command {
+  public static readonly paths = [['hub', 'replicate']];
+  public static readonly usage = Command.Usage({ description: 'Replicate GitHub release bundles into an Artifactory hub source.', category: 'Hub & Discovery' });
+  public commandContext!: { ctx: Context; http?: HttpClient; tokens?: TokenProvider };
+  public sourceHub = Option.String('--source-hub', { required: true });
+  public sourceRef = Option.String('--source-ref', { required: false });
+  public targetRoot = Option.String('--target-root', { required: true });
+  public mode = Option.String('--mode', { required: false });
+  public publish = Option.Boolean('--publish', false);
+  public dryRun = Option.Boolean('--dry-run', false);
+  public cacheDir = Option.String('--cache-dir', { required: false });
+  public workers = Option.String('--workers', { required: false });
+  public requestBudget = Option.String('--request-budget', { required: false });
+  public targetCredentialRef = Option.String('--target-credential-ref', { required: false });
+  public publisherCredentialRef = Option.String('--publisher-credential-ref', { required: false });
+  public targetAuth = Option.String('--target-auth', { required: false });
+  public output = Option.String('-o,--output');
+  public review = Option.Boolean('--review', false);
+  public allowUnverifiedExisting = Option.Boolean('--allow-unverified-existing', false);
+  public async execute(): Promise<number> {
+    const { ctx } = this.commandContext;
+    const mode = (this.mode ?? 'latest') as 'latest' | 'all';
+    const sourceRef = this.sourceRef ?? 'main';
+    const targetAuth = (this.targetAuth ?? 'bearer') as 'anonymous' | 'bearer';
+    const cacheDir = this.cacheDir ?? '.cache/github-artifactory-replication';
+    const budget = Number(this.requestBudget ?? '600');
+    const workers = Number(this.workers ?? '4');
+    const consumerCredentialRef = this.targetCredentialRef ?? 'ARTIFACTORY_READER_TOKEN';
+    const publisherCredentialRef = this.publisherCredentialRef ?? 'ARTIFACTORY_PUBLISHER_TOKEN';
+    if (!['latest', 'all'].includes(mode) || !this.sourceHub.includes('/') || !['anonymous', 'bearer'].includes(targetAuth) || !Number.isInteger(budget) || budget < 1 || !Number.isInteger(workers) || workers < 1) {
+      renderError(new RegistryError({ code: 'USAGE.INVALID_FLAG', message: 'Invalid replication options.' }), ctx); return 1;
+    }
+    if (this.dryRun && this.publish) {
+      renderError(new RegistryError({ code: 'USAGE.INVALID_FLAG', message: '--dry-run and --publish cannot be combined.' }), ctx); return 1;
+    }
+    if (this.publish && targetAuth === 'anonymous') {
+      renderError(new RegistryError({ code: 'USAGE.INVALID_FLAG', message: '--publish requires bearer target authentication.' }), ctx); return 1;
+    }
+    if (this.publish && !this.review) {
+      renderError(new RegistryError({ code: 'USAGE.CONFIRMATION_REQUIRED', message: 'Publication requires explicit --review acknowledgement.' }), ctx); return 1;
+    }
+    const http = this.commandContext.http ?? new NodeHttpClient();
+    const tokens: TokenProvider = this.commandContext.tokens ?? defaultTokenProvider(ctx.env);
+    const api = new GitHubApiClient(http, { tokenProvider: tokens });
+    const source = new GitHubReleaseSource(api, new FileReplicationCache(cacheDir), budget);
+    const target = `${this.targetRoot.replace(/\/$/, '')}/sources/replicated`;
+    const publisher = this.publish
+      ? new ArtifactoryReplicationPublisher(
+        http,
+        new ArtifactoryEnvCredentialProvider(ctx.env, publisherCredentialRef, target),
+        target,
+        this.allowUnverifiedExisting
+      )
+      : undefined;
+    try {
+      const result = await replicateHub({
+        sourceHub: this.sourceHub,
+        sourceRef,
+        targetRoot: this.targetRoot,
+        mode,
+        publish: this.publish,
+        workers,
+        allowUnverifiedExisting: this.allowUnverifiedExisting,
+        targetAuth,
+        targetCredentialRef: consumerCredentialRef
+      }, source, publisher);
+      formatOutput({
+        ctx,
+        command: 'hub.replicate',
+        output: (this.output ?? 'json') as 'json' | 'text' | 'yaml' | 'ndjson',
+        status: result.warnings.length > 0 ? 'warning' : 'ok',
+        data: { mode, publish: this.publish, selectedBundles: result.selected.length, unresolvedProfiles: result.warnings, index: result.index, targetRoot: target },
+        warnings: result.warnings
+      });
+      return result.warnings.length > 0 ? 2 : 0;
+    } catch (error) {
+      renderError(new RegistryError({ code: 'REPLICATE.FAILED', message: error instanceof Error ? error.message : 'Replication failed.' }), ctx); return 1;
+    }
+  }
+}

--- a/packages/cli/src/commands/hub.ts
+++ b/packages/cli/src/commands/hub.ts
@@ -172,7 +172,7 @@ export class HubAddCommand extends BaseHubCommand {
         --ref <branch>           Git branch, tag, or commit (GitHub only)
         --config-file <path>     Artifactory config path (default: hub-config.yml)
         --auth <mode>            Artifactory auth: anonymous or bearer
-        --credential-ref <name>  Environment variable for Artifactory Bearer auth
+        --credential-ref <name>  Environment variable name for Artifactory Bearer auth (CLI only)
         --id <id>                Custom hub ID (defaults to repo name)
         --no-sync                Skip syncing after import
         --no-use                 Skip setting as active hub

--- a/packages/cli/src/commands/hub.ts
+++ b/packages/cli/src/commands/hub.ts
@@ -167,6 +167,8 @@ export class HubAddCommand extends BaseHubCommand {
       Options:
         --type <type>            Reference type: github (default), local, url, artifactory
         --location <ref>         GitHub owner/repo, local path, URL, or Artifactory hub root
+                                  Example: http://127.0.0.1:8081/artifactory/<repository-key>/<hub-prefix>
+                                  Use the repository API root; omit /ui/native and hub-config.yml.
         --ref <branch>           Git branch, tag, or commit (GitHub only)
         --config-file <path>     Artifactory config path (default: hub-config.yml)
         --auth <mode>            Artifactory auth: anonymous or bearer

--- a/packages/cli/src/commands/hub.ts
+++ b/packages/cli/src/commands/hub.ts
@@ -165,9 +165,12 @@ export class HubAddCommand extends BaseHubCommand {
       Usage: ai-primitives-hub hub add --location <ref> [options]
 
       Options:
-        --type <type>            Reference type: github (default), local, url
-        --location <ref>         GitHub owner/repo, local path, or URL
+        --type <type>            Reference type: github (default), local, url, artifactory
+        --location <ref>         GitHub owner/repo, local path, URL, or Artifactory hub root
         --ref <branch>           Git branch, tag, or commit (GitHub only)
+        --config-file <path>     Artifactory config path (default: hub-config.yml)
+        --auth <mode>            Artifactory auth: anonymous or bearer
+        --credential-ref <name>  Environment variable for Artifactory Bearer auth
         --id <id>                Custom hub ID (defaults to repo name)
         --no-sync                Skip syncing after import
         --no-use                 Skip setting as active hub
@@ -182,6 +185,9 @@ export class HubAddCommand extends BaseHubCommand {
   public refType = Option.String('--type');
   public refLocation = Option.String('--location');
   public refRef = Option.String('--ref');
+  public configFile = Option.String('--config-file');
+  public authMode = Option.String('--auth');
+  public credentialRef = Option.String('--credential-ref');
   public hubId = Option.String('--id');
   public noSync = Option.Boolean('--no-sync');
   public noUse = Option.Boolean('--no-use');
@@ -200,7 +206,27 @@ export class HubAddCommand extends BaseHubCommand {
       return 1;
     }
 
-    const refType = (this.refType ?? 'github') as 'github' | 'local' | 'url';
+    const refType = (this.refType ?? 'github') as 'github' | 'local' | 'url' | 'artifactory';
+    if (!['github', 'local', 'url', 'artifactory'].includes(refType)) {
+      renderError(new RegistryError({ code: 'USAGE.INVALID_FLAG', message: `hub add: unsupported type '${refType}'` }), ctx);
+      return 1;
+    }
+    if (refType !== 'artifactory' && (this.configFile || this.authMode || this.credentialRef)) {
+      renderError(new RegistryError({ code: 'USAGE.INVALID_FLAG', message: 'Artifactory options require --type artifactory' }), ctx);
+      return 1;
+    }
+    if (this.authMode !== undefined && this.authMode !== 'anonymous' && this.authMode !== 'bearer') {
+      renderError(new RegistryError({ code: 'USAGE.INVALID_FLAG', message: '--auth must be anonymous or bearer' }), ctx);
+      return 1;
+    }
+    if (refType === 'artifactory' && this.authMode === 'bearer' && !this.credentialRef) {
+      renderError(new RegistryError({ code: 'USAGE.INVALID_FLAG', message: '--credential-ref is required with --auth bearer' }), ctx);
+      return 1;
+    }
+    if (this.credentialRef !== undefined && !/^[A-Z_][A-Z0-9_]*$/.test(this.credentialRef)) {
+      renderError(new RegistryError({ code: 'USAGE.INVALID_FLAG', message: '--credential-ref must be an environment variable name' }), ctx);
+      return 1;
+    }
     let location = this.refLocation;
     if (refType === 'local' && !path.isAbsolute(location)) {
       location = path.resolve(ctx.cwd(), location);
@@ -209,7 +235,12 @@ export class HubAddCommand extends BaseHubCommand {
     const id = await mgr.importHub({
       type: refType,
       location,
-      ref: this.refRef
+      ref: this.refRef,
+      configFile: refType === 'artifactory' ? (this.configFile ?? 'hub-config.yml') : undefined,
+      authMode: refType === 'artifactory'
+        ? ((this.authMode ?? 'anonymous'))
+        : undefined,
+      credentialRef: refType === 'artifactory' ? this.credentialRef : undefined
     }, this.hubId);
 
     // F-05: auto-use and auto-sync after import (unless flags disable)

--- a/packages/cli/src/commands/index-harvest.ts
+++ b/packages/cli/src/commands/index-harvest.ts
@@ -82,18 +82,19 @@ async function autoDetectHubFromActive(
 /**
  * Apply a loaded hub reference to the command's hub source fields.
  * @param cmd Command instance (mutated).
- * @param cmd.hubRepo Output GitHub owner/repo.
- * @param cmd.hubBranch Output Git ref.
- * @param cmd.hubConfigFile Output local/URL config file path.
+ * @param cmd.hubRepo
+ * @param cmd.hubBranch
+ * @param cmd.hubConfigFile
  * @param hubRef Loaded hub reference.
- * @param hubRef.type Hub source type.
- * @param hubRef.location Hub location or owner/repo.
- * @param hubRef.ref Optional Git ref.
+ * @param hubRef.type
+ * @param hubRef.location
+ * @param hubRef.ref
+ * @param hubRef.configFile
  * @param hubConfigFile Absolute path to the locally cached hub config YAML.
  */
 function applyHubRef(
   cmd: { hubRepo?: string; hubBranch?: string; hubConfigFile?: string },
-  hubRef: { type: 'github' | 'local' | 'url'; location: string; ref?: string },
+  hubRef: { type: 'github' | 'local' | 'url' | 'artifactory'; location: string; ref?: string; configFile?: string },
   hubConfigFile: string
 ): void {
   if (hubRef.type === 'github') {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -59,7 +59,7 @@ import {
 } from '../framework';
 
 type TargetScope = 'user' | 'repository';
-type HubType = 'github' | 'local' | 'url';
+type HubType = 'github' | 'local' | 'url' | 'artifactory';
 
 const DEFAULT_TARGET_NAME = 'copilot';
 const DEFAULT_TARGET_TYPE: TargetType = 'copilot-cli';

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -50,6 +50,10 @@ import {
 } from '@ai-primitives-hub/core';
 import {
   ActiveHubStore,
+  AnonymousCredentialProvider,
+  ArtifactoryBundleDownloader,
+  ArtifactoryEnvCredentialProvider,
+  ArtifactoryHttpClient,
   AwesomeCopilotBundleResolver,
   createGitHubSourceAuthRuntime,
   defaultTokenProvider,
@@ -1049,11 +1053,15 @@ async function performRemoteInstall(
     }
     const http = opts.http ?? new NodeHttpClient();
     const tokens = opts.tokens ?? defaultTokenProvider(ctx.env);
+    const isArtifactory = opts.sourceConfig?.type === 'artifactory';
     let githubApi: GitHubApi;
     let downloadTokens: TokenProvider;
     let repositoryTarget: GitHubRepositoryTarget | undefined;
     let authenticationCategory: Exclude<GitHubSourceAuthCategory, 'unresolved'> | undefined;
-    if (isGitHubAppAuthEnabled(ctx.env)) {
+    if (isArtifactory) {
+      githubApi = githubApiFor(http, tokens);
+      downloadTokens = tokens;
+    } else if (isGitHubAppAuthEnabled(ctx.env)) {
       const dependencies = opts.sourceAwareDependencyCache === undefined
         ? await sourceAwareInstallDependencies(repoSlug, opts.sourceConfig, http, ctx)
         : await opts.sourceAwareDependencyCache.get(repoSlug, opts.sourceConfig);
@@ -1066,18 +1074,31 @@ async function performRemoteInstall(
       downloadTokens = tokens;
     }
 
-    // Use SourceDispatcher to select the appropriate resolver based on source config
+    // Use SourceDispatcher to select the appropriate resolver based on source config.
     let resolver: BundleResolver;
-    if (opts.sourceConfig) {
+    let downloader: HttpsBundleDownloader | ArtifactoryBundleDownloader;
+    if (isArtifactory && opts.sourceConfig !== undefined) {
+      const config = opts.sourceConfig.config ?? {};
+      const credentialRef = typeof config.credentialRef === 'string' ? config.credentialRef : undefined;
+      const credentials = config.authMode === 'bearer' && credentialRef !== undefined
+        ? new ArtifactoryEnvCredentialProvider(ctx.env, credentialRef, opts.sourceConfig.url)
+        : new AnonymousCredentialProvider();
+      const artifactoryHttp = new ArtifactoryHttpClient(http, credentials, opts.sourceConfig.url);
+      const dispatcher = new SourceDispatcher({
+        githubApi, fs: ctx.fs, http,
+        artifactoryCredentialProvider: () => credentials
+      });
+      resolver = dispatcher.resolverFor(opts.sourceConfig) as BundleResolver;
+      downloader = new ArtifactoryBundleDownloader(artifactoryHttp);
+    } else if (opts.sourceConfig) {
       const dispatcher = new SourceDispatcher({ githubApi, fs: ctx.fs });
       const selectedResolver = dispatcher.resolverFor(opts.sourceConfig);
       resolver = selectedResolver ?? new GitHubBundleResolver({ repoSlug, githubApi });
+      downloader = new HttpsBundleDownloader(http, downloadTokens, repositoryTarget, authenticationCategory);
     } else {
-      // Default to GitHub resolver when no source config is provided
       resolver = new GitHubBundleResolver({ repoSlug, githubApi });
+      downloader = new HttpsBundleDownloader(http, downloadTokens, repositoryTarget, authenticationCategory);
     }
-
-    const downloader = new HttpsBundleDownloader(http, downloadTokens, repositoryTarget, authenticationCategory);
     const extractor = new ZipBundleExtractor();
 
     const installable = await resolver.resolve(spec);
@@ -1105,7 +1126,7 @@ async function performRemoteInstall(
           dryRun: true,
           target: effectiveTarget.name,
           bundle: { id: manifest.id, version: manifest.version },
-          source: { type: 'github', repo: repoSlug, downloadUrl: installable.downloadUrl },
+          source: { type: opts.sourceConfig?.type ?? 'github', repo: repoSlug, downloadUrl: installable.downloadUrl },
           sha256: dl.sha256,
           files: [...files.keys()]
         },
@@ -1135,11 +1156,19 @@ async function performRemoteInstall(
       entry.commitMode = commitMode;
     }
     let nextLock = upsertBundleEntry(existing, manifest.id, entry);
-    const collectionsPath = opts.sourceConfig?.config?.collectionsPath;
+    const sourceConfig = opts.sourceConfig;
+    const collectionsPath = sourceConfig?.config?.collectionsPath;
     nextLock = upsertSource(nextLock, installable.ref.sourceId, {
-      type: opts.sourceConfig?.type ?? 'github',
-      url: `https://github.com/${repoSlug}`,
-      ...(collectionsPath ? { collectionsPath } : {})
+      type: sourceConfig?.type ?? 'github',
+      url: sourceConfig?.url ?? `https://github.com/${repoSlug}`,
+      ...(collectionsPath ? { collectionsPath } : {}),
+      ...(sourceConfig?.type === 'artifactory'
+        ? {
+          indexFile: typeof sourceConfig.config?.indexFile === 'string' ? sourceConfig.config.indexFile : undefined,
+          authMode: sourceConfig.config?.authMode === 'bearer' ? 'bearer' : 'anonymous',
+          credentialRef: typeof sourceConfig.config?.credentialRef === 'string' ? sourceConfig.config.credentialRef : undefined
+        }
+        : {})
     });
     await writeLockfile(lockPath, nextLock, ctx.fs);
 
@@ -1151,7 +1180,7 @@ async function performRemoteInstall(
       data: {
         target: effectiveTarget.name,
         bundle: { id: manifest.id, version: manifest.version },
-        source: { type: 'github', repo: repoSlug, sourceId: installable.ref.sourceId },
+        source: { type: opts.sourceConfig?.type ?? 'github', repo: repoSlug, sourceId: installable.ref.sourceId },
         sha256: dl.sha256,
         written: result.written,
         skipped: result.skipped,
@@ -1531,6 +1560,36 @@ export async function fetchFilesForSource(
     }
     const files = await readLocalBundle(src.url, ctx.fs);
     return new Map(files);
+  }
+  if (src.type === 'artifactory') {
+    const sourceConfig: RegistrySource = {
+      id: entry.sourceId, name: entry.sourceId, type: 'artifactory', url: src.url,
+      enabled: true, priority: 0,
+      config: {
+        ...(src.indexFile ? { indexFile: src.indexFile } : {}),
+        ...(src.authMode ? { authMode: src.authMode } : {}),
+        ...(src.credentialRef ? { credentialRef: src.credentialRef } : {})
+      }
+    };
+    const credentialRef = src.credentialRef;
+    const credentials = src.authMode === 'bearer' && credentialRef !== undefined
+      ? new ArtifactoryEnvCredentialProvider(ctx.env, credentialRef, src.url)
+      : new AnonymousCredentialProvider();
+    const artifactoryHttp = new ArtifactoryHttpClient(http, credentials, src.url);
+    const dispatcher = new SourceDispatcher({ githubApi: githubApiFor(http, tokens), fs: ctx.fs, http, artifactoryCredentialProvider: () => credentials });
+    const resolver = dispatcher.resolverFor(sourceConfig);
+    if (resolver === null) {
+      return null;
+    }
+    const installable = await resolver.resolve({ bundleId, bundleVersion: entry.version });
+    if (installable === null) {
+      return null;
+    }
+    const dl = await new ArtifactoryBundleDownloader(artifactoryHttp).download(installable);
+    if (entry.checksum !== undefined && dl.sha256 !== entry.checksum) {
+      return null;
+    }
+    return new Map(await new ZipBundleExtractor().extract(dl.bytes));
   }
   if (src.type === 'github' || src.type === 'skills' || src.type === 'awesome-copilot') {
     // Check if this is an awesome-copilot source (detected by sourceId prefix)

--- a/packages/cli/src/commands/source.ts
+++ b/packages/cli/src/commands/source.ts
@@ -58,10 +58,14 @@ export class SourceAddCommand extends BaseSourceCommand {
     category: 'Hub & Discovery',
     details: `
       Usage: ai-primitives-hub source add --url <ref> [--type <type>] [--id <id>] [--name <name>]
+             [--index-file <path>] [--auth anonymous|bearer] [--credential-ref <env>]
 
       Options:
-        --type <type>   Source type: github (default) or local.
-        --url <ref>     GitHub owner/repo or local path.
+        --type <type>   Source type: github (default), local, or artifactory.
+        --url <ref>     GitHub owner/repo, Artifactory source root, or local path.
+        --index-file    Artifactory index path (relative to source root).
+        --auth          Artifactory auth mode: anonymous or bearer.
+        --credential-ref Artifactory credential environment variable name.
         --id <id>       Source ID (defaults to generated ID).
         --name <name>   Display name (defaults to ID).
         --enabled       Enable the source (default true).
@@ -77,6 +81,9 @@ export class SourceAddCommand extends BaseSourceCommand {
   public sourceId = Option.String('--id');
   public name = Option.String('--name');
   public enabled = Option.Boolean('--enabled');
+  public indexFile = Option.String('--index-file');
+  public auth = Option.String('--auth');
+  public credentialRef = Option.String('--credential-ref');
 
   public async execute() {
     const { ctx, http, tokens } = this.commandContext;
@@ -91,11 +98,37 @@ export class SourceAddCommand extends BaseSourceCommand {
       return 1;
     }
 
-    const type = (this.sourceType ?? 'github') as 'github' | 'local';
-    const id = this.sourceId ?? generateSourceId(type, this.url);
+    const requestedType = this.sourceType ?? 'github';
+    const allowedTypes = new Set(['github', 'local', 'artifactory']);
+    if (!allowedTypes.has(requestedType)) {
+      renderError(new RegistryError({ code: 'USAGE.INVALID_FLAG', message: `source add: unsupported --type "${requestedType}"` }), ctx);
+      return 1;
+    }
+    if (requestedType !== 'artifactory' && (this.indexFile || this.auth || this.credentialRef)) {
+      renderError(new RegistryError({ code: 'USAGE.INVALID_FLAG', message: 'Artifactory options require --type artifactory' }), ctx);
+      return 1;
+    }
+    if (this.auth !== undefined && this.auth !== 'anonymous' && this.auth !== 'bearer') {
+      renderError(new RegistryError({ code: 'USAGE.INVALID_FLAG', message: '--auth must be anonymous or bearer' }), ctx);
+      return 1;
+    }
+    if (requestedType === 'artifactory' && this.auth === 'bearer' && !this.credentialRef) {
+      renderError(new RegistryError({ code: 'USAGE.INVALID_FLAG', message: '--credential-ref is required with --auth bearer' }), ctx);
+      return 1;
+    }
+    const type = requestedType as 'github' | 'local' | 'artifactory';
+    const config = type === 'artifactory'
+      ? {
+        ...(this.indexFile ? { indexFile: this.indexFile } : {}),
+        ...(this.auth ? { authMode: this.auth } : {}),
+        ...(this.credentialRef ? { credentialRef: this.credentialRef } : {})
+      }
+      : undefined;
+    const id = this.sourceId ?? generateSourceId(type, this.url, config);
     const added = await mgr.addDetachedSource({
       id, name: this.name ?? id, type, url: this.url,
-      enabled: this.enabled ?? true, priority: 0
+      enabled: this.enabled ?? true, priority: 0,
+      ...(config && Object.keys(config).length > 0 ? { config } : {})
     });
     formatOutput({
       ctx, command: 'source.add', output: fmt, status: 'ok',

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -43,6 +43,10 @@ import {
 } from '@ai-primitives-hub/core';
 import {
   ActiveHubStore,
+  AnonymousCredentialProvider,
+  ArtifactoryBundleDownloader,
+  ArtifactoryEnvCredentialProvider,
+  ArtifactoryHttpClient,
   createGitHubSourceAuthRuntime,
   defaultTokenProvider,
   FileSystemLayoutConfigLoader,
@@ -116,6 +120,7 @@ interface UpdateCandidate {
   repositoryTarget?: GitHubRepositoryTarget;
   authenticationCategory?: Exclude<GitHubSourceAuthCategory, 'unresolved'>;
   downloadTokens?: TokenProvider;
+  artifactoryClient?: ArtifactoryHttpClient;
 }
 
 interface UpdateContext {
@@ -304,7 +309,7 @@ async function detectUpdateContext(opts: UpdateOptions, ctx: Context): Promise<v
 }
 
 function isRemoteSource(type: string): boolean {
-  return type === 'github' || type === 'awesome-copilot' || type === 'skills';
+  return type === 'github' || type === 'awesome-copilot' || type === 'skills' || type === 'artifactory';
 }
 
 /**
@@ -326,7 +331,8 @@ function toRegistrySource(sourceId: string, src: LockfileSourceEntry): RegistryS
     priority: 0,
     config: {
       branch: src.branch,
-      collectionsPath: src.collectionsPath
+      collectionsPath: src.collectionsPath,
+      ...(src.type === 'artifactory' ? { indexFile: src.indexFile, authMode: src.authMode, credentialRef: src.credentialRef } : {})
     }
   };
 }
@@ -402,7 +408,17 @@ async function findUpdateCandidates(
     try {
       let resolverDispatcher = dispatcher;
       let dependencies: SourceAwareUpdateDependencies | undefined;
-      if (sourceAware) {
+      let artifactoryClient: ArtifactoryHttpClient | undefined;
+      if (src.type === 'artifactory') {
+        const credentials = src.authMode === 'bearer' && src.credentialRef !== undefined
+          ? new ArtifactoryEnvCredentialProvider(ctx.env, src.credentialRef, src.url)
+          : new AnonymousCredentialProvider();
+        artifactoryClient = new ArtifactoryHttpClient(http, credentials, src.url);
+        resolverDispatcher = new SourceDispatcher({
+          githubApi, fs: ctx.fs, http,
+          artifactoryCredentialProvider: () => credentials
+        });
+      } else if (sourceAware && src.type !== 'artifactory') {
         dependencies = sourceDependencies.get(entry.sourceId);
         if (dependencies === undefined) {
           dependencies = await sourceAwareUpdateDependencies(entry.sourceId, src, ctx, http);
@@ -431,7 +447,8 @@ async function findUpdateCandidates(
           installable,
           repositoryTarget: dependencies?.repositoryTarget,
           authenticationCategory: dependencies?.authenticationCategory,
-          downloadTokens: dependencies?.downloadTokens
+          downloadTokens: dependencies?.downloadTokens,
+          artifactoryClient
         });
       }
     } catch (error) {
@@ -574,12 +591,14 @@ async function applyUpdate(
   http: HttpClient,
   tokens: TokenProvider
 ): Promise<void> {
-  const downloader = new HttpsBundleDownloader(
-    http,
-    candidate.downloadTokens ?? tokens,
-    candidate.repositoryTarget,
-    candidate.authenticationCategory
-  );
+  const downloader = candidate.source.type === 'artifactory' && candidate.artifactoryClient !== undefined
+    ? new ArtifactoryBundleDownloader(candidate.artifactoryClient)
+    : new HttpsBundleDownloader(
+      http,
+      candidate.downloadTokens ?? tokens,
+      candidate.repositoryTarget,
+      candidate.authenticationCategory
+    );
   const extractor = new ZipBundleExtractor();
 
   const dl = await downloader.download(candidate.installable);

--- a/packages/cli/src/framework/hub-manager.ts
+++ b/packages/cli/src/framework/hub-manager.ts
@@ -26,6 +26,9 @@ import type {
 } from '@ai-primitives-hub/core';
 import {
   ActiveHubStore,
+  AnonymousCredentialProvider,
+  ArtifactoryEnvCredentialProvider,
+  ArtifactoryHubResolver,
   CompositeHubResolver,
   createGitHubSourceAuthRuntime,
   EnvTokenProvider,
@@ -87,7 +90,16 @@ export const createHubManager = (opts: CreateHubManagerOptions): HubManager => {
         }
       }),
     new LocalHubResolver(ctx.fs),
-    new UrlHubResolver(httpClient, tokenProvider)
+    new UrlHubResolver(httpClient, tokenProvider),
+    new ArtifactoryHubResolver(httpClient, (reference, root) => {
+      if (reference.authMode !== 'bearer') {
+        return new AnonymousCredentialProvider();
+      }
+      if (!reference.credentialRef) {
+        throw new Error('Artifactory Bearer authentication requires credentialRef.');
+      }
+      return new ArtifactoryEnvCredentialProvider(ctx.env, reference.credentialRef, root);
+    })
   );
   return new HubManager({
     store: new HubStore(paths.hubs, ctx.fs),

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -64,6 +64,9 @@ import {
   HubValidateCommand,
 } from './commands/hub';
 import {
+  HubReplicateCommand,
+} from './commands/hub-replicate';
+import {
   IndexBenchCommand,
 } from './commands/index-bench';
 import {
@@ -195,6 +198,7 @@ async function main(): Promise<number> {
     HubSyncCommand,
     HubRefreshCommand,
     HubValidateCommand,
+    HubReplicateCommand,
     SourceAddCommand,
     SourceListCommand,
     SourceRemoveCommand,

--- a/packages/cli/test/commands/hub-replicate.test.ts
+++ b/packages/cli/test/commands/hub-replicate.test.ts
@@ -1,0 +1,117 @@
+import {
+  Buffer,
+} from 'node:buffer';
+import type {
+  HttpClient,
+  HttpRequest,
+  HttpResponse,
+  TokenProvider,
+} from '@ai-primitives-hub/core';
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  HubReplicateCommand,
+} from '../../src/commands/hub-replicate';
+import {
+  createTestContext,
+  runCli,
+} from '../../src/framework';
+
+const manifest = `id: bundle
+version: 1.0.0
+name: Replicated bundle
+description: Test bundle
+author: Test
+environments: [vscode]
+tags: [test]
+license: Apache-2.0
+`;
+const hub = `version: 1.0.0
+metadata:
+  name: Private source hub
+  description: Test hub
+  maintainer: Test
+  updatedAt: '2026-01-01T00:00:00Z'
+sources:
+  - id: source
+    name: Source
+    type: github
+    url: https://github.com/owner/repo
+    enabled: true
+    priority: 1
+profiles:
+  - id: default
+    name: Default
+    description: Default
+    bundles:
+      - id: owner-repo-bundle
+        version: latest
+        source: source
+        required: true
+`;
+
+class RecordingHttp implements HttpClient {
+  public readonly requests: HttpRequest[] = [];
+  public async fetch(request: HttpRequest): Promise<HttpResponse> {
+    this.requests.push(request);
+    let body: Uint8Array;
+    if (request.url.includes('/contents/hub-config.yml')) {
+      body = new TextEncoder().encode(JSON.stringify({ content: Buffer.from(hub).toString('base64') }));
+    } else if (request.url.includes('/releases')) {
+      body = new TextEncoder().encode(JSON.stringify([{
+        tag_name: 'bundle-v1.0.0',
+        name: 'Bundle 1.0.0',
+        published_at: '2026-01-01T00:00:00Z',
+        assets: [
+          { name: 'deployment-manifest.yml', url: 'https://api.github.com/assets/manifest', size: manifest.length },
+          { name: 'bundle.zip', url: 'https://api.github.com/assets/archive', size: 4 }
+        ]
+      }]));
+    } else if (request.url.endsWith('/assets/manifest')) {
+      body = new TextEncoder().encode(manifest);
+    } else {
+      body = new Uint8Array([80, 75, 3, 4]);
+    }
+    return { statusCode: 200, body, finalUrl: request.url, headers: {} };
+  }
+}
+
+const tokenProvider: TokenProvider = {
+  getToken: async (host) => host === 'api.github.com' ? 'github-private-token' : undefined
+};
+
+describe('hub replicate command', () => {
+  it('uses the supplied GitHub credential for a private source hub without leaking it', async () => {
+    const http = new RecordingHttp();
+    const ctx = createTestContext({ env: { HOME: '/tmp/aph-replicate-test' } });
+    const cacheDir = `/tmp/aph-replicate-test-cache-${process.pid}-${Date.now()}`;
+    const exitCode = await runCli([
+      'hub', 'replicate',
+      '--source-hub', 'owner/hub',
+      '--target-root', 'https://artifactory.example/replicated',
+      '--mode', 'latest',
+      '--cache-dir', cacheDir
+    ], {
+      ctx,
+      http,
+      tokens: tokenProvider,
+      commandClasses: [HubReplicateCommand],
+      commands: [],
+      name: 'ai-primitives-hub',
+      version: 'test'
+    });
+
+    expect(exitCode).toBe(0);
+    expect(http.requests.length).toBeGreaterThan(0);
+    expect(http.requests.map((request) => request.headers?.Authorization)).toEqual([
+      'token github-private-token',
+      'token github-private-token',
+      'token github-private-token'
+    ]);
+    expect(ctx.stdout.captured()).not.toContain('github-private-token');
+    expect(JSON.parse(ctx.stdout.captured()).data.selectedBundles).toBe(1);
+  });
+});

--- a/packages/cli/test/commands/hub.test.ts
+++ b/packages/cli/test/commands/hub.test.ts
@@ -135,6 +135,33 @@ profiles: []
     );
   });
 
+  it('imports a private Artifactory hub with a source-scoped Bearer credential', async () => {
+    const requests: HttpRequest[] = [];
+    const http: HttpClient = {
+      fetch: async (request) => {
+        requests.push(request);
+        return {
+          statusCode: 200,
+          body: new Uint8Array(await readFile(hubConfigFile)),
+          finalUrl: request.url,
+          headers: {}
+        };
+      }
+    };
+    const result = await runWithHttp([
+      'hub', 'add', '--type', 'artifactory', '--location', 'https://artifactory.example/repo/hub',
+      '--auth', 'bearer', '--credential-ref', 'PRIVATE_HUB', '--no-sync', '--no-use', '-o', 'json'
+    ], http, {
+      HOME: workspace,
+      PRIVATE_HUB: 'private-test-token'
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(requests).toHaveLength(1);
+    expect(requests[0].headers?.Authorization).toBe('Bearer private-test-token');
+    expect(result.stdout).not.toContain('private-test-token');
+  });
+
   afterEach(async () => {
     await rm(workspace, { recursive: true, force: true });
   });

--- a/packages/cli/test/commands/source.test.ts
+++ b/packages/cli/test/commands/source.test.ts
@@ -87,6 +87,33 @@ describe('source commands', () => {
       expect(listEnvelope.data.sources.map((s) => s.id)).toContain('local-skills');
     });
 
+    it('adds an Artifactory source with non-secret configuration', async () => {
+      const result = await run([
+        'source', 'add', '--type', 'artifactory', '--url', 'https://artifactory.example/repo',
+        '--index-file', 'index.json', '--auth', 'bearer', '--credential-ref', 'ARTIFACTORY_TOKEN', '-o', 'json'
+      ]);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseJson<{ source: { type: string; url: string; config: Record<string, unknown> } }>(result.stdout);
+      expect(envelope.data.source).toMatchObject({ type: 'artifactory', url: 'https://artifactory.example/repo' });
+      expect(envelope.data.source.config).toEqual({ indexFile: 'index.json', authMode: 'bearer', credentialRef: 'ARTIFACTORY_TOKEN' });
+      expect(JSON.stringify(envelope.data.source)).not.toContain('test-token');
+    });
+
+    it('includes a custom Artifactory index path in the generated source ID', async () => {
+      const defaultIndex = await run([
+        'source', 'add', '--type', 'artifactory', '--url', 'https://artifactory.example/repo', '-o', 'json'
+      ]);
+      const customIndex = await run([
+        'source', 'add', '--type', 'artifactory', '--url', 'https://artifactory.example/repo',
+        '--index-file', 'catalog.json', '-o', 'json'
+      ]);
+      expect(defaultIndex.exitCode).toBe(0);
+      expect(customIndex.exitCode).toBe(0);
+      const first = parseJson<{ source: { id: string } }>(defaultIndex.stdout);
+      const second = parseJson<{ source: { id: string } }>(customIndex.stdout);
+      expect(first.data.source.id).not.toBe(second.data.source.id);
+    });
+
     it('fails with a non-zero exit code when --url is missing', async () => {
       const result = await run(['source', 'add', '--type', 'local', '-o', 'json']);
       expect(result.exitCode).not.toBe(0);

--- a/packages/core/src/domain/hub/replicate.ts
+++ b/packages/core/src/domain/hub/replicate.ts
@@ -1,0 +1,95 @@
+/* eslint-disable @stylistic/max-len, @stylistic/max-statements-per-line, unicorn/no-array-sort, @typescript-eslint/no-base-to-string -- compact domain contract helpers */
+import * as semver from 'semver';
+import type {
+  ArtifactoryBundleIndexEntry,
+  ArtifactorySourceIndex,
+} from '../source/artifactory-source-index';
+import type {
+  HubConfig,
+} from './types';
+
+export interface ReplicationCandidate {
+  sourceId: string; repo: string; tag: string; publishedAt: string; releaseName: string;
+  manifest: Record<string, unknown>; manifestBytes: Uint8Array; manifestName: string;
+  archiveUrl: string; archiveSize: number; version: string; bundleId: string;
+}
+export interface ReplicationRequest { sourceId: string; bundleId: string; versions: Set<string> }
+export interface ReplicationSelection { selected: ReplicationCandidate[]; unresolved: string[] }
+export interface ReplicationResult { index: ArtifactorySourceIndex; hubConfig: HubConfig; warnings: string[]; selected: ReplicationCandidate[] }
+export interface ReplicationSourcePort {
+  getHubConfig(ownerRepo: string, ref: string): Promise<Record<string, unknown>>;
+  listReleaseCandidates(owner: string, repo: string, sourceId: string): Promise<ReplicationCandidate[]>;
+  downloadArchive(candidate: ReplicationCandidate): Promise<Uint8Array>;
+}
+export interface ReplicationPublisherPort {
+  publish(path: string, data: Uint8Array, mediaType: string): Promise<'uploaded' | 'skipped-existing' | 'skipped-unverified'>;
+}
+
+export const stableReplicatedBundleId = (repo: string, manifest: Record<string, unknown>): string => {
+  const [owner, name] = repo.split('/', 2);
+  const id = typeof manifest.id === 'string' && manifest.id.length > 0 ? `-${manifest.id}` : '';
+  return `${owner}-${name}${id}`;
+};
+export const normalizedReleaseVersion = (manifest: Record<string, unknown>, tag: string): string | undefined => {
+  const values = [manifest.version, tag.replace(/^v/, '')];
+  for (const value of values) {
+    if (typeof value === 'string' && semver.valid(value)) {
+      return semver.clean(value) ?? undefined;
+    }
+  }
+  return undefined;
+};
+export const selectReplications = (candidates: ReplicationCandidate[], requests: ReplicationRequest[], mode: 'latest' | 'all'): ReplicationSelection => {
+  if (mode === 'all') {
+    const available = new Set(candidates.map((candidate) => `${candidate.sourceId}\0${candidate.bundleId}`));
+    return { selected: deduplicate(candidates), unresolved: requests.filter((request) => !available.has(`${request.sourceId}\0${request.bundleId}`)).map((request) => `${request.sourceId}:${request.bundleId}`) };
+  }
+  const byKey = new Map<string, ReplicationCandidate[]>();
+  for (const candidate of candidates) {
+    byKey.set(`${candidate.sourceId}\0${candidate.bundleId}`, [...(byKey.get(`${candidate.sourceId}\0${candidate.bundleId}`) ?? []), candidate]);
+  }
+  const selected: ReplicationCandidate[] = []; const unresolved: string[] = [];
+  for (const request of requests) {
+    const options = byKey.get(`${request.sourceId}\0${request.bundleId}`) ?? [];
+    const explicit = [...request.versions].filter((version) => version !== 'latest');
+    const matches = explicit.length > 0 ? options.filter((candidate) => explicit.includes(candidate.version)) : options;
+    if (matches.length === 0) {
+      unresolved.push(`${request.sourceId}:${request.bundleId}`); continue;
+    }
+    if (explicit.length > 0) {
+      selected.push(...matches);
+    } else {
+      selected.push([...matches].sort((a, b) => semver.rcompare(a.version, b.version))[0]);
+    }
+  }
+  return { selected: deduplicate(selected), unresolved };
+};
+const deduplicate = (items: ReplicationCandidate[]): ReplicationCandidate[] => [...new Map(items.map((item) => [`${item.bundleId}\0${item.version}`, item])).values()].sort((a, b) => a.bundleId.localeCompare(b.bundleId) || semver.compare(a.version, b.version));
+
+export const requestsFromHubConfig = (hub: Record<string, unknown>): ReplicationRequest[] => {
+  const sources = new Set((Array.isArray(hub.sources) ? hub.sources : []).filter((s): s is Record<string, unknown> => !!s && typeof s === 'object' && s.enabled !== false && s.type === 'github' && typeof s.id === 'string').map((s) => s.id as string));
+  const requests = new Map<string, ReplicationRequest>();
+  for (const profile of Array.isArray(hub.profiles) ? hub.profiles : []) {
+    if (!profile || typeof profile !== 'object') {
+      continue;
+    }
+    const bundles = (profile as Record<string, unknown>).bundles;
+    for (const bundle of (Array.isArray(bundles) ? bundles : []) as unknown[]) {
+      if (!bundle || typeof bundle !== 'object') {
+        continue;
+      }
+      const item = bundle as Record<string, unknown>; const sourceId = String(item.source ?? ''); const bundleId = String(item.id ?? '');
+      if (!sources.has(sourceId) || !bundleId) {
+        continue;
+      }
+      const key = `${sourceId}\0${bundleId}`; const request = requests.get(key) ?? { sourceId, bundleId, versions: new Set<string>() };
+      request.versions.add(String(item.version ?? 'latest')); requests.set(key, request);
+    }
+  }
+  return [...requests.values()];
+};
+
+export const makeReplicatedEntry = (candidate: ReplicationCandidate, manifestPath: string, archivePath: string, archive: Uint8Array, sha256: (data: Uint8Array) => string): ArtifactoryBundleIndexEntry => {
+  const m = candidate.manifest; const text = (key: string, fallback: string) => typeof m[key] === 'string' ? m[key] : fallback;
+  return { id: candidate.bundleId, version: candidate.version, name: text('name', candidate.releaseName || candidate.bundleId), description: text('description', candidate.releaseName), author: text('author', 'GitHub release publisher'), environments: Array.isArray(m.environments) ? m.environments as string[] : ['vscode'], tags: Array.isArray(m.tags) ? m.tags as string[] : [], lastUpdated: candidate.publishedAt || '1970-01-01T00:00:00Z', dependencies: Array.isArray(m.dependencies) ? m.dependencies as never[] : [], license: text('license', 'UNLICENSED'), manifest: { path: manifestPath, size: candidate.manifestBytes.byteLength, sha256: sha256(candidate.manifestBytes), mediaType: 'application/yaml' }, archive: { path: archivePath, size: archive.byteLength, sha256: sha256(archive), mediaType: 'application/zip' }, canonicalSource: `https://github.com/${candidate.repo}`, revision: candidate.tag };
+};

--- a/packages/core/src/domain/hub/types.ts
+++ b/packages/core/src/domain/hub/types.ts
@@ -25,10 +25,16 @@ export const DEFAULT_LOCAL_HUB_ID = 'default-local';
  * Reference to a hub's location.
  */
 export interface HubReference {
-  type: 'github' | 'local' | 'url';
+  type: 'github' | 'local' | 'url' | 'artifactory';
   location: string;
   /** Git ref for GitHub sources (branch, tag, or commit). */
   ref?: string;
+  /** Relative config path within an Artifactory hub root. */
+  configFile?: string;
+  /** Artifactory authentication mode. */
+  authMode?: 'anonymous' | 'bearer';
+  /** Environment/secret-store credential key; never a raw credential. */
+  credentialRef?: string;
   autoSync?: boolean;
 }
 

--- a/packages/core/src/domain/hub/types.ts
+++ b/packages/core/src/domain/hub/types.ts
@@ -33,7 +33,7 @@ export interface HubReference {
   configFile?: string;
   /** Artifactory authentication mode. */
   authMode?: 'anonymous' | 'bearer';
-  /** Environment/secret-store credential key; never a raw credential. */
+  /** Credential key: environment variable name in the CLI, SecretStorage key in VS Code; never a raw credential. */
   credentialRef?: string;
   autoSync?: boolean;
 }

--- a/packages/core/src/domain/hub/validate.ts
+++ b/packages/core/src/domain/hub/validate.ts
@@ -184,6 +184,14 @@ export function isValidProtocol(protocol: string): boolean {
 }
 
 /**
+ * Loopback hosts may use HTTP only for local development/testing.
+ * @param hostname - Parsed URL hostname.
+ */
+export function isLoopbackHostname(hostname: string): boolean {
+  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]';
+}
+
+/**
  * Validate a hub ID: non-empty, ≤255 chars, no path separators or
  * traversal, alphanumeric/dash/underscore only.
  * @param hubId - Hub ID to validate.
@@ -238,7 +246,10 @@ export function validateHubReference(ref: HubReference): void {
       } catch {
         throw new Error('Invalid URL format');
       }
-      if (!isValidProtocol(url.protocol)) {
+      const loopbackHttp = ref.type === 'artifactory'
+        && url.protocol === 'http:'
+        && isLoopbackHostname(url.hostname);
+      if (!isValidProtocol(url.protocol) && !loopbackHttp) {
         throw new Error('Only HTTPS URLs are allowed for security');
       }
       if (ref.type === 'artifactory') {

--- a/packages/core/src/domain/hub/validate.ts
+++ b/packages/core/src/domain/hub/validate.ts
@@ -230,7 +230,8 @@ export function validateHubReference(ref: HubReference): void {
       }
       break;
     }
-    case 'url': {
+    case 'url':
+    case 'artifactory': {
       let url: URL;
       try {
         url = new URL(ref.location);
@@ -239,6 +240,15 @@ export function validateHubReference(ref: HubReference): void {
       }
       if (!isValidProtocol(url.protocol)) {
         throw new Error('Only HTTPS URLs are allowed for security');
+      }
+      if (ref.type === 'artifactory') {
+        const configFile = ref.configFile ?? 'hub-config.yml';
+        if (!configFile || configFile.startsWith('/') || configFile.includes('\\') || hasPathTraversal(configFile)) {
+          throw new Error('Artifactory configFile must be a confined relative path');
+        }
+        if (ref.authMode !== undefined && ref.authMode !== 'anonymous' && ref.authMode !== 'bearer') {
+          throw new Error('Invalid Artifactory authentication mode');
+        }
       }
       break;
     }

--- a/packages/core/src/domain/index.ts
+++ b/packages/core/src/domain/index.ts
@@ -14,6 +14,7 @@ export * from './discovery/types';
 export * from './errors';
 export * from './registry-error';
 export * from './source/types';
+export * from './source/artifactory-source-index';
 export * from './source/github-repository-target';
 export * from './source/github-source-authentication';
 export * from './source-id';

--- a/packages/core/src/domain/index.ts
+++ b/packages/core/src/domain/index.ts
@@ -30,6 +30,7 @@ export * from './registry/guards';
 export * from './registry/settings';
 export * from './hub/types';
 export * from './hub/validate';
+export * from './hub/replicate';
 export * from './primitive/types';
 export * from './skill/validate';
 export * from './mcp';

--- a/packages/core/src/domain/install/installable.ts
+++ b/packages/core/src/domain/install/installable.ts
@@ -74,7 +74,7 @@ export interface Installable {
    * than serving pre-packaged zips.
    */
   inlineBytes?: Uint8Array;
-  /** Optional integrity hash (e.g., `sha256-base64`). */
+  /** Optional canonical archive integrity (`sha256:<64 lowercase hexadecimal characters>`). */
   integrity?: string;
   /** Optional pre-fetched manifest. */
   manifest?: Record<string, unknown>;

--- a/packages/core/src/domain/install/integrity.ts
+++ b/packages/core/src/domain/install/integrity.ts
@@ -18,6 +18,33 @@
  * its own.
  * @module domain/install/integrity
  */
+import {
+  createHash,
+} from 'node:crypto';
+
+const SHA256_INTEGRITY = /^sha256:([a-f0-9]{64})$/;
+
+/**
+ * Parse canonical archive integrity, returning the bare digest or null.
+ * @param value
+ */
+export function parseArchiveIntegrity(value: string): string | null {
+  return SHA256_INTEGRITY.exec(value)?.[1] ?? null;
+}
+
+/**
+ * Verify bytes against canonical `sha256:<64 lowercase hex>` integrity.
+ * @param bytes
+ * @param integrity
+ */
+export function verifyArchiveIntegrity(bytes: Uint8Array, integrity: string): boolean {
+  const digest = parseArchiveIntegrity(integrity);
+  return digest !== null && createHash('sha256').update(bytes).digest('hex') === digest;
+}
+
+/** Short aliases for callers that work with generic integrity values. */
+export const parseIntegrity = parseArchiveIntegrity;
+export const verifyIntegrity = verifyArchiveIntegrity;
 
 /**
  * Narrow port subset needed to verify a written file. Satisfied by the

--- a/packages/core/src/domain/registry-error.ts
+++ b/packages/core/src/domain/registry-error.ts
@@ -19,7 +19,7 @@
 const NAMESPACES = [
   'BUNDLE', 'INDEX', 'HUB', 'PRIMITIVE',
   'CONFIG', 'NETWORK', 'AUTH', 'FS',
-  'PLUGIN', 'USAGE', 'INTERNAL'
+  'PLUGIN', 'USAGE', 'INTERNAL', 'ARTIFACTORY'
 ] as const;
 
 /**

--- a/packages/core/src/domain/source-id.ts
+++ b/packages/core/src/domain/source-id.ts
@@ -20,6 +20,8 @@ export interface SourceIdConfig {
   branch?: string;
   /** Path to the collections directory. Defaults to 'collections'. */
   collectionsPath?: string;
+  /** Artifactory source index path. Defaults to 'index-v1.json'. */
+  indexFile?: string;
 }
 
 /**
@@ -28,19 +30,18 @@ export interface SourceIdConfig {
  * Falls back to a regex-based normalization when `URL` parsing fails
  * (matches the extension's behaviour for invalid URLs).
  * @param url Raw URL.
+ * @param preservePathCase
  * @returns Normalized URL string.
  */
-export const normalizeUrl = (url: string): string => {
+export const normalizeUrl = (url: string, preservePathCase = false): string => {
   try {
     const u = new URL(url);
     const host = u.hostname.toLowerCase();
-    const path = u.pathname.toLowerCase().replace(/\/+$/, '');
-    return host + path;
+    const path = u.pathname.replace(/\/+$/, '');
+    return host + (preservePathCase ? path : path.toLowerCase());
   } catch {
-    return url
-      .toLowerCase()
-      .replace(/^https?:\/\//, '')
-      .replace(/\/+$/, '');
+    const withoutProtocol = url.replace(/^https?:\/\//, '').replace(/\/+$/, '');
+    return preservePathCase ? withoutProtocol : withoutProtocol.toLowerCase();
   }
 };
 
@@ -72,11 +73,15 @@ export const generateSourceId = (
   url: string,
   config?: SourceIdConfig
 ): string => {
-  const normalizedUrl = normalizeUrl(url);
+  const isArtifactory = sourceType === 'artifactory';
+  const normalizedUrl = normalizeUrl(url, isArtifactory);
   const branch = canonicalBranch(config?.branch);
   const collectionsPath = config?.collectionsPath ?? 'collections';
+  const indexFile = config?.indexFile ?? 'index-v1.json';
   const hash = createHash('sha256')
-    .update(`${sourceType}:${normalizedUrl}:${branch}:${collectionsPath}`)
+    .update(isArtifactory
+      ? `${sourceType}:${normalizedUrl}:${branch}:${collectionsPath}:${indexFile}`
+      : `${sourceType}:${normalizedUrl}:${branch}:${collectionsPath}`)
     .digest('hex')
     .substring(0, 12);
   return `${sourceType}-${hash}`;

--- a/packages/core/src/domain/source-id.ts
+++ b/packages/core/src/domain/source-id.ts
@@ -61,8 +61,8 @@ const canonicalBranch = (branch?: string): string => {
  * Generate a stable sourceId of the form `{type}-{12hex}`.
  *
  * The hash includes (sourceType, normalizedUrl, branch,
- * collectionsPath) so that the same logical source maps to the same
- * id regardless of how the user typed the URL.
+ * collectionsPath), plus indexFile for Artifactory, so that the same
+ * logical source maps to the same id regardless of how the user typed the URL.
  * @param sourceType e.g. 'github', 'awesome-copilot', 'apm'.
  * @param url Source URL.
  * @param config Optional branch + collections path.

--- a/packages/core/src/domain/source/artifactory-source-index.ts
+++ b/packages/core/src/domain/source/artifactory-source-index.ts
@@ -1,0 +1,190 @@
+/** Provider-neutral published bundle index contract used by Artifactory sources. */
+import * as semver from 'semver';
+import type {
+  ValidationResult,
+} from './types';
+
+export interface PublishedObject {
+  path: string;
+  size: number;
+  sha256: string;
+  mediaType?: string;
+}
+export interface ArtifactoryDependency {
+  bundleId: string;
+  versionRange: string;
+  optional: boolean;
+}
+export interface ArtifactoryBundleIndexEntry {
+  id: string;
+  version: string;
+  name: string;
+  description: string;
+  author: string;
+  environments: string[];
+  tags: string[];
+  lastUpdated: string;
+  dependencies: ArtifactoryDependency[];
+  homepage?: string;
+  repository?: string;
+  license: string;
+  manifest: PublishedObject;
+  archive: PublishedObject;
+  readme?: PublishedObject;
+  canonicalSource?: string;
+  revision?: string;
+}
+export interface ArtifactorySourceIndex {
+  formatVersion: 1;
+  source: { id: string; name: string; description?: string; updatedAt: string };
+  bundles: ArtifactoryBundleIndexEntry[];
+}
+
+/** Provider-neutral aliases for consumers that do not expose the backend name. */
+export type PublishedBundleIndex = ArtifactorySourceIndex;
+export type PublishedBundleIndexEntry = ArtifactoryBundleIndexEntry;
+
+export const isValidSemVer = (version: string): boolean => typeof version === 'string' && semver.valid(version) !== null;
+export const compareSemVer = (a: string, b: string): number => semver.compare(a, b);
+
+const RELATIVE_PATH = /^(?!\/)(?!.*%)(?!.*\\)(?!.*(?:^|\/)\.\.(?:\/|$))(?![a-zA-Z][a-zA-Z0-9+.-]*:).+$/;
+const SHA256 = /^[a-f0-9]{64}$/;
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null;
+const required = (value: Record<string, unknown>, fields: readonly string[], prefix: string, errors: string[]) => {
+  for (const field of fields) {
+    if (!(field in value)) {
+      errors.push(`${prefix}.${field} is required`);
+    }
+  }
+};
+const noUnknown = (value: Record<string, unknown>, allowed: readonly string[], prefix: string, errors: string[]) => {
+  for (const key of Object.keys(value)) {
+    if (!allowed.includes(key)) {
+      errors.push(`${prefix}.${key} is not allowed`);
+    }
+  }
+};
+const objectErrors = (value: unknown, prefix: string, errors: string[]): void => {
+  if (!isRecord(value)) {
+    errors.push(`${prefix} must be an object`);
+    return;
+  }
+  noUnknown(value, ['path', 'size', 'sha256', 'mediaType'], prefix, errors);
+  required(value, ['path', 'size', 'sha256'], prefix, errors);
+  if (typeof value.path !== 'string' || !RELATIVE_PATH.test(value.path)) {
+    errors.push(`${prefix}.path must be a safe relative path`);
+  }
+  if (!Number.isInteger(value.size) || (value.size as number) < 0) {
+    errors.push(`${prefix}.size must be a non-negative integer`);
+  }
+  if (typeof value.sha256 !== 'string' || !SHA256.test(value.sha256)) {
+    errors.push(`${prefix}.sha256 must be 64 lowercase hexadecimal characters`);
+  }
+};
+
+/**
+ * Validate an Artifactory source index, including invariants not expressible in JSON Schema.
+ * @param input
+ * @param expectedSourceId
+ */
+export const validateArtifactorySourceIndex = (input: unknown, expectedSourceId?: string | { hubSourceId?: string }): ValidationResult => {
+  const configuredSourceId = typeof expectedSourceId === 'string' ? expectedSourceId : expectedSourceId?.hubSourceId;
+  const errors: string[] = [];
+  if (!isRecord(input)) {
+    return { valid: false, errors: ['index must be an object'] };
+  }
+  noUnknown(input, ['formatVersion', 'source', 'bundles'], 'index', errors);
+  if (input.formatVersion !== 1) {
+    errors.push('formatVersion must be 1');
+  }
+  const source = input.source;
+  if (isRecord(source)) {
+    noUnknown(source, ['id', 'name', 'description', 'updatedAt'], 'source', errors);
+    required(source, ['id', 'name', 'updatedAt'], 'source', errors);
+    if (typeof source.id !== 'string' || !/^[a-zA-Z0-9_-]{1,50}$/.test(source.id)) {
+      errors.push('source.id is invalid');
+    }
+    if (typeof source.name !== 'string' || source.name.length === 0 || source.name.length > 100) {
+      errors.push('source.name is invalid');
+    }
+    if (typeof source.updatedAt !== 'string' || Number.isNaN(Date.parse(source.updatedAt))) {
+      errors.push('source.updatedAt is invalid');
+    }
+    if (configuredSourceId !== undefined && source.id !== configuredSourceId) {
+      errors.push('source.id does not match the configured hub source id');
+    }
+  } else {
+    errors.push('source is required and must be an object');
+  }
+  if (Array.isArray(input.bundles)) {
+    const identities = new Set<string>();
+    input.bundles.forEach((bundle, index) => {
+      const prefix = `bundles[${index}]`;
+      if (!isRecord(bundle)) {
+        errors.push(`${prefix} must be an object`);
+        return;
+      }
+      noUnknown(
+        bundle,
+        [
+          'id', 'version', 'name', 'description', 'author', 'environments', 'tags',
+          'lastUpdated', 'dependencies', 'homepage', 'repository', 'license', 'manifest',
+          'archive', 'readme', 'canonicalSource', 'revision'
+        ],
+        prefix,
+        errors
+      );
+      required(
+        bundle,
+        ['id', 'version', 'name', 'description', 'author', 'environments', 'tags',
+          'lastUpdated', 'dependencies', 'license', 'manifest', 'archive'],
+        prefix,
+        errors
+      );
+      if (typeof bundle.id !== 'string' || !/^[\w.-]{1,200}$/.test(bundle.id)) {
+        errors.push(`${prefix}.id is invalid`);
+      }
+      if (typeof bundle.version !== 'string' || !isValidSemVer(bundle.version)) {
+        errors.push(`${prefix}.version is not valid SemVer`);
+      }
+      const identity = `${String(bundle.id)}\0${String(bundle.version)}`;
+      if (identities.has(identity)) {
+        errors.push(`duplicate bundle id/version: ${bundle.id}@${bundle.version}`);
+      }
+      identities.add(identity);
+      for (const field of ['name', 'description', 'author', 'license']) {
+        if (typeof bundle[field] !== 'string') {
+          errors.push(`${prefix}.${field} is required`);
+        }
+      }
+      for (const field of ['environments', 'tags', 'dependencies']) {
+        if (!Array.isArray(bundle[field])) {
+          errors.push(`${prefix}.${field} must be an array`);
+        }
+      }
+      objectErrors(bundle.manifest, `${prefix}.manifest`, errors);
+      objectErrors(bundle.archive, `${prefix}.archive`, errors);
+      if (isRecord(bundle.archive) && bundle.archive.mediaType !== 'application/zip') {
+        errors.push(`${prefix}.archive.mediaType must be application/zip`);
+      }
+      if (bundle.readme !== undefined) {
+        objectErrors(bundle.readme, `${prefix}.readme`, errors);
+      }
+      const paths = [bundle.manifest, bundle.archive, bundle.readme]
+        .filter((object): object is Record<string, unknown> => isRecord(object))
+        .map((object) => object.path);
+      if (new Set(paths).size !== paths.length) {
+        errors.push(`${prefix} object paths must be distinct`);
+      }
+    });
+  } else {
+    errors.push('bundles is required and must be an array');
+  }
+  return {
+    valid: errors.length === 0,
+    errors,
+    bundlesFound: Array.isArray(input.bundles) ? input.bundles.length : 0
+  };
+};
+
+export const validatePublishedBundleIndex = validateArtifactorySourceIndex;

--- a/packages/core/src/domain/source/types.ts
+++ b/packages/core/src/domain/source/types.ts
@@ -22,7 +22,8 @@ export type SourceType =
   | 'local-apm'
   | 'skills'
   | 'local-skills'
-  | 'azure-devops';
+  | 'azure-devops'
+  | 'artifactory';
 
 /**
  * A configured bundle source.
@@ -56,7 +57,7 @@ export interface RegistrySource {
     branch?: string;
     /** Collections directory, for awesome-copilot sources. */
     collectionsPath?: string;
-    /** Index file name, for awesome-copilot sources. */
+    /** Index file name, for awesome-copilot and Artifactory sources. */
     indexFile?: string;
     [key: string]: unknown;
   };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,6 +37,9 @@ export { default as DEPLOYMENT_MANIFEST_SCHEMA } from './public/schemas/deployme
  */
 export { default as HUB_CONFIG_SCHEMA } from './public/schemas/hub-config.schema.json';
 
+/** Artifactory source index JSON schema. */
+export { default as ARTIFACTORY_SOURCE_INDEX_SCHEMA } from './public/schemas/artifactory-source-index.schema.json';
+
 /**
  * Phase 1 scaffolding marker, kept until `infra`/`app`/`cli` each have real
  * code of their own to depend on instead of this placeholder re-export

--- a/packages/core/src/ports/http-credentials.ts
+++ b/packages/core/src/ports/http-credentials.ts
@@ -1,0 +1,10 @@
+/** Provider-neutral source-scoped HTTP credential port. */
+export interface SourceRequestContext {
+  sourceId: string;
+  trustedOrigin: string;
+  trustedPathPrefix: string;
+}
+
+export interface HttpCredentialProvider {
+  headersFor(url: string, context: SourceRequestContext): Promise<Readonly<Record<string, string>>>;
+}

--- a/packages/core/src/ports/http.ts
+++ b/packages/core/src/ports/http.ts
@@ -26,7 +26,7 @@ export interface HttpRequest {
   /** Absolute URL. */
   url: string;
   /** Defaults to `'GET'`. */
-  method?: 'GET' | 'HEAD' | 'POST';
+  method?: 'GET' | 'HEAD' | 'POST' | 'PUT';
   /** Request headers (case-insensitive). */
   headers?: Record<string, string>;
   /** Request body, for `POST`. */

--- a/packages/core/src/ports/index.ts
+++ b/packages/core/src/ports/index.ts
@@ -9,6 +9,7 @@ export * from './clock';
 export * from './copilot-sdk';
 export * from './filesystem';
 export * from './http';
+export * from './http-credentials';
 export * from './github-api';
 export * from './azure-devops-api';
 export * from './process-runner';

--- a/packages/core/src/public/schemas/artifactory-source-index.schema.json
+++ b/packages/core/src/public/schemas/artifactory-source-index.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/AmadeusITGroup/ai-primitives-hub/schemas/artifactory-source-index.schema.json",
+  "title": "AI Primitives Hub Artifactory source index",
+  "type": "object",
+  "required": ["formatVersion", "source", "bundles"],
+  "properties": {
+    "formatVersion": { "const": 1 },
+    "source": {
+      "type": "object",
+      "required": ["id", "name", "updatedAt"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-zA-Z0-9-_]+$", "minLength": 1, "maxLength": 50 },
+        "name": { "type": "string", "minLength": 1, "maxLength": 100 },
+        "description": { "type": "string", "maxLength": 500 },
+        "updatedAt": { "type": "string", "format": "date-time" }
+      },
+      "additionalProperties": false
+    },
+    "bundles": { "type": "array", "items": { "$ref": "#/definitions/bundle" } }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "relativePath": { "type": "string", "description": "Syntax guard only. Consumers must also enforce source-root confinement.", "minLength": 1, "pattern": "^(?!/)(?!.*%)(?!.*\\\\)(?!.*(?:^|/)\\.\\.(?:/|$))(?![a-zA-Z][a-zA-Z0-9+.-]*:).+$" },
+    "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "object": {
+      "type": "object", "required": ["path", "size", "sha256"],
+      "properties": { "path": { "$ref": "#/definitions/relativePath" }, "size": { "type": "integer", "minimum": 0 }, "sha256": { "$ref": "#/definitions/sha256" }, "mediaType": { "type": "string", "minLength": 1 } },
+      "additionalProperties": false
+    },
+    "dependency": {
+      "type": "object", "required": ["bundleId", "versionRange", "optional"],
+      "properties": { "bundleId": { "type": "string", "minLength": 1 }, "versionRange": { "type": "string", "minLength": 1 }, "optional": { "type": "boolean" } },
+      "additionalProperties": false
+    },
+    "bundle": {
+      "type": "object", "required": ["id", "version", "name", "description", "author", "environments", "tags", "lastUpdated", "dependencies", "license", "manifest", "archive"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[\\w.\\-]+$", "minLength": 1, "maxLength": 200 }, "version": { "type": "string", "pattern": "^\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?$" }, "name": { "type": "string", "minLength": 1, "maxLength": 100 }, "description": { "type": "string", "maxLength": 500 }, "author": { "type": "string" }, "environments": { "type": "array", "items": { "type": "string" } }, "tags": { "type": "array", "items": { "type": "string" } }, "lastUpdated": { "type": "string", "format": "date-time" }, "dependencies": { "type": "array", "items": { "$ref": "#/definitions/dependency" } }, "homepage": { "type": "string", "format": "uri" }, "repository": { "type": "string" }, "license": { "type": "string" }, "manifest": { "$ref": "#/definitions/object" }, "archive": { "allOf": [{ "$ref": "#/definitions/object" }, { "properties": { "mediaType": { "const": "application/zip" } } }] }, "readme": { "$ref": "#/definitions/object" }, "canonicalSource": { "type": "string", "format": "uri" }, "revision": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/packages/core/src/public/schemas/hub-config.schema.json
+++ b/packages/core/src/public/schemas/hub-config.schema.json
@@ -76,7 +76,7 @@
           },
           "type": {
             "type": "string",
-            "description": "Type of the source repository (github, local, awesome-copilot, local-awesome-copilot, apm, local-apm, skills, local-skills, azure-devops)",
+            "description": "Type of the source repository (github, local, awesome-copilot, local-awesome-copilot, apm, local-apm, skills, local-skills, azure-devops, artifactory)",
             "enum": [
               "github",
               "local",
@@ -86,7 +86,8 @@
               "local-apm",
               "skills",
               "local-skills",
-              "azure-devops"
+              "azure-devops",
+              "artifactory"
             ]
           },
           "url": {
@@ -109,6 +110,10 @@
             "type": "boolean",
             "description": "Whether this source is currently active"
           },
+          "private": {
+            "type": "boolean",
+            "description": "Whether the source requires private credentials"
+          },
           "priority": {
             "type": "number",
             "description": "Priority order for source resolution (higher = higher priority)",
@@ -129,7 +134,17 @@
               },
               "indexFile": {
                 "type": "string",
-                "description": "Index file name (for awesome-copilot sources)"
+                "description": "Index file name (for awesome-copilot and Artifactory sources)"
+              },
+              "authMode": {
+                "type": "string",
+                "enum": ["anonymous", "bearer"],
+                "description": "Artifactory authentication mode"
+              },
+              "credentialRef": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Reference to an external Artifactory credential; never a secret value"
               }
             }
           },

--- a/packages/core/src/public/schemas/lockfile.schema.json
+++ b/packages/core/src/public/schemas/lockfile.schema.json
@@ -107,7 +107,11 @@
             "awesome-copilot",
             "local-awesome-copilot",
             "apm",
-            "local-apm"
+            "local-apm",
+            "skills",
+            "local-skills",
+            "azure-devops",
+            "artifactory"
           ]
         },
         "installedAt": {
@@ -179,7 +183,11 @@
             "awesome-copilot",
             "local-awesome-copilot",
             "apm",
-            "local-apm"
+            "local-apm",
+            "skills",
+            "local-skills",
+            "azure-devops",
+            "artifactory"
           ]
         },
         "url": {
@@ -190,6 +198,24 @@
         "branch": {
           "type": "string",
           "description": "Optional Git branch for git-based sources"
+        },
+        "collectionsPath": {
+          "type": "string",
+          "description": "Optional collections subdirectory for awesome-copilot sources"
+        },
+        "indexFile": {
+          "type": "string",
+          "description": "Optional Artifactory index file"
+        },
+        "authMode": {
+          "type": "string",
+          "enum": ["anonymous", "bearer"],
+          "description": "Optional Artifactory authentication mode"
+        },
+        "credentialRef": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional external Artifactory credential reference"
         }
       },
       "additionalProperties": false

--- a/packages/core/test/domain/hub/replicate.test.ts
+++ b/packages/core/test/domain/hub/replicate.test.ts
@@ -1,0 +1,21 @@
+/* eslint-disable @stylistic/max-len, @stylistic/max-statements-per-line -- focused fixtures */
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  type ReplicationCandidate,
+  selectReplications,
+  stableReplicatedBundleId,
+} from '../../../src';
+
+const candidate = (version: string): ReplicationCandidate => ({ sourceId: 'source', repo: 'owner/repo', tag: `v${version}`, publishedAt: '', releaseName: '', manifest: {}, manifestBytes: new Uint8Array([1]), manifestName: 'deployment-manifest.yml', archiveUrl: 'https://example.invalid/a.zip', archiveSize: 3, version, bundleId: 'owner-repo' });
+describe('replication domain', () => {
+  it('matches stable IDs and selects latest stable over prerelease', () => {
+    expect(stableReplicatedBundleId('owner/repo', { id: 'bundle' })).toBe('owner-repo-bundle'); const result = selectReplications([candidate('1.0.0-alpha.1'), candidate('1.0.0'), candidate('2.0.0')], [{ sourceId: 'source', bundleId: 'owner-repo', versions: new Set(['latest']) }], 'latest'); expect(result.selected.map((item) => item.version)).toEqual(['2.0.0']);
+  });
+  it('selects every release in all mode and reports unresolved requests', () => {
+    const result = selectReplications([candidate('1.0.0')], [{ sourceId: 'source', bundleId: 'missing', versions: new Set(['latest']) }], 'latest'); expect(result.unresolved).toEqual(['source:missing']); expect(selectReplications([candidate('1.0.0'), candidate('1.1.0')], [], 'all').selected).toHaveLength(2);
+  });
+});

--- a/packages/core/test/domain/hub/validate.test.ts
+++ b/packages/core/test/domain/hub/validate.test.ts
@@ -112,6 +112,12 @@ describe('validateHubReference', () => {
     );
   });
 
+  it('allows loopback http only for Artifactory development references', () => {
+    expect(() => validateHubReference({ type: 'artifactory', location: 'http://127.0.0.1:8081/artifactory/hub' })).not.toThrow();
+    expect(() => validateHubReference({ type: 'artifactory', location: 'http://localhost:8081/artifactory/hub' })).not.toThrow();
+    expect(() => validateHubReference({ type: 'artifactory', location: 'http://example.com/artifactory/hub' })).toThrow('HTTPS');
+  });
+
   it('rejects a malformed url reference', () => {
     expect(() => validateHubReference({ type: 'url', location: 'not a url' })).toThrow('Invalid URL format');
   });

--- a/packages/core/test/domain/install/archive-integrity.test.ts
+++ b/packages/core/test/domain/install/archive-integrity.test.ts
@@ -1,0 +1,24 @@
+import {
+  createHash,
+} from 'node:crypto';
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  parseArchiveIntegrity,
+  verifyArchiveIntegrity,
+} from '../../../src';
+
+describe('archive integrity', () => {
+  it('parses only canonical sha256 digests and verifies bytes', () => {
+    const bytes = new TextEncoder().encode('archive');
+    const digest = createHash('sha256').update(bytes).digest('hex');
+    expect(parseArchiveIntegrity(`sha256:${digest}`)).toBe(digest);
+    expect(parseArchiveIntegrity(`sha256:${digest.toUpperCase()}`)).toBeNull();
+    expect(parseArchiveIntegrity(`sha512:${digest}`)).toBeNull();
+    expect(verifyArchiveIntegrity(bytes, `sha256:${digest}`)).toBe(true);
+    expect(verifyArchiveIntegrity(bytes, `sha256:${'b'.repeat(64)}`)).toBe(false);
+  });
+});

--- a/packages/core/test/domain/source-id.test.ts
+++ b/packages/core/test/domain/source-id.test.ts
@@ -1,0 +1,23 @@
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  generateSourceId,
+  normalizeUrl,
+} from '../../src';
+
+describe('Artifactory source IDs', () => {
+  it('includes the configured Artifactory index path and preserves URL path case', () => {
+    expect(normalizeUrl('https://ART.example/Repo/Path', true)).toBe('art.example/Repo/Path');
+    expect(generateSourceId('artifactory', 'https://art.example/Repo/Path'))
+      .toBe(generateSourceId('artifactory', 'https://art.example/Repo/Path', { indexFile: 'index-v1.json' }));
+    expect(generateSourceId('artifactory', 'https://ART.example/Repo/Path', { indexFile: 'INDEX.JSON' }))
+      .toBe(generateSourceId('artifactory', 'https://art.example/Repo/Path', { indexFile: 'INDEX.JSON' }));
+    expect(generateSourceId('artifactory', 'https://art.example/Repo/Path', { indexFile: 'INDEX.JSON' }))
+      .not.toBe(generateSourceId('artifactory', 'https://art.example/repo/path', { indexFile: 'INDEX.JSON' }));
+    expect(generateSourceId('artifactory', 'https://art.example/Repo/Path', { indexFile: 'INDEX.JSON' }))
+      .not.toBe(generateSourceId('artifactory', 'https://art.example/Repo/Path', { indexFile: 'index.json' }));
+  });
+});

--- a/packages/core/test/domain/source/artifactory-source-index.test.ts
+++ b/packages/core/test/domain/source/artifactory-source-index.test.ts
@@ -1,0 +1,46 @@
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  type ArtifactorySourceIndex,
+  compareSemVer,
+  isValidSemVer,
+  validateArtifactorySourceIndex,
+} from '../../../src';
+
+type IndexWithBundles = ArtifactorySourceIndex;
+
+const object = (path: string) => ({
+  path,
+  size: 1,
+  sha256: 'a'.repeat(64),
+  mediaType: 'application/zip'
+});
+
+const validIndex = (): IndexWithBundles => ({
+  formatVersion: 1,
+  source: { id: 'example', name: 'Example', updatedAt: '2026-01-01T00:00:00Z' },
+  bundles: [{
+    id: 'bundle', version: '1.0.0', name: 'Bundle', description: 'Description', author: 'Author',
+    environments: [], tags: [], lastUpdated: '2026-01-01T00:00:00Z', dependencies: [], license: 'Apache-2.0',
+    manifest: { ...object('bundles/bundle/1.0.0/deployment-manifest.yml'), mediaType: 'application/yaml' },
+    archive: object('bundles/bundle/1.0.0/bundle.zip')
+  }]
+});
+
+describe('Artifactory source index', () => {
+  it('validates the contract and rejects duplicate bundle versions and unsafe paths', () => {
+    const index = validIndex();
+    index.bundles.push({ ...index.bundles[0], archive: { ...index.bundles[0].archive, path: '../escape.zip' } });
+    expect(validateArtifactorySourceIndex(index)).toMatchObject({ valid: false });
+    expect(validateArtifactorySourceIndex({ ...validIndex(), bundles: [validIndex().bundles[0], validIndex().bundles[0]] }).errors.join(' ')).toMatch(/duplicate/i);
+  });
+
+  it('exposes strict SemVer validity and ordering helpers', () => {
+    expect(isValidSemVer('1.2.3-alpha.1')).toBe(true);
+    expect(isValidSemVer('1.2')).toBe(false);
+    expect(compareSemVer('1.0.0', '1.0.0-alpha')).toBeGreaterThan(0);
+  });
+});

--- a/packages/infra/src/adapters/artifactory-adapter.ts
+++ b/packages/infra/src/adapters/artifactory-adapter.ts
@@ -1,0 +1,98 @@
+/* eslint-disable @stylistic/max-len, @stylistic/max-statements-per-line, @typescript-eslint/member-ordering, unicorn/no-array-sort -- compact mapping and deterministic ordering are intentional here */
+import {
+  createHash,
+} from 'node:crypto';
+import {
+  type ArtifactoryBundleIndexEntry,
+  type ArtifactorySourceIndex,
+  type Bundle,
+  compareSemVer,
+  RegistryError,
+  type RegistrySource,
+  type SourceMetadata,
+  validateArtifactorySourceIndex,
+  type ValidationResult,
+} from '@ai-primitives-hub/core';
+import {
+  ArtifactoryHttpClient,
+} from '../artifactory/http-client';
+import {
+  BaseSourceAdapter,
+} from './base-source-adapter';
+
+const sizeText = (n: number): string => n < 1024 ? `${n} B` : (n < 1024 * 1024 ? `${(n / 1024).toFixed(1)} KB` : `${(n / (1024 * 1024)).toFixed(1)} MB`);
+const digest = (bytes: Uint8Array): string => createHash('sha256').update(bytes).digest('hex');
+
+export class ArtifactorySourceAdapter extends BaseSourceAdapter {
+  public readonly type = 'artifactory';
+  private index?: ArtifactorySourceIndex;
+  public constructor(source: RegistrySource, private readonly client: ArtifactoryHttpClient) {
+    super(source);
+  }
+
+  private async load(): Promise<ArtifactorySourceIndex> {
+    if (this.index) {
+      return this.index;
+    }
+    const result = await this.client.getIndex(this.source.config?.indexFile ?? 'index-v1.json');
+    const validation = validateArtifactorySourceIndex(result.value, this.source.hubSourceId ? { hubSourceId: this.source.hubSourceId } : undefined);
+    if (!validation.valid) {
+      throw new RegistryError({ code: 'ARTIFACTORY.INDEX_INVALID', message: `Invalid Artifactory index: ${validation.errors.join('; ')}` });
+    }
+    this.index = result.value as ArtifactorySourceIndex;
+    return this.index;
+  }
+
+  private async entry(bundle: Bundle): Promise<ArtifactoryBundleIndexEntry> {
+    const found = (await this.load()).bundles.find((item) => item.id === bundle.id && item.version === bundle.version);
+    if (!found) {
+      throw new Error(`Bundle ${bundle.id}@${bundle.version} was not found.`);
+    }
+    return found;
+  }
+
+  public async fetchBundles(): Promise<Bundle[]> {
+    const index = await this.load();
+    return [...index.bundles].sort((a, b) => a.id.localeCompare(b.id) || compareSemVer(b.version, a.version)).map((item) => ({ id: item.id, name: item.name, version: item.version, description: item.description, author: item.author, sourceId: this.source.id, environments: item.environments, tags: item.tags, lastUpdated: item.lastUpdated, size: sizeText(item.archive.size), dependencies: item.dependencies, homepage: item.homepage, repository: item.repository, license: item.license, manifestUrl: this.client.urlFor(item.manifest.path), downloadUrl: this.client.urlFor(item.archive.path), checksum: { algorithm: 'sha256', hash: item.archive.sha256 }, readmeUrl: item.readme ? this.client.urlFor(item.readme.path) : undefined, readmeRevision: item.revision }));
+  }
+
+  public async downloadBundle(bundle: Bundle): Promise<Buffer> {
+    const item = await this.entry(bundle); const bytes = await this.client.getBytes(item.archive); this.verify(bytes, item.archive.sha256, item.archive.size, 'BUNDLE.ARCHIVE_INTEGRITY_MISMATCH'); return Buffer.from(bytes);
+  }
+
+  public async downloadReadme(bundle: Bundle): Promise<string | null> {
+    const item = await this.entry(bundle); if (!item.readme) {
+      return null;
+    } const bytes = await this.client.getBytes(item.readme); this.verify(bytes, item.readme.sha256, item.readme.size, 'BUNDLE.MANIFEST_INTEGRITY_MISMATCH'); return Buffer.from(bytes).toString('utf8');
+  }
+
+  private verify(bytes: Uint8Array, expectedHash: string, expectedSize: number, code: string): void {
+    if (bytes.byteLength !== expectedSize || digest(bytes) !== expectedHash) {
+      throw new RegistryError({ code, message: 'Published object integrity check failed.' });
+    }
+  }
+
+  public async fetchMetadata(): Promise<SourceMetadata> {
+    const index = await this.load(); return { name: index.source.name, description: index.source.description ?? '', bundleCount: index.bundles.length, lastUpdated: index.source.updatedAt, version: '1' };
+  }
+
+  public async validate(): Promise<ValidationResult> {
+    try {
+      const index = await this.load(); return { valid: true, errors: [], bundlesFound: index.bundles.length };
+    } catch (error) {
+      return { valid: false, errors: [error instanceof Error ? error.message : String(error)] };
+    }
+  }
+
+  public requiresAuthentication(): boolean {
+    return this.source.private === true || this.source.config?.authMode === 'bearer';
+  }
+
+  public getManifestUrl(bundleId: string, version?: string): string {
+    const item = this.index?.bundles.find((b) => b.id === bundleId && (version === undefined || b.version === version)); return item ? this.client.urlFor(item.manifest.path) : '';
+  }
+
+  public getDownloadUrl(bundleId: string, version?: string): string {
+    const item = this.index?.bundles.find((b) => b.id === bundleId && (version === undefined || b.version === version)); return item ? this.client.urlFor(item.archive.path) : '';
+  }
+}

--- a/packages/infra/src/adapters/index.ts
+++ b/packages/infra/src/adapters/index.ts
@@ -6,6 +6,7 @@ export * from './apm-adapter';
 export * from './awesome-copilot-adapter';
 export * from './azure-devops-adapter';
 export * from './base-source-adapter';
+export * from './artifactory-adapter';
 export * from './github-adapter';
 export * from './local-adapter';
 export * from './local-apm-adapter';

--- a/packages/infra/src/artifactory/config.ts
+++ b/packages/infra/src/artifactory/config.ts
@@ -1,0 +1,36 @@
+import {
+  RegistryError,
+  type RegistrySource,
+} from '@ai-primitives-hub/core';
+import {
+  normalizeSourceRoot,
+} from './published-object-url';
+
+export interface ArtifactorySourceConfig { indexFile?: string; authMode?: 'anonymous' | 'bearer'; credentialRef?: string }
+
+/**
+ * Parse and validate the small Artifactory-specific source configuration.
+ * @param source Configured source.
+ */
+export function parseArtifactorySourceConfig(source: RegistrySource): ArtifactorySourceConfig {
+  try {
+    normalizeSourceRoot(source.url);
+  } catch (cause) {
+    throw new RegistryError({ code: 'ARTIFACTORY.CONFIG_INVALID', message: 'Invalid Artifactory source configuration.', cause });
+  }
+  const config = source.config ?? {};
+  for (const key of ['token', 'password', 'secret', 'apiKey', 'accessToken']) {
+    if (key in config) {
+      throw new RegistryError({ code: 'ARTIFACTORY.CONFIG_INVALID', message: 'Artifactory configuration must not contain secret values.' });
+    }
+  }
+  const indexFile = typeof config.indexFile === 'string' && config.indexFile.length > 0 ? config.indexFile : 'index-v1.json';
+  if (indexFile.startsWith('/') || indexFile.includes('\\') || indexFile.includes('..') || indexFile.includes('%')) {
+    throw new RegistryError({ code: 'ARTIFACTORY.CONFIG_INVALID', message: 'Artifactory indexFile must be a confined relative path.' });
+  }
+  const authMode = config.authMode === 'bearer' ? 'bearer' : 'anonymous';
+  if (source.private === true && authMode !== 'bearer') {
+    throw new RegistryError({ code: 'ARTIFACTORY.CONFIG_INVALID', message: 'Private Artifactory sources require Bearer authentication.' });
+  }
+  return { indexFile, authMode, credentialRef: typeof config.credentialRef === 'string' ? config.credentialRef : undefined };
+}

--- a/packages/infra/src/artifactory/credentials.ts
+++ b/packages/infra/src/artifactory/credentials.ts
@@ -1,0 +1,34 @@
+import {
+  type HttpCredentialProvider,
+  RegistryError,
+  type SourceRequestContext,
+} from '@ai-primitives-hub/core';
+import {
+  isWithinSourceRoot,
+  normalizeSourceRoot,
+} from './published-object-url';
+
+export class AnonymousCredentialProvider implements HttpCredentialProvider {
+  public async headersFor(url: string, context: SourceRequestContext): Promise<Readonly<Record<string, string>>> {
+    const target = new URL(url);
+    if (!isWithinSourceRoot(normalizeSourceRoot(context.trustedOrigin), target)) {
+      throw new RegistryError({ code: 'ARTIFACTORY.PATH_ESCAPE', message: 'Credential request is outside the trusted source root.' });
+    }
+    return {};
+  }
+}
+
+export class ArtifactoryEnvCredentialProvider implements HttpCredentialProvider {
+  public constructor(private readonly env: Record<string, string | undefined>, private readonly envName: string, private readonly sourceRoot: string) {}
+  public async headersFor(url: string, context: SourceRequestContext): Promise<Readonly<Record<string, string>>> {
+    const root = normalizeSourceRoot(this.sourceRoot);
+    if (!isWithinSourceRoot(root, new URL(url)) || context.trustedOrigin !== root.origin) {
+      throw new RegistryError({ code: 'ARTIFACTORY.PATH_ESCAPE', message: 'Credential request is outside the trusted source root.' });
+    }
+    const token = this.env[this.envName];
+    if (!token) {
+      throw new RegistryError({ code: 'ARTIFACTORY.CREDENTIAL_MISSING', message: `Credential ${this.envName} is not available.` });
+    }
+    return { Authorization: `Bearer ${token}` };
+  }
+}

--- a/packages/infra/src/artifactory/http-client.ts
+++ b/packages/infra/src/artifactory/http-client.ts
@@ -45,7 +45,20 @@ export class ArtifactoryHttpClient {
 
   public async getBytes(object: PublishedObject): Promise<Uint8Array> {
     const url = resolveConfinedObject(this.root, object.path);
-    const response = await this.request(url, object.mediaType ?? '*/*', undefined, this.options.maxObjectBytes);
+    return this.getBytesAt(url.href, object.mediaType);
+  }
+
+  /**
+   * Fetch an already-resolved URL while retaining source-root confinement.
+   * @param url
+   * @param mediaType
+   */
+  public async getBytesAt(url: string, mediaType = '*/*'): Promise<Uint8Array> {
+    const target = new URL(url);
+    if (!isWithinSourceRoot(this.root, target)) {
+      throw new RegistryError({ code: 'ARTIFACTORY.PATH_ESCAPE', message: 'Artifactory URL is outside the source root.' });
+    }
+    const response = await this.request(target, mediaType, undefined, this.options.maxObjectBytes);
     return response.body;
   }
 

--- a/packages/infra/src/artifactory/http-client.ts
+++ b/packages/infra/src/artifactory/http-client.ts
@@ -1,0 +1,91 @@
+/* eslint-disable @typescript-eslint/member-ordering, @stylistic/max-len, @stylistic/max-statements-per-line, @stylistic/no-mixed-operators, unicorn/no-nested-ternary -- small transport implementation keeps policy together */
+import {
+  type HttpClient,
+  type HttpCredentialProvider,
+  type HttpResponse,
+  type PublishedObject,
+  RegistryError,
+  type SourceRequestContext,
+} from '@ai-primitives-hub/core';
+import {
+  isWithinSourceRoot,
+  normalizeSourceRoot,
+  resolveConfinedObject,
+} from './published-object-url';
+
+export interface ConditionalJsonResult<T> { status: 'fresh' | 'not-modified'; value?: T; etag?: string; finalUrl: string }
+export interface ArtifactoryHttpClientOptions { maxRetries?: number; maxIndexBytes?: number; maxObjectBytes?: number; sleep?: (ms: number) => Promise<void> }
+const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+const transient = new Set([408, 429, 502, 503, 504]);
+
+export class ArtifactoryHttpClient {
+  private readonly root: URL;
+  private readonly options: Required<Pick<ArtifactoryHttpClientOptions, 'maxRetries' | 'maxIndexBytes' | 'maxObjectBytes'>> & Pick<ArtifactoryHttpClientOptions, 'sleep'>;
+  public constructor(private readonly http: HttpClient, private readonly credentials: HttpCredentialProvider, sourceRoot: string | URL, options: ArtifactoryHttpClientOptions = {}) {
+    this.root = typeof sourceRoot === 'string' ? normalizeSourceRoot(sourceRoot) : normalizeSourceRoot(sourceRoot.toString());
+    this.options = { maxRetries: options.maxRetries ?? 3, maxIndexBytes: options.maxIndexBytes ?? 5 * 1024 * 1024, maxObjectBytes: options.maxObjectBytes ?? 100 * 1024 * 1024, sleep: options.sleep };
+  }
+
+  public async getIndex(indexPath = 'index-v1.json', etag?: string): Promise<ConditionalJsonResult<unknown>> {
+    const url = resolveConfinedObject(this.root, indexPath);
+    const response = await this.request(url, 'application/json', etag, this.options.maxIndexBytes);
+    if (response.statusCode === 304) {
+      return { status: 'not-modified', etag, finalUrl: response.finalUrl };
+    }
+    try {
+      return { status: 'fresh', value: JSON.parse(Buffer.from(response.body).toString('utf8')), etag: response.headers.etag, finalUrl: response.finalUrl };
+    } catch (cause) {
+      throw new RegistryError({ code: 'ARTIFACTORY.INDEX_INVALID', message: 'Artifactory index is not valid JSON.', cause });
+    }
+  }
+
+  public async getText(object: PublishedObject): Promise<string> {
+    return Buffer.from(await this.getBytes(object)).toString('utf8');
+  }
+
+  public async getBytes(object: PublishedObject): Promise<Uint8Array> {
+    const url = resolveConfinedObject(this.root, object.path);
+    const response = await this.request(url, object.mediaType ?? '*/*', undefined, this.options.maxObjectBytes);
+    return response.body;
+  }
+
+  public urlFor(path: string): string {
+    return resolveConfinedObject(this.root, path).href;
+  }
+
+  private async request(url: URL, accept: string, etag: string | undefined, maxBytes: number): Promise<HttpResponse> {
+    const context: SourceRequestContext = { sourceId: this.root.href, trustedOrigin: this.root.origin, trustedPathPrefix: this.root.pathname };
+    let headers: Record<string, string> = { Accept: accept, ...(await this.credentials.headersFor(url.href, context)) };
+    if (etag) {
+      headers = { ...headers, 'If-None-Match': etag };
+    }
+    for (let attempt = 0; ; attempt += 1) {
+      let response: HttpResponse;
+      try {
+        response = await this.http.fetch({ url: url.href, headers });
+      } catch (cause) {
+        if (attempt < this.options.maxRetries) {
+          await (this.options.sleep ?? wait)(Math.min(100 * 2 ** attempt, 2000)); continue;
+        } throw new RegistryError({ code: 'ARTIFACTORY.TRANSIENT', message: 'Artifactory request failed.', cause });
+      }
+      if (!isWithinSourceRoot(this.root, new URL(response.finalUrl)) && response.statusCode !== 304) {
+        throw new RegistryError({ code: 'ARTIFACTORY.PATH_ESCAPE', message: 'Artifactory response redirected outside the source root.' });
+      }
+      if (response.statusCode >= 200 && response.statusCode < 300 || response.statusCode === 304) {
+        const declared = Number(response.headers['content-length']);
+        if (Number.isFinite(declared) && declared > maxBytes) {
+          throw new RegistryError({ code: 'ARTIFACTORY.INDEX_TOO_LARGE', message: 'Artifactory response exceeds the permitted size.' });
+        }
+        if (response.body.byteLength > maxBytes) {
+          throw new RegistryError({ code: 'ARTIFACTORY.INDEX_TOO_LARGE', message: 'Artifactory response exceeds the permitted size.' });
+        }
+        return response;
+      }
+      if (transient.has(response.statusCode) && attempt < this.options.maxRetries) {
+        const retry = Number(response.headers['retry-after']); await (this.options.sleep ?? wait)(Math.min(Number.isFinite(retry) ? retry * 1000 : 100 * 2 ** attempt, 2000)); continue;
+      }
+      const code = response.statusCode === 401 ? 'ARTIFACTORY.AUTHENTICATION_FAILED' : response.statusCode === 403 ? 'ARTIFACTORY.ACCESS_DENIED' : response.statusCode === 404 ? 'ARTIFACTORY.OBJECT_NOT_FOUND' : transient.has(response.statusCode) ? 'ARTIFACTORY.TRANSIENT' : 'ARTIFACTORY.REQUEST_FAILED';
+      throw new RegistryError({ code, message: `Artifactory request failed with HTTP ${String(response.statusCode)}.` });
+    }
+  }
+}

--- a/packages/infra/src/artifactory/index.ts
+++ b/packages/infra/src/artifactory/index.ts
@@ -1,0 +1,4 @@
+export * from './published-object-url';
+export * from './config';
+export * from './credentials';
+export * from './http-client';

--- a/packages/infra/src/artifactory/published-object-url.ts
+++ b/packages/infra/src/artifactory/published-object-url.ts
@@ -1,0 +1,56 @@
+/* eslint-disable no-control-regex, jsdoc/require-description -- security validation is deliberately explicit */
+import {
+  RegistryError,
+} from '@ai-primitives-hub/core';
+
+const invalid = (message: string): RegistryError => new RegistryError({ code: 'ARTIFACTORY.PATH_ESCAPE', message });
+const hasControl = (value: string): boolean => /[\u0000-\u001F\u007F]/.test(value);
+
+/**
+ *
+ * @param raw
+ */
+export function normalizeSourceRoot(raw: string): URL {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch (cause) {
+    throw new RegistryError({ code: 'ARTIFACTORY.CONFIG_INVALID', message: 'Artifactory source URL is invalid.', cause });
+  }
+  const loopback = url.hostname === '127.0.0.1' || url.hostname === 'localhost' || url.hostname === '[::1]';
+  if ((url.protocol !== 'https:' && !(url.protocol === 'http:' && loopback))
+    || url.username || url.password || url.search || url.hash || hasControl(raw) || raw.includes('\\')) {
+    throw new RegistryError({ code: 'ARTIFACTORY.CONFIG_INVALID', message: 'Artifactory source URL must be a credential-free HTTPS URL, or loopback HTTP for local development.' });
+  }
+  url.pathname = url.pathname.endsWith('/') ? url.pathname : `${url.pathname}/`;
+  return url;
+}
+
+/**
+ *
+ * @param root
+ * @param candidate
+ */
+export function isWithinSourceRoot(root: URL, candidate: URL): boolean {
+  return root.protocol === candidate.protocol && root.hostname === candidate.hostname && root.port === candidate.port && candidate.pathname.startsWith(root.pathname);
+}
+
+/**
+ *
+ * @param root
+ * @param relativePath
+ */
+export function resolveConfinedObject(root: URL, relativePath: string): URL {
+  if (!relativePath || hasControl(relativePath) || relativePath.includes('\\') || relativePath.includes('%') || relativePath.startsWith('/') || /^[a-z][a-z\d+.-]*:/i.test(relativePath)) {
+    throw invalid('Published object path is not confined to the source root.');
+  }
+  const segments = relativePath.split('/');
+  if (segments.some((segment) => segment === '' || segment === '.' || segment === '..')) {
+    throw invalid('Published object path contains unsafe segments.');
+  }
+  const candidate = new URL(relativePath, root);
+  if (candidate.search || candidate.hash || !isWithinSourceRoot(root, candidate)) {
+    throw invalid('Published object path escapes the source root.');
+  }
+  return candidate;
+}

--- a/packages/infra/src/downloaders/artifactory-bundle-downloader.ts
+++ b/packages/infra/src/downloaders/artifactory-bundle-downloader.ts
@@ -1,0 +1,36 @@
+import {
+  createHash,
+} from 'node:crypto';
+import {
+  RegistryError,
+  verifyArchiveIntegrity,
+} from '@ai-primitives-hub/core';
+import type {
+  BundleDownloader,
+  DownloadResult,
+  Installable,
+} from '@ai-primitives-hub/core';
+import type {
+  ArtifactoryHttpClient,
+} from '../artifactory/http-client';
+
+/** Downloads an Artifactory archive through the source-scoped HTTP client. */
+export class ArtifactoryBundleDownloader implements BundleDownloader {
+  public constructor(private readonly client: ArtifactoryHttpClient) {}
+
+  private digest(bytes: Uint8Array): string {
+    return createHash('sha256').update(bytes).digest('hex');
+  }
+
+  public async download(installable: Installable): Promise<DownloadResult> {
+    const bytes = installable.inlineBytes ?? await this.client.getBytesAt(installable.downloadUrl);
+    const sha256 = this.digest(bytes);
+    if (installable.integrity !== undefined && !verifyArchiveIntegrity(bytes, installable.integrity)) {
+      throw new RegistryError({
+        code: 'BUNDLE.ARCHIVE_INTEGRITY_MISMATCH',
+        message: 'Artifactory archive integrity verification failed.'
+      });
+    }
+    return { bytes, sha256 };
+  }
+}

--- a/packages/infra/src/downloaders/index.ts
+++ b/packages/infra/src/downloaders/index.ts
@@ -3,3 +3,4 @@
  * @module downloaders
  */
 export * from './https-bundle-downloader';
+export * from './artifactory-bundle-downloader';

--- a/packages/infra/src/hub/artifactory-hub-resolver.ts
+++ b/packages/infra/src/hub/artifactory-hub-resolver.ts
@@ -1,0 +1,55 @@
+import type {
+  HttpClient,
+  HttpCredentialProvider,
+  HubConfig,
+  HubReference,
+} from '@ai-primitives-hub/core';
+import * as yaml from 'js-yaml';
+import {
+  AnonymousCredentialProvider,
+} from '../artifactory/credentials';
+import {
+  ArtifactoryHttpClient,
+} from '../artifactory/http-client';
+import type {
+  HubResolver,
+  ResolvedHub,
+} from './hub-resolver';
+import {
+  validateHubConfigDocument,
+} from './validate-hub-config';
+
+export type ArtifactoryCredentialProvider = (reference: HubReference, root: string) => HttpCredentialProvider;
+
+/** Resolves a complete hub tree from a confined Artifactory repository root. */
+export class ArtifactoryHubResolver implements HubResolver {
+  public constructor(
+    private readonly http: HttpClient,
+    private readonly credentials: HttpCredentialProvider | ArtifactoryCredentialProvider,
+    private readonly sourceRoot?: string
+  ) {}
+
+  public async resolve(ref: HubReference): Promise<ResolvedHub> {
+    if (ref.type !== 'artifactory') {
+      throw new Error(`Artifactory resolver cannot resolve '${ref.type}' references`);
+    }
+    const root = this.sourceRoot ?? ref.location;
+    const provider = typeof this.credentials === 'function'
+      ? this.credentials(ref, root)
+      : (ref.authMode === 'anonymous' ? new AnonymousCredentialProvider() : this.credentials);
+    const client = new ArtifactoryHttpClient(this.http, provider, root);
+    const configFile = ref.configFile ?? 'hub-config.yml';
+    const text = await client.getText({ path: configFile, size: 0, sha256: '' });
+    let parsed: unknown;
+    try {
+      parsed = yaml.load(text);
+    } catch (cause) {
+      throw new Error(`Failed to parse Artifactory hub config: ${cause instanceof Error ? cause.message : String(cause)}`);
+    }
+    const validation = validateHubConfigDocument(parsed);
+    if (!validation.valid) {
+      throw new Error(`Invalid Artifactory hub config: ${validation.errors.join(', ')}`);
+    }
+    return { config: parsed as HubConfig, reference: ref };
+  }
+}

--- a/packages/infra/src/hub/hub-resolver.ts
+++ b/packages/infra/src/hub/hub-resolver.ts
@@ -228,11 +228,13 @@ export class CompositeHubResolver implements HubResolver {
    * @param github Resolver for `github` references.
    * @param local Resolver for `local` references.
    * @param url Resolver for `url` references.
+   * @param artifactory
    */
   public constructor(
     private readonly github: HubResolver,
     private readonly local: HubResolver,
-    private readonly url: HubResolver
+    private readonly url: HubResolver,
+    private readonly artifactory?: HubResolver
   ) {}
 
   /**
@@ -247,6 +249,14 @@ export class CompositeHubResolver implements HubResolver {
     if (ref.type === 'local') {
       return this.local.resolve(ref);
     }
+    if (ref.type === 'artifactory') {
+      if (this.artifactory === undefined) {
+        throw new Error('No Artifactory hub resolver is configured.');
+      }
+      return this.artifactory.resolve(ref);
+    }
     return this.url.resolve(ref);
   }
 }
+
+export { ArtifactoryHubResolver } from './artifactory-hub-resolver';

--- a/packages/infra/src/index.ts
+++ b/packages/infra/src/index.ts
@@ -20,6 +20,7 @@ export * from './http';
 export * from './hub';
 export * from './process';
 export * from './resolvers';
+export * from './replicate';
 export * from './scaffolding';
 export * from './search';
 export * from './storage';

--- a/packages/infra/src/index.ts
+++ b/packages/infra/src/index.ts
@@ -8,6 +8,7 @@
  * adapters/ (Phase 3a).
  */
 export * from './adapters';
+export * from './artifactory';
 export * from './auth';
 export * from './clock';
 export * from './downloaders';

--- a/packages/infra/src/replicate/artifactory-publisher.ts
+++ b/packages/infra/src/replicate/artifactory-publisher.ts
@@ -1,0 +1,31 @@
+/* eslint-disable @stylistic/max-len, @stylistic/max-statements-per-line -- transport policy kept in one adapter */
+import type {
+  HttpClient,
+  HttpCredentialProvider,
+  ReplicationPublisherPort,
+} from '@ai-primitives-hub/core';
+import {
+  normalizeSourceRoot,
+  resolveConfinedObject,
+} from '../artifactory/published-object-url';
+
+export class ArtifactoryReplicationPublisher implements ReplicationPublisherPort {
+  private readonly root: URL;
+  public constructor(private readonly http: HttpClient, private readonly credentials: HttpCredentialProvider, sourceRoot: string, private readonly allowUnverifiedExisting = false) {
+    this.root = normalizeSourceRoot(sourceRoot);
+  }
+
+  public async publish(path: string, data: Uint8Array, mediaType: string): Promise<'uploaded' | 'skipped-existing' | 'skipped-unverified'> {
+    const url = resolveConfinedObject(this.root, path).href; const headers = { ...(await this.credentials.headersFor(url, { sourceId: this.root.href, trustedOrigin: this.root.origin, trustedPathPrefix: this.root.pathname })), Accept: '*/*' }; const digest = await import('node:crypto').then(({ createHash }) => createHash('sha256').update(data).digest('hex')); const head = await this.http.fetch({ url, method: 'HEAD', headers }); if (head.statusCode === 200 || head.statusCode === 204) {
+      const remote = head.headers['x-checksum-sha256'] ?? head.headers['x-artifactory-checksum-sha256']; if (remote?.toLowerCase() === digest) {
+        return 'skipped-existing';
+      } if (this.allowUnverifiedExisting) {
+        return 'skipped-unverified';
+      } throw new Error(`Existing Artifactory object cannot be verified or conflicts at ${path}; publication stopped.`);
+    } if (head.statusCode !== 404 && head.statusCode !== 410) {
+      throw new Error(`Artifactory HEAD failed for ${path}: HTTP ${String(head.statusCode)}`);
+    } const response = await this.http.fetch({ url, method: 'PUT', headers: { ...headers, 'Content-Type': mediaType, 'X-Checksum-Sha256': digest }, body: data }); if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw new Error(`Artifactory upload failed for ${path}: HTTP ${String(response.statusCode)}`);
+    } return 'uploaded';
+  }
+}

--- a/packages/infra/src/replicate/cache.ts
+++ b/packages/infra/src/replicate/cache.ts
@@ -1,0 +1,32 @@
+/* eslint-disable @stylistic/max-len, @stylistic/max-statements-per-line -- atomic cache adapter */
+import {
+  createHash,
+} from 'node:crypto';
+import {
+  promises as fs,
+} from 'node:fs';
+import * as path from 'node:path';
+import type {
+  ReplicationCache,
+} from './github-release-source';
+
+export class FileReplicationCache implements ReplicationCache {
+  public constructor(private readonly root: string) {}
+  private file(key: string): string {
+    return path.join(this.root, createHash('sha256').update(key).digest('hex'));
+  }
+
+  public async get(key: string): Promise<Uint8Array | undefined> {
+    try {
+      return await fs.readFile(this.file(key));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return undefined;
+      } throw error;
+    }
+  }
+
+  public async set(key: string, value: Uint8Array): Promise<void> {
+    await fs.mkdir(this.root, { recursive: true, mode: 0o700 }); await fs.chmod(this.root, 0o700); const target = this.file(key); const temporary = `${target}.tmp-${process.pid}-${Date.now()}`; await fs.writeFile(temporary, value, { mode: 0o600 }); await fs.rename(temporary, target); await fs.chmod(target, 0o600);
+  }
+}

--- a/packages/infra/src/replicate/github-release-source.ts
+++ b/packages/infra/src/replicate/github-release-source.ts
@@ -1,0 +1,58 @@
+import type {
+  GitHubApi,
+  ReplicationCandidate,
+  ReplicationSourcePort,
+} from '@ai-primitives-hub/core';
+import {
+  normalizedReleaseVersion,
+  stableReplicatedBundleId,
+} from '@ai-primitives-hub/core';
+/* eslint-disable @stylistic/max-len, @stylistic/max-statements-per-line, @typescript-eslint/naming-convention, @typescript-eslint/member-ordering -- focused GitHub adapter */
+import * as yaml from 'js-yaml';
+
+interface ReleaseAsset { name?: string; url?: string; size?: number }
+interface Release { tag_name?: string; name?: string; published_at?: string; draft?: boolean; assets?: ReleaseAsset[] }
+export interface ReplicationCache { get(key: string): Promise<Uint8Array | undefined>; set(key: string, value: Uint8Array): Promise<void> }
+export class GitHubReleaseSource implements ReplicationSourcePort {
+  public constructor(private readonly api: GitHubApi, private readonly cache?: ReplicationCache, private readonly budget = 600) {}
+  private used = 0;
+  private async get<T>(key: string, load: () => Promise<T>, encode: (value: T) => Uint8Array, decode: (value: Uint8Array) => T): Promise<T> {
+    const cached = await this.cache?.get(key); if (cached) {
+      return decode(cached);
+    } if (++this.used > this.budget) {
+      throw new Error(`GitHub request budget (${this.budget}) exhausted; rerun with the same cache directory.`);
+    } const value = await load(); await this.cache?.set(key, encode(value)); return value;
+  }
+
+  public get requestCount(): number {
+    return this.used;
+  }
+
+  public async getHubConfig(ownerRepo: string, ref: string): Promise<Record<string, unknown>> {
+    const data = await this.get(`hub:${ownerRepo}:${ref}`, () => this.api.getJson<{ content: string }>(`/repos/${ownerRepo}/contents/hub-config.yml?ref=${encodeURIComponent(ref)}`), (value) => new TextEncoder().encode(value.content), (bytes) => ({ content: new TextDecoder().decode(bytes) })); const text = Buffer.from(data.content.replace(/\s/g, ''), 'base64').toString('utf8'); const parsed = yaml.load(text); if (!parsed || typeof parsed !== 'object') {
+      throw new Error('source hub-config.yml must be a mapping');
+    } return parsed as Record<string, unknown>;
+  }
+
+  public async listReleaseCandidates(owner: string, repo: string, sourceId: string): Promise<ReplicationCandidate[]> {
+    const releases = await this.get(`releases:${owner}/${repo}`, () => this.api.getJson<Release[]>(`/repos/${owner}/${repo}/releases?per_page=100`), (value) => new TextEncoder().encode(JSON.stringify(value)), (bytes) => JSON.parse(new TextDecoder().decode(bytes)) as Release[]); const result: ReplicationCandidate[] = []; for (const release of releases) {
+      if (release.draft) {
+        continue;
+      } const assets = release.assets ?? []; const manifest = assets.find((asset) => ['deployment-manifest.yml', 'deployment-manifest.yaml', 'deployment-manifest.json'].includes(asset.name ?? '')); const archive = assets.find((asset) => asset.name?.endsWith('.zip')); if (!manifest?.url || !archive?.url || !manifest.name) {
+        continue;
+      } const manifestBytes = await this.get(`manifest:${manifest.url}`, () => this.api.download(manifest.url!), (value) => value, (value) => value); let parsed: unknown; try {
+        parsed = manifest.name.endsWith('.json') ? JSON.parse(new TextDecoder().decode(manifestBytes)) : yaml.load(new TextDecoder().decode(manifestBytes));
+      } catch {
+        continue;
+      } if (!parsed || typeof parsed !== 'object') {
+        continue;
+      } const version = normalizedReleaseVersion(parsed as Record<string, unknown>, release.tag_name ?? ''); if (!version) {
+        continue;
+      } const bundleId = stableReplicatedBundleId(`${owner}/${repo}`, parsed as Record<string, unknown>); result.push({ sourceId, repo: `${owner}/${repo}`, tag: release.tag_name ?? '', publishedAt: release.published_at ?? '', releaseName: release.name ?? '', manifest: parsed as Record<string, unknown>, manifestBytes, manifestName: manifest.name, archiveUrl: archive.url, archiveSize: archive.size ?? 0, version, bundleId });
+    } return result;
+  }
+
+  public downloadArchive(candidate: ReplicationCandidate): Promise<Uint8Array> {
+    return this.get(`archive:${candidate.archiveUrl}`, () => this.api.download(candidate.archiveUrl), (value) => value, (value) => value);
+  }
+}

--- a/packages/infra/src/replicate/index.ts
+++ b/packages/infra/src/replicate/index.ts
@@ -1,0 +1,3 @@
+export * from './cache';
+export * from './github-release-source';
+export * from './artifactory-publisher';

--- a/packages/infra/src/resolvers/artifactory-resolver.ts
+++ b/packages/infra/src/resolvers/artifactory-resolver.ts
@@ -1,0 +1,40 @@
+/* eslint-disable @stylistic/max-len -- compact resolver mapping */
+import {
+  type ArtifactorySourceIndex,
+  type BundleResolver,
+  type BundleSpec,
+  compareSemVer,
+  type Installable,
+  type RegistrySource,
+  validateArtifactorySourceIndex,
+} from '@ai-primitives-hub/core';
+import {
+  ArtifactoryHttpClient,
+} from '../artifactory/http-client';
+
+export class ArtifactoryBundleResolver implements BundleResolver {
+  private index?: ArtifactorySourceIndex;
+  public constructor(private readonly source: RegistrySource, private readonly client: ArtifactoryHttpClient) {}
+  private async load(): Promise<ArtifactorySourceIndex> {
+    if (this.index) {
+      return this.index;
+    }
+    const result = await this.client.getIndex(this.source.config?.indexFile ?? 'index-v1.json');
+    const validation = validateArtifactorySourceIndex(result.value, this.source.hubSourceId ? { hubSourceId: this.source.hubSourceId } : undefined);
+    if (!validation.valid) {
+      throw new Error(`Invalid Artifactory index: ${validation.errors.join('; ')}`);
+    }
+    this.index = result.value as ArtifactorySourceIndex;
+    return this.index;
+  }
+
+  public async resolve(spec: BundleSpec): Promise<Installable | null> {
+    const candidates = (await this.load()).bundles.filter((entry) => entry.id === spec.bundleId && (spec.bundleVersion === undefined || spec.bundleVersion === 'latest' || entry.version === spec.bundleVersion));
+    if (candidates.length === 0) {
+      return null;
+    }
+    candidates.sort((a, b) => compareSemVer(b.version, a.version));
+    const selected = candidates[0];
+    return { ref: { sourceId: this.source.id, sourceType: 'artifactory', bundleId: selected.id, bundleVersion: selected.version, installed: false }, downloadUrl: this.client.urlFor(selected.archive.path), integrity: `sha256:${selected.archive.sha256}` };
+  }
+}

--- a/packages/infra/src/resolvers/artifactory-resolver.ts
+++ b/packages/infra/src/resolvers/artifactory-resolver.ts
@@ -5,6 +5,7 @@ import {
   type BundleSpec,
   compareSemVer,
   type Installable,
+  RegistryError,
   type RegistrySource,
   validateArtifactorySourceIndex,
 } from '@ai-primitives-hub/core';
@@ -22,7 +23,10 @@ export class ArtifactoryBundleResolver implements BundleResolver {
     const result = await this.client.getIndex(this.source.config?.indexFile ?? 'index-v1.json');
     const validation = validateArtifactorySourceIndex(result.value, this.source.hubSourceId ? { hubSourceId: this.source.hubSourceId } : undefined);
     if (!validation.valid) {
-      throw new Error(`Invalid Artifactory index: ${validation.errors.join('; ')}`);
+      throw new RegistryError({
+        code: 'ARTIFACTORY.INDEX_INVALID',
+        message: `Invalid Artifactory index: ${validation.errors.join('; ')}`
+      });
     }
     this.index = result.value as ArtifactorySourceIndex;
     return this.index;

--- a/packages/infra/src/resolvers/index.ts
+++ b/packages/infra/src/resolvers/index.ts
@@ -3,6 +3,7 @@
  * @module resolvers
  */
 export * from './local-resolver';
+export * from './artifactory-resolver';
 export * from './github-resolver';
 export * from './awesome-copilot-resolver';
 export * from './skills-resolver';

--- a/packages/infra/src/resolvers/resolver-registry.ts
+++ b/packages/infra/src/resolvers/resolver-registry.ts
@@ -31,11 +31,22 @@ import type {
   BundleResolver,
   FileSystem,
   GitHubApi,
+  HttpClient,
+  HttpCredentialProvider,
   RegistrySource,
 } from '@ai-primitives-hub/core';
 import {
+  AnonymousCredentialProvider,
+} from '../artifactory/credentials';
+import {
+  ArtifactoryHttpClient,
+} from '../artifactory/http-client';
+import {
   parseGitHubRepositoryTarget,
 } from '../http/github-repository-target';
+import {
+  ArtifactoryBundleResolver,
+} from './artifactory-resolver';
 import {
   AwesomeCopilotBundleResolver,
 } from './awesome-copilot-resolver';
@@ -50,9 +61,13 @@ import {
 
 export interface SourceDispatcherOptions {
   /** Shared GitHub API client, reused across every GitHub-backed resolver. */
-  githubApi: GitHubApi;
+  githubApi?: GitHubApi;
   /** Optional source-bound client factory; overrides `githubApi` for remote sources. */
   githubApiFactory?: (source: RegistrySource) => GitHubApi;
+  /** HTTP transport used by non-GitHub remote sources. */
+  http?: HttpClient;
+  /** Source-scoped credentials for Artifactory; defaults to anonymous. */
+  artifactoryCredentialProvider?: (source: RegistrySource) => HttpCredentialProvider;
   /** Filesystem abstraction for local sources. */
   fs: FileSystem;
 }
@@ -61,14 +76,18 @@ export interface SourceDispatcherOptions {
  * Dispatcher that selects the appropriate resolver based on source type.
  */
 export class SourceDispatcher {
-  private readonly githubApi: GitHubApi;
+  private readonly githubApi: GitHubApi | undefined;
   private readonly githubApiFactory: ((source: RegistrySource) => GitHubApi) | undefined;
   private readonly fs: FileSystem;
+  private readonly http: HttpClient | undefined;
+  private readonly artifactoryCredentialProvider: (source: RegistrySource) => HttpCredentialProvider;
 
   public constructor(opts: SourceDispatcherOptions) {
     this.githubApi = opts.githubApi;
     this.githubApiFactory = opts.githubApiFactory;
     this.fs = opts.fs;
+    this.http = opts.http;
+    this.artifactoryCredentialProvider = opts.artifactoryCredentialProvider ?? (() => new AnonymousCredentialProvider());
   }
 
   /**
@@ -82,7 +101,11 @@ export class SourceDispatcher {
   }
 
   private apiFor(source: RegistrySource): GitHubApi {
-    return this.githubApiFactory?.(source) ?? this.githubApi;
+    const api = this.githubApiFactory?.(source) ?? this.githubApi;
+    if (api === undefined) {
+      throw new Error(`A GitHub API is required for source type: ${source.type}`);
+    }
+    return api;
   }
 
   /**
@@ -92,6 +115,15 @@ export class SourceDispatcher {
    */
   public resolverFor(source: RegistrySource): BundleResolver | null {
     switch (source.type) {
+      case 'artifactory': {
+        if (this.http === undefined) {
+          throw new Error('An HttpClient is required for Artifactory sources.');
+        }
+        return new ArtifactoryBundleResolver(
+          source,
+          new ArtifactoryHttpClient(this.http, this.artifactoryCredentialProvider(source), source.url)
+        );
+      }
       case 'github': {
         return new GitHubBundleResolver({
           repoSlug: this.repoSlug(source.url),
@@ -145,7 +177,7 @@ export class SourceDispatcher {
    * @returns true if the source type is remote and requires a resolver.
    */
   public isRemote(sourceType: string): boolean {
-    const remoteTypes = ['github', 'awesome-copilot', 'skills', 'apm'];
+    const remoteTypes = ['github', 'awesome-copilot', 'skills', 'apm', 'artifactory'];
     return remoteTypes.includes(sourceType);
   }
 }

--- a/packages/infra/test/artifactory-infra.test.ts
+++ b/packages/infra/test/artifactory-infra.test.ts
@@ -19,6 +19,7 @@ import {
   it,
 } from 'vitest';
 import {
+  ArtifactoryBundleDownloader,
   ArtifactoryBundleResolver,
   ArtifactoryEnvCredentialProvider,
   ArtifactoryHttpClient,
@@ -159,6 +160,25 @@ describe('Artifactory HTTP client', () => {
       source.url
     );
     await expect(denied.getIndex()).rejects.toMatchObject({ code: 'ARTIFACTORY.ACCESS_DENIED' });
+  });
+});
+
+describe('Artifactory downloader', () => {
+  it('enforces resolver-provided archive integrity', async () => {
+    const downloader = new ArtifactoryBundleDownloader({
+      getBytesAt: async () => archive
+    } as never);
+    const installable = {
+      ref: { sourceId: source.id, sourceType: 'artifactory', bundleId: 'bundle', bundleVersion: '1.0.0', installed: false },
+      downloadUrl: `${source.url}/bundles/bundle/1.0.0/bundle.zip`,
+      integrity: `sha256:${sha256(archive)}`
+    };
+    await expect(downloader.download(installable)).resolves.toMatchObject({ sha256: sha256(archive) });
+
+    const invalid = new ArtifactoryBundleDownloader({
+      getBytesAt: async () => new TextEncoder().encode('tampered')
+    } as never);
+    await expect(invalid.download(installable)).rejects.toMatchObject({ code: 'BUNDLE.ARCHIVE_INTEGRITY_MISMATCH' });
   });
 });
 

--- a/packages/infra/test/artifactory-infra.test.ts
+++ b/packages/infra/test/artifactory-infra.test.ts
@@ -1,0 +1,190 @@
+import {
+  createHash,
+} from 'node:crypto';
+import type {
+  ArtifactorySourceIndex,
+  HttpClient,
+  HttpCredentialProvider,
+  HttpRequest,
+  HttpResponse,
+  RegistrySource,
+  SourceRequestContext,
+} from '@ai-primitives-hub/core';
+import {
+  RegistryError,
+} from '@ai-primitives-hub/core';
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  ArtifactoryBundleResolver,
+  ArtifactoryEnvCredentialProvider,
+  ArtifactoryHttpClient,
+  ArtifactorySourceAdapter,
+  normalizeSourceRoot,
+  resolveConfinedObject,
+} from '../src';
+
+const archive = new TextEncoder().encode('bundle bytes');
+const sha256 = (bytes: Uint8Array): string => createHash('sha256').update(bytes).digest('hex');
+
+const source: RegistrySource = {
+  id: 'study-source',
+  name: 'Study source',
+  type: 'artifactory',
+  url: 'http://127.0.0.1:8081/artifactory/example-repo-local/ai-primitives-study',
+  enabled: true,
+  priority: 0,
+  config: { indexFile: 'index-v1.json', authMode: 'bearer', credentialRef: 'ARTIFACTORY_TOKEN' }
+};
+
+const index = (): ArtifactorySourceIndex => ({
+  formatVersion: 1,
+  source: { id: 'study-source', name: 'Study source', updatedAt: '2026-09-02T00:00:00Z' },
+  bundles: [{
+    id: 'bundle',
+    version: '1.0.0',
+    name: 'Bundle',
+    description: 'A bundle',
+    author: 'Study',
+    environments: [],
+    tags: [],
+    lastUpdated: '2026-09-02T00:00:00Z',
+    dependencies: [],
+    license: 'Apache-2.0',
+    manifest: { path: 'bundles/bundle/1.0.0/deployment-manifest.yml', size: 10, sha256: 'a'.repeat(64), mediaType: 'application/yaml' },
+    archive: { path: 'bundles/bundle/1.0.0/bundle.zip', size: archive.byteLength, sha256: sha256(archive), mediaType: 'application/zip' }
+  }]
+});
+
+class FakeHttpClient implements HttpClient {
+  public readonly requests: HttpRequest[] = [];
+  public constructor(private readonly responses: HttpResponse[]) {}
+  public fetch(request: HttpRequest): Promise<HttpResponse> {
+    this.requests.push(request);
+    const response = this.responses[Math.min(this.requests.length - 1, this.responses.length - 1)];
+    return Promise.resolve({ ...response, finalUrl: response.finalUrl || request.url });
+  }
+}
+
+class FakeCredentials implements HttpCredentialProvider {
+  public readonly contexts: SourceRequestContext[] = [];
+  public headersFor(_url: string, context: SourceRequestContext): Promise<Readonly<Record<string, string>>> {
+    this.contexts.push(context);
+    return Promise.resolve({ Authorization: 'Bearer test-token' });
+  }
+}
+
+const makeResponse = (statusCode: number, body: Uint8Array, headers: Record<string, string> = {}): HttpResponse => ({
+  statusCode,
+  body,
+  finalUrl: '',
+  headers
+});
+
+const httpClientForIndexAndArchive = (): FakeHttpClient => new FakeHttpClient([
+  makeResponse(200, new TextEncoder().encode(JSON.stringify(index())), { etag: 'index-1' }),
+  makeResponse(200, archive, { 'content-length': String(archive.byteLength) })
+]);
+
+describe('Artifactory source URL confinement', () => {
+  it('accepts loopback HTTP and rejects non-loopback HTTP', () => {
+    expect(normalizeSourceRoot(source.url).protocol).toBe('http:');
+    expect(() => normalizeSourceRoot('http://artifactory.example/source')).toThrow(RegistryError);
+  });
+
+  it('rejects traversal, encoded paths, and source-root siblings', () => {
+    const root = normalizeSourceRoot(source.url);
+    expect(resolveConfinedObject(root, 'bundles/a.zip').href)
+      .toBe(`${source.url}/bundles/a.zip`);
+    expect(() => resolveConfinedObject(root, '../secret')).toThrow();
+    expect(() => resolveConfinedObject(root, 'bundles/%2e%2e/secret')).toThrow();
+    expect(() => resolveConfinedObject(root, 'https://evil.example/a')).toThrow();
+    expect(() => resolveConfinedObject(root, 'https://127.0.0.1:8081/artifactory/other/a')).toThrow();
+  });
+});
+
+describe('Artifactory credentials', () => {
+  it('returns a Bearer header only for the configured source root', async () => {
+    const provider = new ArtifactoryEnvCredentialProvider(
+      { ARTIFACTORY_TOKEN: 'test-token' },
+      'ARTIFACTORY_TOKEN',
+      source.url
+    );
+    const context: SourceRequestContext = {
+      sourceId: source.id,
+      trustedOrigin: new URL(source.url).origin,
+      trustedPathPrefix: new URL(source.url).pathname + '/'
+    };
+    await expect(provider.headersFor(`${source.url}/index-v1.json`, context))
+      .resolves.toEqual({ Authorization: 'Bearer test-token' });
+    await expect(provider.headersFor('http://127.0.0.1:8081/artifactory/other/index.json', context))
+      .rejects.toThrow(RegistryError);
+  });
+});
+
+describe('Artifactory HTTP client', () => {
+  it('fetches an index with scoped credentials and handles 304', async () => {
+    const http = new FakeHttpClient([
+      makeResponse(200, new TextEncoder().encode('{}'), { etag: 'index-1' }),
+      makeResponse(304, new Uint8Array(), { etag: 'index-1' })
+    ]);
+    const credentials = new FakeCredentials();
+    const client = new ArtifactoryHttpClient(http, credentials, source.url);
+    await expect(client.getIndex()).resolves.toMatchObject({ status: 'fresh', etag: 'index-1' });
+    await expect(client.getIndex('index-v1.json', 'index-1')).resolves.toMatchObject({ status: 'not-modified' });
+    expect(http.requests[0].headers?.Authorization).toBe('Bearer test-token');
+    expect(http.requests[1].headers?.['If-None-Match']).toBe('index-1');
+  });
+
+  it('retries transient responses and maps auth failures', async () => {
+    const sleeps: number[] = [];
+    const http = new FakeHttpClient([
+      makeResponse(503, new Uint8Array()),
+      makeResponse(200, new TextEncoder().encode('{}'))
+    ]);
+    const client = new ArtifactoryHttpClient(http, new FakeCredentials(), source.url, {
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      }
+    });
+    await expect(client.getIndex()).resolves.toMatchObject({ status: 'fresh' });
+    expect(sleeps).toHaveLength(1);
+
+    const denied = new ArtifactoryHttpClient(
+      new FakeHttpClient([makeResponse(403, new Uint8Array())]),
+      new FakeCredentials(),
+      source.url
+    );
+    await expect(denied.getIndex()).rejects.toMatchObject({ code: 'ARTIFACTORY.ACCESS_DENIED' });
+  });
+});
+
+describe('Artifactory source adapter and resolver', () => {
+  it('maps the static index to Bundle and verifies downloaded bytes', async () => {
+    const http = httpClientForIndexAndArchive();
+    const adapter = new ArtifactorySourceAdapter(
+      source,
+      new ArtifactoryHttpClient(http, new FakeCredentials(), source.url)
+    );
+    const bundles = await adapter.fetchBundles();
+    expect(bundles[0]).toMatchObject({ id: 'bundle', version: '1.0.0', sourceId: source.id, size: '12 B' });
+    await expect(adapter.downloadBundle(bundles[0])).resolves.toEqual(Buffer.from(archive));
+  });
+
+  it('resolves the highest version for latest and returns archive integrity', async () => {
+    const data = index();
+    data.bundles.push({ ...data.bundles[0], version: '2.0.0' });
+    const http = new FakeHttpClient([makeResponse(200, new TextEncoder().encode(JSON.stringify(data)))]);
+    const resolver = new ArtifactoryBundleResolver(
+      source,
+      new ArtifactoryHttpClient(http, new FakeCredentials(), source.url)
+    );
+    await expect(resolver.resolve({ bundleId: 'bundle' })).resolves.toMatchObject({
+      ref: { bundleVersion: '2.0.0', sourceType: 'artifactory' },
+      integrity: `sha256:${sha256(archive)}`
+    });
+  });
+});

--- a/packages/infra/test/hub/hub-resolver.test.ts
+++ b/packages/infra/test/hub/hub-resolver.test.ts
@@ -17,6 +17,7 @@ import {
   vi,
 } from 'vitest';
 import {
+  ArtifactoryHubResolver,
   CompositeHubResolver,
   GitHubHubResolver,
   LocalHubResolver,
@@ -181,6 +182,38 @@ describe('GitHubHubResolver', () => {
     expect(requests).toHaveLength(2);
     expect(requests[0].headers?.Authorization).toBe('token generic-token');
     expect(requests[1].headers?.Authorization).toBe('token app-token');
+  });
+});
+
+describe('ArtifactoryHubResolver', () => {
+  it('reads the confined config file with bearer credentials and never falls back', async () => {
+    const requests: HttpRequest[] = [];
+    const http: HttpClient = {
+      fetch: async (request) => {
+        requests.push(request);
+        return { statusCode: 200, body: new TextEncoder().encode(VALID_YAML), finalUrl: request.url, headers: {} };
+      }
+    };
+    const resolver = new ArtifactoryHubResolver(http, {
+      headersFor: async () => ({ Authorization: 'Bearer private-token' })
+    }, 'https://artifactory.example/repo/hub');
+
+    const ref: HubReference = { type: 'artifactory', location: 'https://artifactory.example/repo/hub', configFile: 'hub-config.yml', authMode: 'bearer', credentialRef: 'PRIVATE_HUB' };
+    await resolver.resolve(ref);
+
+    expect(requests[0].url).toBe('https://artifactory.example/repo/hub/hub-config.yml');
+    expect(requests[0].headers?.Authorization).toBe('Bearer private-token');
+    expect(JSON.stringify(ref)).not.toContain('private-token');
+  });
+
+  it('rejects config path traversal', async () => {
+    const resolver = new ArtifactoryHubResolver(
+      fakeHttpClient(() => ({ statusCode: 200, body: new Uint8Array(), finalUrl: '', headers: {} })),
+      { headersFor: async () => ({}) },
+      'https://artifactory.example/repo/hub'
+    );
+    await expect(resolver.resolve({ type: 'artifactory', location: 'https://artifactory.example/repo/hub', configFile: '../secret.yml' }))
+      .rejects.toThrow(/confined|path/i);
   });
 });
 

--- a/packages/infra/test/replicate.test.ts
+++ b/packages/infra/test/replicate.test.ts
@@ -1,0 +1,71 @@
+import {
+  createHash,
+} from 'node:crypto';
+import type {
+  HttpClient,
+  HttpCredentialProvider,
+  HttpRequest,
+  HttpResponse,
+} from '@ai-primitives-hub/core';
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  ArtifactoryReplicationPublisher,
+} from '../src/replicate/artifactory-publisher';
+
+const bytes = new TextEncoder().encode('published object');
+const sha256 = createHash('sha256').update(bytes).digest('hex');
+const credentials: HttpCredentialProvider = {
+  headersFor: async () => ({ Authorization: 'Bearer publisher' })
+};
+
+class FakeHttp implements HttpClient {
+  public readonly requests: HttpRequest[] = [];
+  public constructor(private readonly responses: HttpResponse[]) {}
+  public async fetch(request: HttpRequest): Promise<HttpResponse> {
+    this.requests.push(request);
+    return this.responses[Math.min(this.requests.length - 1, this.responses.length - 1)];
+  }
+}
+
+const response = (statusCode: number, headers: Record<string, string> = {}): HttpResponse => ({
+  statusCode,
+  body: new Uint8Array(),
+  finalUrl: 'https://art.example/repo/bundles/object',
+  headers
+});
+
+describe('ArtifactoryReplicationPublisher', () => {
+  it('uploads after a missing HEAD and sends the expected digest/auth headers', async () => {
+    const http = new FakeHttp([response(404), response(201)]);
+    const publisher = new ArtifactoryReplicationPublisher(http, credentials, 'https://art.example/repo');
+
+    await expect(publisher.publish('bundles/object', bytes, 'application/zip')).resolves.toBe('uploaded');
+    expect(http.requests.map((request) => request.method)).toEqual(['HEAD', 'PUT']);
+    expect(http.requests[1].headers).toMatchObject({
+      Authorization: 'Bearer publisher',
+      'X-Checksum-Sha256': sha256,
+      'Content-Type': 'application/zip'
+    });
+  });
+
+  it('skips an existing object when its remote digest matches', async () => {
+    const http = new FakeHttp([response(200, { 'x-checksum-sha256': sha256 })]);
+    const publisher = new ArtifactoryReplicationPublisher(http, credentials, 'https://art.example/repo');
+
+    await expect(publisher.publish('bundles/object', bytes, 'application/zip')).resolves.toBe('skipped-existing');
+    expect(http.requests).toHaveLength(1);
+  });
+
+  it('fails closed for an existing object without a verifiable digest', async () => {
+    const http = new FakeHttp([response(200)]);
+    const publisher = new ArtifactoryReplicationPublisher(http, credentials, 'https://art.example/repo');
+
+    await expect(publisher.publish('bundles/object', bytes, 'application/zip'))
+      .rejects.toThrow(/cannot be verified|conflicts/i);
+    expect(http.requests).toHaveLength(1);
+  });
+});

--- a/packages/infra/test/resolvers/source-dispatcher.test.ts
+++ b/packages/infra/test/resolvers/source-dispatcher.test.ts
@@ -1,6 +1,8 @@
 import type {
   FileSystem,
   GitHubApi,
+  HttpClient,
+  HttpCredentialProvider,
   RegistrySource,
 } from '@ai-primitives-hub/core';
 import {
@@ -14,6 +16,8 @@ import {
 
 const fs = {} as FileSystem;
 const api = {} as GitHubApi;
+const http = {} as HttpClient;
+const credentials = {} as HttpCredentialProvider;
 
 const source: RegistrySource = {
   id: 'source',
@@ -25,6 +29,22 @@ const source: RegistrySource = {
 };
 
 describe('SourceDispatcher', () => {
+  it('dispatches Artifactory through its HTTP client and source credential provider', () => {
+    const artifactory: RegistrySource = {
+      ...source,
+      type: 'artifactory',
+      url: 'https://artifactory.example/repo'
+    };
+    const dispatcher = new SourceDispatcher({
+      fs,
+      http,
+      artifactoryCredentialProvider: () => credentials
+    });
+
+    expect(dispatcher.resolverFor(artifactory)).not.toBeNull();
+    expect(dispatcher.isRemote('artifactory')).toBe(true);
+  });
+
   it('uses a source-bound API factory for remote resolvers', () => {
     const seen: RegistrySource[] = [];
     const dispatcher = new SourceDispatcher({

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -82,6 +82,7 @@ const sidebars: SidebarsConfig = {
         { type: "doc", id: "reference/settings", label: "Settings" },
         { type: "doc", id: "reference/adapter-api", label: "Adapter API" },
         { type: "doc", id: "reference/hub-schema", label: "Hub Schema" },
+        { type: "doc", id: "reference/hub-replication", label: "Hub Replication" },
       ],
     },
   ],

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -1,8 +1,10 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "paths": {
+      "@site/*": ["./*"]
+    },
     "target": "ES2020",
     "jsx": "react-jsx",
     "strict": true,


### PR DESCRIPTION
## Description

This PR adds an explicit JFrog Artifactory distribution channel for AI Primitives Hub and a CLI workflow for replicating GitHub-backed hub content into an Artifactory-hosted hub tree.

The implementation keeps GitHub as the canonical authoring and provenance channel while allowing CLI and VS Code consumers to discover, install, update, and replay bundles from a private Artifactory repository without runtime access to a private GitHub organization. It uses a generic repository plus a project-owned, schema-validated static index rather than coupling the core contract to beta JFrog Agent Packages, Skills, or Agent Plugins APIs.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test coverage improvement
- [x] 🔧 Configuration/build changes

## Related Issues

- Closes #436 


## Changes Made

- Added the `artifactory` source contract across core types, hub/lockfile schemas, validation, source identity handling, and the published `index-v1.json` schema.
- Added Artifactory infrastructure adapters for:
  - static-index catalog discovery;
  - authenticated object retrieval;
  - source-root/path confinement and URL construction;
  - archive size and SHA-256 verification;
  - anonymous and Bearer credential providers; and
  - Artifactory hub-config resolution.
- Reused the shared app installation and lockfile pipelines for Artifactory sources, including exact version/path/checksum replay behavior.
- Added CLI support for Artifactory source configuration and installation, update, validation, and hub workflows.
- Added `ai-primitives-hub hub replicate` with:
  - `latest` and `all` selection modes;
  - bounded workers and GitHub request budgets;
  - metadata/archive caching and resumable publication;
  - dry-run and explicit `--publish --review` gates;
  - same-digest reuse and conflicting/unverifiable-object protection; and
  - publication ordering of bundle objects, index, then hub configuration.
- Added VS Code support for Artifactory Hub import and source setup, including:
  - repository-root URL guidance instead of Artifactory UI URLs;
  - private-hub Bearer credential enrollment;
  - SecretStorage-backed token values with reference-only persisted configuration;
  - reuse of hub credentials for Artifactory sources; and
  - loopback HTTP support for local testing with a warning while retaining HTTPS requirements for non-loopback targets.
- Enforced explicit provider selection with no implicit GitHub fallback for Artifactory authentication, authorization, path, schema, manifest, or integrity failures.
- Added core, infra, app, CLI, and extension tests for source contracts, adapters, credential handling, integrity checks, replication, lockfile behavior, and user-facing command flows.
- Added reference and user/author documentation for Artifactory sources, private hub workflows, and replication.

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing completed
- [ ] All existing tests pass

### Automated validation completed

- `pnpm install --frozen-lockfile` — passed; lockfile passed supply-chain policy verification.
- `pnpm -C packages -r build` — passed.
- `pnpm -C packages -r test` — core, app, CLI, website, and extension unit portions passed.
- `pnpm -C lib test` — 173 tests passed.
- `pnpm run test:unit` — 2,237 tests passed, 17 pending.
- `pnpm -C apps/vscode-extension run lint:fix` — completed with existing lint warnings and no errors.
- `pnpm run package:vsix` — passed and produced `prompt-registry-0.0.3.vsix`.


### Manual Testing Steps

1. Prepare a private Artifactory generic repository and a complete hub tree containing `hub-config.yml`, source index, deployment manifests, and ZIP archives. Use separate read-only consumer and deploy-only publisher principals.
2. Run `ai-primitives-hub hub replicate` in dry-run mode, review selected versions, unresolved profile references, request budget, target prefix, and expected archive inventory.
3. Publish only with explicit `--publish --review`, then verify that objects are uploaded before `index-v1.json` and `hub-config.yml`, and that a rerun reuses verified same-digest objects.
4. In a clean CLI environment without GitHub credentials, import the generated hub with `hub add --type artifactory`, sync it, install a bundle, update it, and replay its lockfile using only the Artifactory credential reference.
5. In a clean VS Code profile, import the Artifactory Hub, enroll the Bearer token through the SecretStorage prompt, browse the marketplace, install/update a bundle, restart VS Code, and verify re-authentication.
6. Exercise negative cases: invalid credentials, 401/403, unsafe paths, malformed index, checksum mismatch, manifest identity mismatch, ETag/304 reuse, consumer PUT/DELETE denial, and no GitHub fallback.

### Tested On

- [x] Linux
- [ ] macOS
- [ ] Windows

- [ ] VS Code Stable — integration runner was attempted but blocked by the downloaded binary's unsupported `--user-data-dir` option.
- [ ] VS Code Insiders

## Screenshots

Not applicable. The feature is primarily a source, authentication, integrity, CLI, and distribution workflow change.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of the code and branch history
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Documentation

- [x] README.md updated
- [x] JSDoc comments added/updated where new public behavior requires them
- [ ] No documentation changes needed

Documentation added or updated includes the Artifactory source workflow, hub replication command reference, publishing guidance, and user-facing source configuration guidance.

## Additional Notes

- Artifactory is an explicit source/channel in the MVP. There is no transparent GitHub-to-Artifactory fallback.
- GitHub release content is copied as verified release objects; the target hub retains GitHub provenance metadata but does not require GitHub access at runtime.
- Credentials are reference-only in hub configuration and lockfiles. CLI references resolve through the environment; VS Code token values are stored in SecretStorage.
- The generated hub tree is designed for a generic Artifactory repository and avoids AQL, recursive listing, and JFrog CLI/APM runtime dependencies.
- A real target qualification still needs to confirm the target Artifactory version/edition, endpoint behavior, ETag semantics, and least-privilege publisher permissions, especially publisher DELETE denial.
- The tracked generated change under `github-actions/validate-collections/dist/index.js` is validation/build output and is not part of the feature diff described by this PR.

## Reviewer Guidelines

Please pay special attention to:

- credential boundaries: tokens must not enter hub YAML, indexes, lockfiles, URLs, logs, caches, or JSON output;
- exact-origin and path-scoped authorization, redirect handling, and fail-closed 401/403 behavior;
- index path validation, SemVer selection, archive size/hash verification, and manifest identity checks before installation;
- replication publication ordering, request budgets, cache/resume behavior, conflict handling, and the explicit review gate;
- source identity and lockfile replay when equivalent content exists in GitHub and Artifactory; and
- extension layering: Artifactory behavior should remain in shared `core`/`infra`/`app` code, with VS Code limited to prompts, SecretStorage, and delivery concerns.

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.**
