### PR TITLE
fix(hub): fall back to owner/repo when a full GitHub URL is given

### DIFF
--- a/apps/vscode-extension/src/commands/hub-commands.ts
+++ b/apps/vscode-extension/src/commands/hub-commands.ts
@@ -6,6 +6,9 @@
 import * as yaml from 'js-yaml';
 import * as vscode from 'vscode';
 import {
+  normalizeGitHubHubLocation,
+} from '@ai-primitives-hub/infra';
+import {
   HubManager,
 } from '../services/hub-manager';
 import {
@@ -169,11 +172,11 @@ export class HubCommands {
     switch (sourceType) {
       case 'github': {
         const location = await vscode.window.showInputBox({
-          prompt: 'Enter GitHub repository (e.g., owner/repo)',
-          placeHolder: 'owner/repo',
+          prompt: 'Enter GitHub repository URL or owner/repo',
+          placeHolder: 'https://github.com/owner/repo or owner/repo',
           validateInput: (value) => {
             if (!value || !value.includes('/')) {
-              return 'Please enter a valid GitHub repository (owner/repo)';
+              return 'Please enter a valid GitHub repository URL or owner/repo';
             }
             return null;
           },
@@ -190,10 +193,12 @@ export class HubCommands {
           ignoreFocusOut: true
         });
 
+        // Fall back to owner/repo when a full repo/blob URL was pasted instead.
+        const normalized = normalizeGitHubHubLocation(location, ref || undefined);
         return {
           type: 'github',
-          location,
-          ref: ref || undefined
+          location: normalized.location,
+          ref: normalized.ref
         };
       }
 

--- a/apps/vscode-extension/src/commands/hub-commands.ts
+++ b/apps/vscode-extension/src/commands/hub-commands.ts
@@ -3,11 +3,11 @@
  * Provides user interface for importing, listing, syncing, and deleting hubs
  */
 
-import * as yaml from 'js-yaml';
-import * as vscode from 'vscode';
 import {
   normalizeGitHubHubLocation,
 } from '@ai-primitives-hub/infra';
+import * as yaml from 'js-yaml';
+import * as vscode from 'vscode';
 import {
   HubManager,
 } from '../services/hub-manager';

--- a/packages/cli/src/commands/hub.ts
+++ b/packages/cli/src/commands/hub.ts
@@ -44,6 +44,7 @@ import {
   isGitHubAppAuthEnabled,
   NodeHttpClient,
   NodeProcessRunner,
+  normalizeGitHubHubLocation,
   parseHubConfig,
 } from '@ai-primitives-hub/infra';
 import type {
@@ -166,7 +167,7 @@ export class HubAddCommand extends BaseHubCommand {
 
       Options:
         --type <type>            Reference type: github (default), local, url
-        --location <ref>         GitHub owner/repo, local path, or URL
+        --location <ref>         GitHub owner/repo (or full repo/blob URL), local path, or URL
         --ref <branch>           Git branch, tag, or commit (GitHub only)
         --id <id>                Custom hub ID (defaults to repo name)
         --no-sync                Skip syncing after import
@@ -175,6 +176,7 @@ export class HubAddCommand extends BaseHubCommand {
 
       Examples:
         ai-primitives-hub hub add --location amadeus/copilot-hub
+        ai-primitives-hub hub add --location https://github.com/amadeus/copilot-hub
         ai-primitives-hub hub add --type local --location ./my-hub --id local-hub
     `
   });
@@ -202,14 +204,20 @@ export class HubAddCommand extends BaseHubCommand {
 
     const refType = (this.refType ?? 'github') as 'github' | 'local' | 'url';
     let location = this.refLocation;
+    let refRef = this.refRef;
     if (refType === 'local' && !path.isAbsolute(location)) {
       location = path.resolve(ctx.cwd(), location);
+    } else if (refType === 'github') {
+      // Fall back to owner/repo when a full repo/blob URL was passed instead.
+      const normalized = normalizeGitHubHubLocation(location, refRef);
+      location = normalized.location;
+      refRef = normalized.ref;
     }
 
     const id = await mgr.importHub({
       type: refType,
       location,
-      ref: this.refRef
+      ref: refRef
     }, this.hubId);
 
     // F-05: auto-use and auto-sync after import (unless flags disable)

--- a/packages/cli/test/commands/hub.test.ts
+++ b/packages/cli/test/commands/hub.test.ts
@@ -538,6 +538,49 @@ profiles: []
       const result = await run(['hub', 'add', '--type', 'local', '-o', 'json']);
       expect(result.exitCode).toBe(1);
     });
+
+    it('falls back to owner/repo when a full GitHub blob URL is given as --location (#351)', async () => {
+      const requests: HttpRequest[] = [];
+      const http: HttpClient = {
+        fetch: async (request: HttpRequest): Promise<HttpResponse> => {
+          requests.push(request);
+          return {
+            statusCode: 200,
+            body: new TextEncoder().encode(`version: 1.0.0
+metadata:
+  name: Remote Hub
+  description: d
+  maintainer: m
+  updatedAt: '2026-01-01T00:00:00Z'
+sources: []
+profiles: []
+`),
+            finalUrl: request.url,
+            headers: {}
+          };
+        }
+      };
+
+      const result = await runWithHttp(
+        [
+          'hub', 'add',
+          '--location', 'https://github.com/owner/repo/blob/main/hub-config.yml',
+          '--id', 'remote-hub', '-o', 'json'
+        ],
+        http,
+        {
+          HOME: workspace,
+          USERPROFILE: workspace,
+          XDG_CONFIG_HOME: path.join(workspace, 'xdg-config'),
+          XDG_CACHE_HOME: path.join(workspace, 'xdg-cache')
+        }
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(requests[0]?.url).toMatch(/^https:\/\/raw\.githubusercontent\.com\/owner\/repo\/main\/hub-config\.yml\?t=\d+$/);
+      const envelope = parseJson<{ id: string; location: string }>(result.stdout);
+      expect(envelope.data).toMatchObject({ id: 'remote-hub', location: 'owner/repo' });
+    });
   });
 
   describe('hub list --check', () => {

--- a/packages/infra/src/hub/hub-resolver.ts
+++ b/packages/infra/src/hub/hub-resolver.ts
@@ -27,8 +27,62 @@ import type {
 } from '@ai-primitives-hub/core';
 import * as yaml from 'js-yaml';
 import {
+  isGitHubHost,
+} from '../http/github-host';
+import {
   parseGitHubRepositoryTarget,
 } from '../http/github-repository-target';
+
+const GIT_SSH_PATTERN = /^git@([^:]+):(.+)$/u;
+
+/**
+ * Normalize a `github`-type hub location that may be a bare `owner/repo`
+ * slug or a full repository/file URL (e.g. a `/blob/<ref>/hub-config.yml`
+ * link copied from the GitHub UI, or an SSH clone URL) into the
+ * `owner/repo` slug the raw-content fetch expects. A branch/tag/commit
+ * carried by a `/blob/<ref>/...` or `/tree/<ref>` URL is used as the
+ * fallback `ref` only when the caller didn't already supply one
+ * explicitly. Bare slugs are returned unchanged, preserving existing
+ * behavior.
+ * @param location Raw location as entered by the user (slug or URL).
+ * @param explicitRef `ref` already set on the reference, if any — always wins over a URL-derived branch.
+ * @returns Normalized `owner/repo` slug and the resolved branch/tag/commit ref.
+ */
+export function normalizeGitHubHubLocation(
+  location: string,
+  explicitRef?: string
+): { location: string; ref?: string } {
+  const sshMatch = GIT_SSH_PATTERN.exec(location);
+  let url: URL | undefined;
+  try {
+    if (sshMatch !== null) {
+      url = new URL(`https://${sshMatch[1]}/${sshMatch[2]}`);
+    } else if (location.includes('://')) {
+      url = new URL(location);
+    }
+  } catch {
+    return { location, ref: explicitRef };
+  }
+
+  if (url === undefined || !isGitHubHost(url.hostname.toLowerCase())) {
+    return { location, ref: explicitRef };
+  }
+
+  const segments = url.pathname.replace(/^\/+|\/+$/gu, '').split('/');
+  if (segments.length < 2 || segments[0].length === 0 || segments[1].length === 0) {
+    return { location, ref: explicitRef };
+  }
+
+  const [owner, repoSegment, kind, refSegment] = segments;
+  const repository = repoSegment.endsWith('.git') ? repoSegment.slice(0, -4) : repoSegment;
+  const normalizedLocation = `${owner}/${repository}`;
+
+  if ((kind === 'blob' || kind === 'tree') && refSegment !== undefined && refSegment.length > 0) {
+    return { location: normalizedLocation, ref: explicitRef ?? refSegment };
+  }
+
+  return { location: normalizedLocation, ref: explicitRef };
+}
 
 export interface ResolvedHub {
   config: HubConfig;
@@ -178,10 +232,11 @@ export class GitHubHubResolver implements HubResolver {
    * @returns Resolved hub.
    */
   public async resolve(ref: HubReference): Promise<ResolvedHub> {
-    const branch = ref.ref ?? 'main';
+    const { location, ref: normalizedRef } = normalizeGitHubHubLocation(ref.location, ref.ref);
+    const branch = normalizedRef ?? 'main';
     const timestamp = Date.now();
-    const url = `https://raw.githubusercontent.com/${ref.location}/${branch}/hub-config.yml?t=${timestamp}`;
-    const repositoryTarget = parseGitHubRepositoryTarget(ref.location);
+    const url = `https://raw.githubusercontent.com/${location}/${branch}/hub-config.yml?t=${timestamp}`;
+    const repositoryTarget = parseGitHubRepositoryTarget(location);
     if (this.options.sourceAware === undefined) {
       const config = await fetchYamlConfig(this.http, this.tokens, url, repositoryTarget);
       return { config, reference: ref };

--- a/packages/infra/src/hub/hub-resolver.ts
+++ b/packages/infra/src/hub/hub-resolver.ts
@@ -33,17 +33,34 @@ import {
   parseGitHubRepositoryTarget,
 } from '../http/github-repository-target';
 
-const GIT_SSH_PATTERN = /^git@([^:]+):(.+)$/u;
+const RAW_CONTENT_HOSTS = new Set(['raw.githubusercontent.com', 'raw.github.com']);
 
 /**
  * Normalize a `github`-type hub location that may be a bare `owner/repo`
- * slug or a full repository/file URL (e.g. a `/blob/<ref>/hub-config.yml`
- * link copied from the GitHub UI, or an SSH clone URL) into the
- * `owner/repo` slug the raw-content fetch expects. A branch/tag/commit
- * carried by a `/blob/<ref>/...` or `/tree/<ref>` URL is used as the
- * fallback `ref` only when the caller didn't already supply one
- * explicitly. Bare slugs are returned unchanged, preserving existing
- * behavior.
+ * slug or a full repository/file URL into the `owner/repo` slug the
+ * raw-content fetch expects, together with any branch/tag/commit the URL
+ * carries. Accepts, in addition to bare slugs:
+ *
+ * - HTTPS and scheme-less GitHub URLs (`github.com/owner/repo`);
+ * - SSH clone URLs (`git@github.com:owner/repo.git`);
+ * - `/blob/<ref>/...`, `/tree/<ref>/...`, and `/raw/<ref>/...` links;
+ * - `raw.githubusercontent.com/owner/repo/<ref>/...` links.
+ *
+ * The `owner/repo` slug (SSH form, `.git` suffix, host prefix) is
+ * canonicalized by {@link parseGitHubRepositoryTarget} rather than parsed
+ * again here. A ref carried by the URL is used only as a fallback — an
+ * `explicitRef` supplied by the caller always wins. Branch/tag names that
+ * contain slashes are preserved.
+ *
+ * Config resolution is root-only: the resolver always fetches
+ * `hub-config.yml` at the repository root, so a URL that points at a
+ * config nested under a subdirectory cannot be honored — the
+ * subdirectory is indistinguishable from a slash-containing branch name
+ * and is folded into the ref.
+ *
+ * Anything that is not a recognizable GitHub reference (bare slugs,
+ * non-GitHub hosts, unparseable input) is returned unchanged, preserving
+ * existing behavior.
  * @param location Raw location as entered by the user (slug or URL).
  * @param explicitRef `ref` already set on the reference, if any — always wins over a URL-derived branch.
  * @returns Normalized `owner/repo` slug and the resolved branch/tag/commit ref.
@@ -52,36 +69,93 @@ export function normalizeGitHubHubLocation(
   location: string,
   explicitRef?: string
 ): { location: string; ref?: string } {
-  const sshMatch = GIT_SSH_PATTERN.exec(location);
-  let url: URL | undefined;
-  try {
-    if (sshMatch !== null) {
-      url = new URL(`https://${sshMatch[1]}/${sshMatch[2]}`);
-    } else if (location.includes('://')) {
-      url = new URL(location);
+  // SSH clone URLs never carry a ref; delegate canonicalization wholesale.
+  if (location.startsWith('git@')) {
+    try {
+      const target = parseGitHubRepositoryTarget(location);
+      return { location: `${target.owner}/${target.repository}`, ref: explicitRef };
+    } catch {
+      return { location, ref: explicitRef };
     }
+  }
+
+  const url = toGitHubUrl(location);
+  if (url === undefined) {
+    return { location, ref: explicitRef };
+  }
+
+  const segments = url.pathname.replace(/^\/+|\/+$/gu, '').split('/').filter((segment) => segment.length > 0);
+  if (segments.length < 2) {
+    return { location, ref: explicitRef };
+  }
+
+  let normalizedLocation: string;
+  try {
+    // Reuse the shared parser for owner/repo canonicalization (.git strip,
+    // host + id validation) instead of re-implementing it here.
+    const target = parseGitHubRepositoryTarget(`${url.hostname}/${segments[0]}/${segments[1]}`);
+    normalizedLocation = `${target.owner}/${target.repository}`;
   } catch {
     return { location, ref: explicitRef };
   }
 
-  if (url === undefined || !isGitHubHost(url.hostname.toLowerCase())) {
-    return { location, ref: explicitRef };
+  const derivedRef = deriveRefFromSegments(url.hostname, segments);
+  return { location: normalizedLocation, ref: explicitRef ?? derivedRef };
+}
+
+/**
+ * Parse a location as a GitHub URL, tolerating a missing scheme.
+ * @param location Raw location (HTTPS URL, scheme-less URL, or slug).
+ * @returns A `URL` on a GitHub-owned host, or `undefined` otherwise.
+ */
+function toGitHubUrl(location: string): URL | undefined {
+  const candidate = location.includes('://') ? location : `https://${location}`;
+  let url: URL;
+  try {
+    url = new URL(candidate);
+  } catch {
+    return undefined;
   }
+  return isGitHubHost(url.hostname.toLowerCase()) ? url : undefined;
+}
 
-  const segments = url.pathname.replace(/^\/+|\/+$/gu, '').split('/');
-  if (segments.length < 2 || segments[0].length === 0 || segments[1].length === 0) {
-    return { location, ref: explicitRef };
+/**
+ * Derive the branch/tag/commit ref carried by a GitHub URL's path.
+ * @param hostname Host the URL points at (lower-cased by `URL`).
+ * @param segments Non-empty path segments (`owner/repo/...`).
+ * @returns The ref, or `undefined` when the URL carries none.
+ */
+function deriveRefFromSegments(hostname: string, segments: string[]): string | undefined {
+  if (RAW_CONTENT_HOSTS.has(hostname.toLowerCase())) {
+    // raw.githubusercontent.com/owner/repo/<ref...>/<file>
+    return refBeforeTrailingFile(segments.slice(2));
   }
-
-  const [owner, repoSegment, kind, refSegment] = segments;
-  const repository = repoSegment.endsWith('.git') ? repoSegment.slice(0, -4) : repoSegment;
-  const normalizedLocation = `${owner}/${repository}`;
-
-  if ((kind === 'blob' || kind === 'tree') && refSegment !== undefined && refSegment.length > 0) {
-    return { location: normalizedLocation, ref: explicitRef ?? refSegment };
+  const kind = segments[2];
+  const rest = segments.slice(3);
+  if (kind === 'tree') {
+    // A tree URL points at a directory, so no trailing file to strip.
+    return rest.length > 0 ? rest.join('/') : undefined;
   }
+  if (kind === 'blob' || kind === 'raw') {
+    return refBeforeTrailingFile(rest);
+  }
+  return undefined;
+}
 
-  return { location: normalizedLocation, ref: explicitRef };
+/**
+ * Extract the ref from `<ref...>/<file>` segments where the last segment
+ * is the (root) config file. Slash-containing refs are preserved.
+ * @param rest Segments following the ref-introducing kind.
+ * @returns The ref, or `undefined` when there are no segments.
+ */
+function refBeforeTrailingFile(rest: string[]): string | undefined {
+  if (rest.length === 0) {
+    return undefined;
+  }
+  if (rest.length === 1) {
+    return rest[0];
+  }
+  return rest.slice(0, -1).join('/');
 }
 
 export interface ResolvedHub {

--- a/packages/infra/test/hub/hub-resolver.test.ts
+++ b/packages/infra/test/hub/hub-resolver.test.ts
@@ -20,6 +20,7 @@ import {
   CompositeHubResolver,
   GitHubHubResolver,
   LocalHubResolver,
+  normalizeGitHubHubLocation,
   UrlHubResolver,
 } from '../../src/hub/hub-resolver';
 import {
@@ -181,6 +182,85 @@ describe('GitHubHubResolver', () => {
     expect(requests).toHaveLength(2);
     expect(requests[0].headers?.Authorization).toBe('token generic-token');
     expect(requests[1].headers?.Authorization).toBe('token app-token');
+  });
+
+  it('falls back to owner/repo when a full blob URL is given as the location (#351)', async () => {
+    const fetchSpy = vi.fn((req: HttpRequest): HttpResponse => ({ statusCode: 200, body: new TextEncoder().encode(VALID_YAML), finalUrl: req.url, headers: {} }));
+    const http: HttpClient = { fetch: (req): Promise<HttpResponse> => Promise.resolve(fetchSpy(req)) };
+    const resolver = new GitHubHubResolver(http, fakeTokenProvider());
+
+    const ref: HubReference = {
+      type: 'github',
+      location: 'https://github.com/Amadeus-xDLC/genai.prompt-registry-config/blob/main/hub-config.yml'
+    };
+    const resolved = await resolver.resolve(ref);
+
+    expect(resolved.reference).toBe(ref);
+    const calledUrl = fetchSpy.mock.calls[0][0].url;
+    expect(calledUrl).toMatch(/^https:\/\/raw\.githubusercontent\.com\/Amadeus-xDLC\/genai\.prompt-registry-config\/main\/hub-config\.yml\?t=\d+$/);
+  });
+
+  it('falls back to owner/repo when a bare repo URL is given as the location', async () => {
+    const fetchSpy = vi.fn((req: HttpRequest): HttpResponse => ({ statusCode: 200, body: new TextEncoder().encode(VALID_YAML), finalUrl: req.url, headers: {} }));
+    const http: HttpClient = { fetch: (req): Promise<HttpResponse> => Promise.resolve(fetchSpy(req)) };
+    const resolver = new GitHubHubResolver(http, fakeTokenProvider());
+
+    await resolver.resolve({ type: 'github', location: 'https://github.com/owner/repo' });
+
+    const calledUrl = fetchSpy.mock.calls[0][0].url;
+    expect(calledUrl).toContain('/owner/repo/main/hub-config.yml');
+  });
+
+  it('prefers an explicit ref over the branch carried by a blob URL', async () => {
+    const fetchSpy = vi.fn((req: HttpRequest): HttpResponse => ({ statusCode: 200, body: new TextEncoder().encode(VALID_YAML), finalUrl: req.url, headers: {} }));
+    const http: HttpClient = { fetch: (req): Promise<HttpResponse> => Promise.resolve(fetchSpy(req)) };
+    const resolver = new GitHubHubResolver(http, fakeTokenProvider());
+
+    await resolver.resolve({
+      type: 'github',
+      location: 'https://github.com/owner/repo/blob/main/hub-config.yml',
+      ref: 'develop'
+    });
+
+    const calledUrl = fetchSpy.mock.calls[0][0].url;
+    expect(calledUrl).toContain('/owner/repo/develop/hub-config.yml');
+  });
+});
+
+describe('normalizeGitHubHubLocation', () => {
+  it('leaves a bare owner/repo slug unchanged', () => {
+    expect(normalizeGitHubHubLocation('owner/repo')).toEqual({ location: 'owner/repo', ref: undefined });
+  });
+
+  it('extracts owner/repo from a plain repo URL', () => {
+    expect(normalizeGitHubHubLocation('https://github.com/owner/repo')).toEqual({ location: 'owner/repo', ref: undefined });
+  });
+
+  it('extracts owner/repo and branch from a blob URL', () => {
+    expect(normalizeGitHubHubLocation('https://github.com/owner/repo/blob/develop/hub-config.yml'))
+      .toEqual({ location: 'owner/repo', ref: 'develop' });
+  });
+
+  it('extracts owner/repo and branch from a tree URL', () => {
+    expect(normalizeGitHubHubLocation('https://github.com/owner/repo/tree/develop'))
+      .toEqual({ location: 'owner/repo', ref: 'develop' });
+  });
+
+  it('strips a trailing .git suffix', () => {
+    expect(normalizeGitHubHubLocation('https://github.com/owner/repo.git')).toEqual({ location: 'owner/repo', ref: undefined });
+  });
+
+  it('extracts owner/repo from an SSH clone URL', () => {
+    expect(normalizeGitHubHubLocation('git@github.com:owner/repo.git')).toEqual({ location: 'owner/repo', ref: undefined });
+  });
+
+  it('keeps an explicit ref over a URL-derived branch', () => {
+    expect(normalizeGitHubHubLocation('https://github.com/owner/repo/blob/develop/hub-config.yml', 'main'))
+      .toEqual({ location: 'owner/repo', ref: 'main' });
+  });
+
+  it('leaves non-GitHub URLs unchanged', () => {
+    expect(normalizeGitHubHubLocation('https://example.com/owner/repo')).toEqual({ location: 'https://example.com/owner/repo', ref: undefined });
   });
 });
 

--- a/packages/infra/test/hub/hub-resolver.test.ts
+++ b/packages/infra/test/hub/hub-resolver.test.ts
@@ -262,6 +262,49 @@ describe('normalizeGitHubHubLocation', () => {
   it('leaves non-GitHub URLs unchanged', () => {
     expect(normalizeGitHubHubLocation('https://example.com/owner/repo')).toEqual({ location: 'https://example.com/owner/repo', ref: undefined });
   });
+
+  it('normalizes a scheme-less GitHub repo URL (#1)', () => {
+    expect(normalizeGitHubHubLocation('github.com/owner/repo')).toEqual({ location: 'owner/repo', ref: undefined });
+  });
+
+  it('normalizes a scheme-less GitHub blob URL and derives its ref (#1)', () => {
+    expect(normalizeGitHubHubLocation('github.com/owner/repo/blob/develop/hub-config.yml'))
+      .toEqual({ location: 'owner/repo', ref: 'develop' });
+  });
+
+  it('keeps a slash-containing branch name from a blob URL (#2)', () => {
+    expect(normalizeGitHubHubLocation('https://github.com/owner/repo/blob/feature/foo/hub-config.yml'))
+      .toEqual({ location: 'owner/repo', ref: 'feature/foo' });
+  });
+
+  it('keeps a slash-containing branch name from a tree URL (#2)', () => {
+    expect(normalizeGitHubHubLocation('https://github.com/owner/repo/tree/feature/foo'))
+      .toEqual({ location: 'owner/repo', ref: 'feature/foo' });
+  });
+
+  it('derives the ref from a raw.githubusercontent.com URL (#4)', () => {
+    expect(normalizeGitHubHubLocation('https://raw.githubusercontent.com/owner/repo/develop/hub-config.yml'))
+      .toEqual({ location: 'owner/repo', ref: 'develop' });
+  });
+
+  it('derives the ref from a /raw/ URL (#4)', () => {
+    expect(normalizeGitHubHubLocation('https://github.com/owner/repo/raw/develop/hub-config.yml'))
+      .toEqual({ location: 'owner/repo', ref: 'develop' });
+  });
+
+  it('derives the ref from a blob URL with no file after it', () => {
+    expect(normalizeGitHubHubLocation('https://github.com/owner/repo/blob/develop'))
+      .toEqual({ location: 'owner/repo', ref: 'develop' });
+  });
+
+  // Root-only contract (finding 3 deferred): a config nested under a
+  // subdirectory cannot be told apart from a slash-containing branch
+  // client-side, so the subdirectory is folded into the ref. resolve()
+  // still fetches root hub-config.yml, so such a URL will not resolve.
+  it('folds a nested config path into the ref (documents the root-only limit)', () => {
+    expect(normalizeGitHubHubLocation('https://github.com/owner/repo/blob/main/configs/hub-config.yml'))
+      .toEqual({ location: 'owner/repo', ref: 'main/configs' });
+  });
 });
 
 describe('CompositeHubResolver', () => {


### PR DESCRIPTION
## Summary
Fixes #351

Importing a hub via a full repo/blob URL (e.g. pasting \https://github.com/<owner>/<repo>/blob/<ref>/hub-config.yml\ into the GitHub location field) built a malformed \aw.githubusercontent.com\ URL and failed with \HTTP 307\.

## Fix
- Added \
ormalizeGitHubHubLocation()\ in \GitHubHubResolver\ (\packages/infra/src/hub/hub-resolver.ts\) to parse \owner/repo\ out of a full HTTPS/SSH GitHub URL (including \/blob/<ref>/...\ and \/tree/<ref>\ links), deriving the branch from the URL only when \ef\ wasn't explicitly given.
- Applied at the resolver level (covers CLI \hub add\/\hub sync\ and the VS Code \Import Hub\/sync commands with a single fix) and also normalized at the two input points (CLI \hub add\, VS Code input box) so the persisted reference stays in the \owner/repo\ form.
- Existing plain \owner/repo\ input/behavior is unchanged.
- Updated the CLI \--location\ help text and the VS Code input prompt to mention a full GitHub URL is now also accepted.

## Testing
- Added unit tests for \
ormalizeGitHubHubLocation\ and \GitHubHubResolver\ reproducing the exact issue URL (\packages/infra/test/hub/hub-resolver.test.ts\).
- Added a CLI end-to-end \hub add\ test with a mocked HTTP client asserting the correct raw-content URL is fetched (\packages/cli/test/commands/hub.test.ts\).
- \packages/infra\ full suite: 78 files / 855 tests passed.
- \packages/cli\ full suite: 29 files / 323 tests passed.
- Manually built and installed a \.vsix\ to verify the VS Code \Import Hub\ flow end-to-end.