### PR TITLE
feat(marketplace): improve filter selection

### DIFF
--- a/apps/vscode-extension/src/ui/webview/marketplace/marketplace.css
+++ b/apps/vscode-extension/src/ui/webview/marketplace/marketplace.css
@@ -121,7 +121,8 @@ main { width: 100%; min-width: 0; }
 .tag-item label, .source-item label, .content-type-item label { flex: 1; cursor: pointer; }
 .tag-item.hidden, .source-item.hidden { display: none; }
 .source-item.active { background: var(--vscode-list-activeSelectionBackground); color: var(--vscode-list-activeSelectionForeground); }
-.content-type-select-all { border-bottom: 1px solid var(--marketplace-border); }
+.content-type-all, .tag-all { border-bottom: 1px solid var(--marketplace-border); }
+.content-type-all.active, .tag-all.active { background: var(--vscode-list-activeSelectionBackground); color: var(--vscode-list-activeSelectionForeground); }
 
 .marketplace-tabs { display: grid; width: 100%; grid-template-columns: repeat(3, minmax(0, 1fr)); margin: 8px 0 0; border-bottom: 1px solid var(--marketplace-border); }
 .marketplace-tab { position: relative; width: 100%; padding: 10px 4px 9px; border: 0; background: transparent; color: var(--marketplace-muted); cursor: pointer; font-family: 'Amadeus Neue Web', var(--vscode-font-family); font-size: 13px; font-weight: 500; text-align: center; }

--- a/apps/vscode-extension/src/ui/webview/marketplace/marketplace.html
+++ b/apps/vscode-extension/src/ui/webview/marketplace/marketplace.html
@@ -43,7 +43,7 @@
         <div class="filter-group source-filter">
             <label class="filter-label" for="sourceSelectorBtn">Source</label>
             <div class="source-selector">
-                <button class="source-selector-btn" id="sourceSelectorBtn">
+                <button class="source-selector-btn" id="sourceSelectorBtn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="sourceDropdown">
                     <span id="sourceSelectorText">Sources</span>
                     <span class="dropdown-arrow">▾</span>
                 </button>
@@ -63,7 +63,7 @@
         
         <div class="filter-group">
             <div class="tag-selector">
-                <button class="tag-selector-btn" id="tagSelectorBtn">
+                <button class="tag-selector-btn" id="tagSelectorBtn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="tagDropdown">
                     <span id="tagSelectorText">Tags</span>
                     <span class="dropdown-arrow">▾</span>
                 </button>
@@ -91,7 +91,7 @@
                 </span>
             </label>
             <div class="content-type-selector">
-                <button class="content-type-selector-btn" id="contentTypeSelectorBtn">
+                <button class="content-type-selector-btn" id="contentTypeSelectorBtn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="contentTypeDropdown">
                     <span id="contentTypeSelectorText">Primitives</span>
                     <span class="dropdown-arrow">▾</span>
                 </button>

--- a/apps/vscode-extension/src/ui/webview/marketplace/marketplace.js
+++ b/apps/vscode-extension/src/ui/webview/marketplace/marketplace.js
@@ -12,6 +12,8 @@
   // Natural default direction per field: best/newest first, names A→Z.
   const SORT_DEFAULT_DIRECTION = { relevance: 'desc', name: 'asc', recent: 'desc' };
   let sortDirection = SORT_DEFAULT_DIRECTION[sortBy];
+  const filterDropdownIds = ['sourceDropdown', 'tagDropdown', 'contentTypeDropdown'];
+  let openFilterDropdownId;
   // Tracks whether the search box currently holds a query. Used to detect the
   // empty→typing transition so entering a search switches ordering to relevance
   // ("best match"), the way every marketplace search does — otherwise a lingering
@@ -95,7 +97,7 @@
         selectedSource = source.id;
         document.querySelector('#sourceSelectorText').textContent = source.name;
         sourceItem.querySelector('input[type="radio"]').checked = true;
-        document.querySelector('#sourceDropdown').style.display = 'none';
+        closeFilterDropdowns();
         updateMarketplaceSummary();
         renderBundles();
       });
@@ -110,13 +112,27 @@
       selectedSource = 'all';
       document.querySelector('#sourceSelectorText').textContent = 'Sources';
       allItem.querySelector('input[type="radio"]').checked = true;
-      document.querySelector('#sourceDropdown').style.display = 'none';
+      closeFilterDropdowns();
       updateMarketplaceSummary();
       renderBundles();
     });
 
     // Populate tag list with checkboxes
     tagList.innerHTML = '';
+
+    var allTagsItem = document.createElement('div');
+    allTagsItem.className = 'tag-item tag-all' + (selectedTags.length === 0 ? ' active' : '');
+    allTagsItem.innerHTML = '<input type="radio" name="tagMode" id="tag-all" ' + (selectedTags.length === 0 ? 'checked' : '') + '>'
+      + '<label for="tag-all">All tags</label>';
+    allTagsItem.addEventListener('click', () => {
+      selectedTags = [];
+      updateFilterUI();
+      updateTagButtonText();
+      updateMarketplaceSummary();
+      renderBundles();
+    });
+    tagList.append(allTagsItem);
+
     filterOptions.tags.forEach((tag) => {
       var tagItem = document.createElement('div');
       tagItem.className = 'tag-item';
@@ -137,13 +153,14 @@
       tagItem.append(checkbox);
       tagItem.append(label);
 
-      // Toggle checkbox on item click
       tagItem.addEventListener('click', (e) => {
-        if (e.target !== checkbox) {
-          checkbox.checked = !checkbox.checked;
+        if (e.target === checkbox || e.target === label) {
+          return;
         }
+        checkbox.checked = !checkbox.checked;
         updateSelectedTags();
       });
+      checkbox.addEventListener('change', updateSelectedTags);
 
       tagList.append(tagItem);
     });
@@ -160,37 +177,18 @@
 
     contentTypeList.innerHTML = '';
 
-    // Add "Select All" option at the top
-    var selectAllItem = document.createElement('div');
-    selectAllItem.className = 'content-type-item content-type-select-all';
-
-    var selectAllCheckbox = document.createElement('input');
-    selectAllCheckbox.type = 'checkbox';
-    selectAllCheckbox.id = 'contentType-selectAll';
-    selectAllCheckbox.checked = selectedContentTypes.length === 0 || selectedContentTypes.length === contentTypes.length;
-
-    var selectAllLabel = document.createElement('label');
-    selectAllLabel.htmlFor = 'contentType-selectAll';
-    selectAllLabel.textContent = 'Select All';
-    selectAllLabel.style.cursor = 'pointer';
-    selectAllLabel.style.flex = '1';
-    selectAllLabel.style.fontWeight = '500';
-
-    selectAllItem.append(selectAllCheckbox);
-    selectAllItem.append(selectAllLabel);
-
-    selectAllItem.addEventListener('click', (e) => {
-      if (e.target !== selectAllCheckbox) {
-        selectAllCheckbox.checked = !selectAllCheckbox.checked;
-      }
-      var allCheckboxes = document.querySelectorAll('#contentTypeList input[type="checkbox"]:not(#contentType-selectAll)');
-      allCheckboxes.forEach((cb) => {
-        cb.checked = selectAllCheckbox.checked;
-      });
-      updateSelectedContentTypes();
+    var allPrimitivesItem = document.createElement('div');
+    allPrimitivesItem.className = 'content-type-item content-type-all' + (selectedContentTypes.length === 0 ? ' active' : '');
+    allPrimitivesItem.innerHTML = '<input type="radio" name="contentTypeMode" id="contentType-all" ' + (selectedContentTypes.length === 0 ? 'checked' : '') + '>'
+      + '<label for="contentType-all">All primitives</label>';
+    allPrimitivesItem.addEventListener('click', () => {
+      selectedContentTypes = [];
+      updateFilterUI();
+      updateContentTypeButtonText();
+      updateMarketplaceSummary();
+      renderBundles();
     });
-
-    contentTypeList.append(selectAllItem);
+    contentTypeList.append(allPrimitivesItem);
 
     contentTypes.forEach((ct) => {
       var item = document.createElement('div');
@@ -213,15 +211,13 @@
       item.append(label);
 
       item.addEventListener('click', (e) => {
-        if (e.target !== checkbox) {
-          checkbox.checked = !checkbox.checked;
+        if (e.target === checkbox || e.target === label) {
+          return;
         }
-        // Update "Select All" checkbox state
-        var allCheckboxes = document.querySelectorAll('#contentTypeList input[type="checkbox"]:not(#contentType-selectAll)');
-        var allChecked = Array.from(allCheckboxes).every((cb) => cb.checked);
-        document.querySelector('#contentType-selectAll').checked = allChecked;
+        checkbox.checked = !checkbox.checked;
         updateSelectedContentTypes();
       });
+      checkbox.addEventListener('change', updateSelectedContentTypes);
 
       contentTypeList.append(item);
     });
@@ -248,22 +244,6 @@
     } else {
       tagSelectorText.textContent = selectedTags.length + ' tags';
     }
-  };
-
-  // Update selected content types from checkboxes
-  const updateSelectedContentTypes = () => {
-    var allCheckboxes = document.querySelectorAll('#contentTypeList input[type="checkbox"]:not(#contentType-selectAll)');
-    var checkedBoxes = Array.from(allCheckboxes).filter((cb) => cb.checked);
-    // When all types are selected (or none are selected), treat as no filter so all bundles are shown
-    if (checkedBoxes.length === 0 || checkedBoxes.length === allCheckboxes.length) {
-      selectedContentTypes = [];
-      document.querySelector('#contentType-selectAll').checked = true;
-    } else {
-      selectedContentTypes = checkedBoxes.map((cb) => cb.value);
-    }
-    updateContentTypeButtonText();
-    updateMarketplaceSummary();
-    renderBundles();
   };
 
   // Keep the compact tab and active-filter strip in sync with the current state.
@@ -479,31 +459,64 @@
     }
   };
 
+  const updateSelectedContentTypes = () => {
+    var checkedBoxes = document.querySelectorAll('#contentTypeList input[type="checkbox"]:checked');
+    selectedContentTypes = Array.from(checkedBoxes).map((checkbox) => checkbox.value);
+    if (selectedContentTypes.length === 5) {
+      selectedContentTypes = [];
+    }
+    updateFilterUI();
+    updateContentTypeButtonText();
+    updateMarketplaceSummary();
+    renderBundles();
+  };
+
+  const closeFilterDropdowns = () => {
+    filterDropdownIds.forEach((dropdownId) => {
+      document.querySelector('#' + dropdownId).style.display = 'none';
+      document.querySelector('[aria-controls="' + dropdownId + '"]').setAttribute('aria-expanded', 'false');
+    });
+    openFilterDropdownId = undefined;
+  };
+
+  const toggleFilterDropdown = (dropdownId) => {
+    openFilterDropdownId = openFilterDropdownId === dropdownId ? undefined : dropdownId;
+    filterDropdownIds.forEach((id) => {
+      var isOpen = id === openFilterDropdownId;
+      document.querySelector('#' + id).style.display = isOpen ? 'block' : 'none';
+      document.querySelector('[aria-controls="' + id + '"]').setAttribute('aria-expanded', String(isOpen));
+    });
+    return openFilterDropdownId === dropdownId;
+  };
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && openFilterDropdownId) {
+      var dropdownId = openFilterDropdownId;
+      closeFilterDropdowns();
+      document.querySelector('[aria-controls="' + dropdownId + '"]')?.focus();
+    }
+  });
+
   // Toggle tag dropdown
   document.querySelector('#tagSelectorBtn').addEventListener('click', (e) => {
     e.stopPropagation();
-    var dropdown = document.querySelector('#tagDropdown');
-    dropdown.style.display = dropdown.style.display === 'none' ? 'block' : 'none';
-
-    if (dropdown.style.display === 'block') {
+    if (toggleFilterDropdown('tagDropdown')) {
       document.querySelector('#tagSearch').focus();
     }
   });
 
-  // Close dropdown when clicking outside
+  // Close filter dropdowns when clicking outside.
   document.addEventListener('click', (e) => {
-    var tagSelector = document.querySelector('.tag-selector');
-    var dropdown = document.querySelector('#tagDropdown');
-
-    if (tagSelector && !tagSelector.contains(e.target) && dropdown && dropdown.style.display === 'block') {
-      dropdown.style.display = 'none';
+    var filterRow = document.querySelector('.filter-row');
+    if (filterRow && !filterRow.contains(e.target)) {
+      closeFilterDropdowns();
     }
   });
 
   // Tag search functionality
   document.querySelector('#tagSearch').addEventListener('input', (e) => {
     var searchTerm = e.target.value.toLowerCase();
-    var tagItems = document.querySelectorAll('.tag-item');
+    var tagItems = document.querySelectorAll('.tag-item[data-tag]');
 
     tagItems.forEach((item) => {
       var tagName = item.dataset.tag.toLowerCase();
@@ -514,18 +527,7 @@
   // Content type selector button click
   document.querySelector('#contentTypeSelectorBtn').addEventListener('click', (e) => {
     e.stopPropagation();
-    var dropdown = document.querySelector('#contentTypeDropdown');
-    dropdown.style.display = dropdown.style.display === 'none' ? 'block' : 'none';
-  });
-
-  // Close content type dropdown when clicking outside
-  document.addEventListener('click', (e) => {
-    var contentTypeSelector = document.querySelector('.content-type-selector');
-    var dropdown = document.querySelector('#contentTypeDropdown');
-
-    if (contentTypeSelector && !contentTypeSelector.contains(e.target) && dropdown && dropdown.style.display === 'block') {
-      dropdown.style.display = 'none';
-    }
+    toggleFilterDropdown('contentTypeDropdown');
   });
 
   // Show the clear (×) button only while the search box holds text.
@@ -587,21 +589,8 @@
   // Source selector button click
   document.querySelector('#sourceSelectorBtn').addEventListener('click', (e) => {
     e.stopPropagation();
-    var dropdown = document.querySelector('#sourceDropdown');
-    dropdown.style.display = dropdown.style.display === 'none' ? 'block' : 'none';
-
-    if (dropdown.style.display === 'block') {
+    if (toggleFilterDropdown('sourceDropdown')) {
       document.querySelector('#sourceSearch').focus();
-    }
-  });
-
-  // Close source dropdown when clicking outside
-  document.addEventListener('click', (e) => {
-    var sourceSelector = document.querySelector('.source-selector');
-    var dropdown = document.querySelector('#sourceDropdown');
-
-    if (sourceSelector && !sourceSelector.contains(e.target) && dropdown && dropdown.style.display === 'block') {
-      dropdown.style.display = 'none';
     }
   });
 
@@ -637,6 +626,7 @@
 
       // Close dropdown
       document.querySelector('#sourceDropdown').style.display = 'none';
+      openFilterDropdownId = undefined;
 
       // Re-render bundles
       updateMarketplaceSummary();
@@ -689,9 +679,12 @@
 
     selectedSource = 'all';
     selectedTags = [];
+    selectedContentTypes = [];
     selectedTab = 'for-you';
     document.querySelectorAll('.marketplace-tab').forEach((item) => item.classList.toggle('active', item.dataset.tab === selectedTab));
+    updateFilterUI();
     updateTagButtonText();
+    updateContentTypeButtonText();
     updateMarketplaceSummary();
     renderBundles();
   };

--- a/apps/vscode-extension/src/ui/webview/marketplace/marketplace.js
+++ b/apps/vscode-extension/src/ui/webview/marketplace/marketplace.js
@@ -8,6 +8,13 @@
   let selectedSource = 'all';
   let selectedTags = [];
   let selectedContentTypes = [];
+  const contentTypes = [
+    { id: 'agents', label: 'Agents', icon: 'fa-robot' },
+    { id: 'skills', label: 'Skills', icon: 'fa-puzzle-piece' },
+    { id: 'prompts', label: 'Prompts', icon: 'fa-file-lines' },
+    { id: 'mcpServers', label: 'MCP Servers', icon: 'fa-plug' },
+    { id: 'instructions', label: 'Instructions', icon: 'fa-list-check' }
+  ];
   let sortBy = 'relevance';
   // Natural default direction per field: best/newest first, names A→Z.
   const SORT_DEFAULT_DIRECTION = { relevance: 'desc', name: 'asc', recent: 'desc' };
@@ -167,13 +174,6 @@
 
     // Populate content type selector
     var contentTypeList = document.querySelector('#contentTypeList');
-    var contentTypes = [
-      { id: 'agents', label: 'Agents', icon: 'fa-robot' },
-      { id: 'skills', label: 'Skills', icon: 'fa-puzzle-piece' },
-      { id: 'prompts', label: 'Prompts', icon: 'fa-file-lines' },
-      { id: 'mcpServers', label: 'MCP Servers', icon: 'fa-plug' },
-      { id: 'instructions', label: 'Instructions', icon: 'fa-list-check' }
-    ];
 
     contentTypeList.innerHTML = '';
 
@@ -502,7 +502,7 @@
   const updateSelectedContentTypes = () => {
     var checkedBoxes = document.querySelectorAll('#contentTypeList input[type="checkbox"]:checked');
     selectedContentTypes = Array.from(checkedBoxes).map((checkbox) => checkbox.value);
-    if (selectedContentTypes.length === 5) {
+    if (selectedContentTypes.length === contentTypes.length) {
       selectedContentTypes = [];
     }
     syncAllPrimitivesRow();
@@ -645,35 +645,6 @@
     });
   });
 
-  // Source item selection
-  document.querySelectorAll('.source-item').forEach((item) => {
-    item.addEventListener('click', () => {
-      // Update selection
-      document.querySelectorAll('.source-item').forEach((i) => {
-        i.classList.remove('active');
-      });
-      item.classList.add('active');
-
-      // Update selected source
-      selectedSource = item.dataset.source;
-
-      // Update button text
-      var label = item.querySelector('label').textContent;
-      document.querySelector('#sourceSelectorText').textContent = label;
-
-      // Check radio button
-      item.querySelector('input[type="radio"]').checked = true;
-
-      // Close dropdown
-      document.querySelector('#sourceDropdown').style.display = 'none';
-      openFilterDropdownId = undefined;
-
-      // Re-render bundles
-      updateMarketplaceSummary();
-      renderBundles();
-    });
-  });
-
   // Reset filters from the compact active-filter strip.
   const resetFilters = () => {
     document.querySelector('#searchBox').value = '';
@@ -707,10 +678,6 @@
     // Reset content type selector
     selectedContentTypes = [];
     document.querySelector('#contentTypeSelectorText').textContent = 'Primitives';
-    var contentTypeCheckboxes = document.querySelectorAll('#contentTypeList input[type="checkbox"]');
-    contentTypeCheckboxes.forEach((cb) => {
-      cb.checked = true;
-    });
 
     // Reset Sort back to Relevance (default direction) and close its popover
     sortBy = 'relevance';

--- a/apps/vscode-extension/src/ui/webview/marketplace/marketplace.js
+++ b/apps/vscode-extension/src/ui/webview/marketplace/marketplace.js
@@ -126,7 +126,7 @@
       + '<label for="tag-all">All tags</label>';
     allTagsItem.addEventListener('click', () => {
       selectedTags = [];
-      updateFilterUI();
+      syncAllTagsRow();
       updateTagButtonText();
       updateMarketplaceSummary();
       renderBundles();
@@ -183,7 +183,7 @@
       + '<label for="contentType-all">All primitives</label>';
     allPrimitivesItem.addEventListener('click', () => {
       selectedContentTypes = [];
-      updateFilterUI();
+      syncAllPrimitivesRow();
       updateContentTypeButtonText();
       updateMarketplaceSummary();
       renderBundles();
@@ -223,12 +223,52 @@
     });
   };
 
+  // Keep an "All …" row (the radio at the top of a multi-select dropdown) in sync
+  // with the checkbox rows below it, without rebuilding the list.
+  //
+  // Rebuilding via updateFilterUI() replaces every row element, so any handler or
+  // caller still holding a row reference ends up mutating a detached node while the
+  // state is read back from the freshly rendered list. That is why toggling the rows
+  // in sequence used to end with an empty selection. It also drops focus and scroll
+  // position mid-interaction. The checkbox DOM is already correct at this point, so
+  // only the "All …" row needs updating.
+  // @param listId - Id of the list holding the individual checkbox rows.
+  // @param allRowSelector - Selector for the "All …" row.
+  // @param allInputId - Id of the "All …" radio input.
+  // @param hasSelection - Whether any individual option is currently selected.
+  const syncAllOptionRow = (listId, allRowSelector, allInputId, hasSelection) => {
+    var allRow = document.querySelector(allRowSelector);
+    if (allRow) {
+      allRow.classList.toggle('active', !hasSelection);
+    }
+    var allInput = document.querySelector('#' + allInputId);
+    if (allInput) {
+      allInput.checked = !hasSelection;
+    }
+    if (!hasSelection) {
+      // "All" means no individual option is active, so clear the boxes too. This
+      // also covers the case where selecting every option collapses back to "all".
+      document.querySelectorAll('#' + listId + ' input[type="checkbox"]').forEach((checkbox) => {
+        checkbox.checked = false;
+      });
+    }
+  };
+
+  const syncAllTagsRow = () => {
+    syncAllOptionRow('tagList', '.tag-all', 'tag-all', selectedTags.length > 0);
+  };
+
+  const syncAllPrimitivesRow = () => {
+    syncAllOptionRow('contentTypeList', '.content-type-all', 'contentType-all', selectedContentTypes.length > 0);
+  };
+
   // Update selected tags from checkboxes
   const updateSelectedTags = () => {
     var checkboxes = document.querySelectorAll('#tagList input[type="checkbox"]:checked');
     selectedTags = Array.from(checkboxes).map((cb) => {
       return cb.value;
     });
+    syncAllTagsRow();
     updateTagButtonText();
     updateMarketplaceSummary();
     renderBundles();
@@ -465,7 +505,7 @@
     if (selectedContentTypes.length === 5) {
       selectedContentTypes = [];
     }
-    updateFilterUI();
+    syncAllPrimitivesRow();
     updateContentTypeButtonText();
     updateMarketplaceSummary();
     renderBundles();

--- a/apps/vscode-extension/src/ui/webview/marketplace/marketplace.js
+++ b/apps/vscode-extension/src/ui/webview/marketplace/marketplace.js
@@ -652,42 +652,22 @@
     document.querySelector('#sourceSearch').value = '';
     document.querySelector('#tagSearch').value = '';
 
-    // Reset source selector
+    // Reset the filters as state only. The render helpers at the end of this function
+    // rebuild the dropdown rows and selector labels from that state, so resetting the
+    // same things imperatively here too would just duplicate them — which is how this
+    // function ended up assigning the same field twice. The source label is the one
+    // exception: it has no state-driven update helper, so it is still set by hand.
     selectedSource = 'all';
-    document.querySelector('#sourceSelectorText').textContent = 'Sources';
-    document.querySelectorAll('.source-item').forEach((item) => {
-      item.classList.remove('active');
-      if (item.dataset.source === 'all') {
-        item.classList.add('active');
-        item.querySelector('input[type="radio"]').checked = true;
-      }
-    });
-
-    // Uncheck all tag checkboxes
-    var checkboxes = document.querySelectorAll('#tagList input[type="checkbox"]');
-    checkboxes.forEach((cb) => {
-      cb.checked = false;
-    });
-
-    // Show all tags
-    var tagItems = document.querySelectorAll('.tag-item');
-    tagItems.forEach((item) => {
-      item.classList.remove('hidden');
-    });
-
-    // Reset content type selector
+    selectedTags = [];
     selectedContentTypes = [];
-    document.querySelector('#contentTypeSelectorText').textContent = 'Primitives';
+    selectedTab = 'for-you';
+    document.querySelector('#sourceSelectorText').textContent = 'Sources';
 
     // Reset Sort back to Relevance (default direction) and close its popover
     sortBy = 'relevance';
     sortDirection = SORT_DEFAULT_DIRECTION[sortBy];
     closeSortPopover();
 
-    selectedSource = 'all';
-    selectedTags = [];
-    selectedContentTypes = [];
-    selectedTab = 'for-you';
     document.querySelectorAll('.marketplace-tab').forEach((item) => item.classList.toggle('active', item.dataset.tab === selectedTab));
     updateFilterUI();
     updateTagButtonText();

--- a/apps/vscode-extension/test/ui/marketplace-webview.behavior.test.ts
+++ b/apps/vscode-extension/test/ui/marketplace-webview.behavior.test.ts
@@ -122,6 +122,30 @@ suite('Marketplace webview behavior', () => {
     }
   });
 
+  test('restores the unfiltered primitives state from the All primitives option', () => {
+    const harness = createHarness();
+    try {
+      loadBundles(harness);
+      const { document } = harness.dom.window;
+
+      (document.querySelector('#contentType-agents') as unknown as { click: () => void }).click();
+      (document.querySelector('#contentType-skills') as unknown as { click: () => void }).click();
+
+      assert.strictEqual(document.querySelector('#contentTypeSelectorText')?.textContent, '2 types');
+      assert.strictEqual(document.querySelectorAll('[data-filter="content"]').length, 2);
+
+      (document.querySelector('.content-type-all') as unknown as { click: () => void }).click();
+
+      assert.strictEqual(document.querySelector('#contentTypeSelectorText')?.textContent, 'Primitives');
+      assert.strictEqual(document.querySelectorAll('[data-filter="content"]').length, 0);
+      assert.strictEqual((document.querySelector('#contentType-all') as unknown as { checked: boolean })?.checked, true);
+      assert.strictEqual((document.querySelector('#contentType-agents') as unknown as { checked: boolean })?.checked, false);
+      assert.strictEqual((document.querySelector('#contentType-skills') as unknown as { checked: boolean })?.checked, false);
+    } finally {
+      harness.dom.window.close();
+    }
+  });
+
   test('keeps Details and Repository actions functional and renders tab empty states', () => {
     const harness = createHarness();
     try {

--- a/apps/vscode-extension/test/ui/marketplace-webview.behavior.test.ts
+++ b/apps/vscode-extension/test/ui/marketplace-webview.behavior.test.ts
@@ -79,6 +79,30 @@ const createHarness = (): WebviewHarness => {
   return { dom, messages };
 };
 
+/** The filter dropdowns sharing the single-open-at-a-time controller, with their triggers. */
+const FILTER_DROPDOWNS = [
+  { trigger: '#sourceSelectorBtn', dropdown: 'sourceDropdown' },
+  { trigger: '#tagSelectorBtn', dropdown: 'tagDropdown' },
+  { trigger: '#contentTypeSelectorBtn', dropdown: 'contentTypeDropdown' }
+];
+
+const visibleDropdowns = (harness: WebviewHarness): string[] => FILTER_DROPDOWNS
+  .map(({ dropdown }) => dropdown)
+  .filter((dropdown) => {
+    const element = harness.dom.window.document.querySelector('#' + dropdown) as unknown as {
+      style: { display: string };
+    } | null;
+
+    return element?.style.display === 'block';
+  });
+
+const pressEscape = (harness: WebviewHarness): void => {
+  harness.dom.window.document.dispatchEvent(new harness.dom.window.KeyboardEvent('keydown', {
+    key: 'Escape',
+    bubbles: true
+  }));
+};
+
 const loadBundles = (harness: WebviewHarness): void => {
   harness.dom.window.dispatchEvent(new harness.dom.window.MessageEvent('message', {
     data: {
@@ -133,14 +157,171 @@ suite('Marketplace webview behavior', () => {
 
       assert.strictEqual(document.querySelector('#contentTypeSelectorText')?.textContent, '2 types');
       assert.strictEqual(document.querySelectorAll('[data-filter="content"]').length, 2);
+      // As with tags, the "All primitives" radio starts out checked, so assert it is
+      // released here to keep the post-reset assertions meaningful.
+      assert.strictEqual((document.querySelector('#contentType-all') as unknown as { checked: boolean })?.checked, false);
+      assert.strictEqual(document.querySelector('.content-type-all')?.classList.contains('active'), false);
 
       (document.querySelector('.content-type-all') as unknown as { click: () => void }).click();
 
       assert.strictEqual(document.querySelector('#contentTypeSelectorText')?.textContent, 'Primitives');
       assert.strictEqual(document.querySelectorAll('[data-filter="content"]').length, 0);
       assert.strictEqual((document.querySelector('#contentType-all') as unknown as { checked: boolean })?.checked, true);
+      assert.strictEqual(document.querySelector('.content-type-all')?.classList.contains('active'), true);
       assert.strictEqual((document.querySelector('#contentType-agents') as unknown as { checked: boolean })?.checked, false);
       assert.strictEqual((document.querySelector('#contentType-skills') as unknown as { checked: boolean })?.checked, false);
+    } finally {
+      harness.dom.window.close();
+    }
+  });
+
+  test('restores the unfiltered tag state from the All tags option', () => {
+    const harness = createHarness();
+    try {
+      loadBundles(harness);
+      const { document } = harness.dom.window;
+
+      (document.querySelector('#tagSelectorBtn') as unknown as { click: () => void }).click();
+      document.querySelectorAll('.tag-item[data-tag]').forEach((item) => {
+        (item as unknown as { click: () => void }).click();
+      });
+
+      assert.strictEqual(document.querySelector('#tagSelectorText')?.textContent, '3 tags');
+      assert.strictEqual(document.querySelectorAll('[data-filter="tag"]').length, 3);
+      // The "All tags" row must give up both its checked radio and its active styling
+      // while individual tags are selected, otherwise the reset below proves nothing:
+      // the radio starts out checked at render time.
+      assert.strictEqual((document.querySelector('#tag-all') as unknown as { checked: boolean })?.checked, false);
+      assert.strictEqual(document.querySelector('.tag-all')?.classList.contains('active'), false);
+
+      (document.querySelector('.tag-all') as unknown as { click: () => void }).click();
+
+      assert.strictEqual(document.querySelector('#tagSelectorText')?.textContent, 'Tags');
+      assert.strictEqual(document.querySelectorAll('[data-filter="tag"]').length, 0);
+      assert.strictEqual((document.querySelector('#tag-all') as unknown as { checked: boolean })?.checked, true);
+      assert.strictEqual(document.querySelector('.tag-all')?.classList.contains('active'), true);
+      assert.strictEqual((document.querySelector('#tag-alpha') as unknown as { checked: boolean })?.checked, false);
+      assert.strictEqual((document.querySelector('#tag-beta') as unknown as { checked: boolean })?.checked, false);
+      assert.strictEqual((document.querySelector('#tag-gamma') as unknown as { checked: boolean })?.checked, false);
+      assert.strictEqual(document.querySelectorAll('.bundle-card').length, 1);
+    } finally {
+      harness.dom.window.close();
+    }
+  });
+
+  test('clears search, tag and primitive filters together from the Clear action', () => {
+    const harness = createHarness();
+    try {
+      loadBundles(harness);
+      const { document } = harness.dom.window;
+      const searchBox = document.querySelector('#searchBox') as unknown as {
+        value: string;
+        dispatchEvent: (event: Event) => boolean;
+      };
+
+      searchBox.value = 'bundle';
+      searchBox.dispatchEvent(new harness.dom.window.Event('input', { bubbles: true }));
+      (document.querySelector('.tag-item[data-tag="alpha"]') as unknown as { click: () => void }).click();
+      (document.querySelector('#contentType-prompts') as unknown as { click: () => void }).click();
+
+      assert.ok(document.querySelectorAll('[data-filter]').length > 0, 'filters should be active before clearing');
+
+      (document.querySelector('#clearActiveFilters') as unknown as { click: () => void }).click();
+
+      assert.strictEqual(searchBox.value, '');
+      assert.strictEqual(document.querySelectorAll('[data-filter]').length, 0);
+      assert.strictEqual(document.querySelector('#tagSelectorText')?.textContent, 'Tags');
+      assert.strictEqual(document.querySelector('#contentTypeSelectorText')?.textContent, 'Primitives');
+      assert.strictEqual(document.querySelector('#sourceSelectorText')?.textContent, 'Sources');
+      // resetFilters resets state and lets updateFilterUI rebuild the rows, so the
+      // rebuilt dropdown rows must come back unchecked and in their "All …" state.
+      assert.strictEqual((document.querySelector('#tag-all') as unknown as { checked: boolean })?.checked, true);
+      assert.strictEqual((document.querySelector('#tag-alpha') as unknown as { checked: boolean })?.checked, false);
+      assert.strictEqual((document.querySelector('#contentType-all') as unknown as { checked: boolean })?.checked, true);
+      assert.strictEqual((document.querySelector('#contentType-prompts') as unknown as { checked: boolean })?.checked, false);
+      assert.strictEqual((document.querySelector('#source-all') as unknown as { checked: boolean })?.checked, true);
+      assert.strictEqual(document.querySelectorAll('.tag-item.hidden').length, 0, 'tag search filtering should be undone');
+      assert.strictEqual(document.querySelectorAll('.bundle-card').length, 1);
+    } finally {
+      harness.dom.window.close();
+    }
+  });
+
+  test('keeps the Source, Tags and Primitives dropdowns mutually exclusive', () => {
+    const harness = createHarness();
+    try {
+      loadBundles(harness);
+      const { document } = harness.dom.window;
+
+      FILTER_DROPDOWNS.forEach(({ trigger, dropdown }) => {
+        (document.querySelector(trigger) as unknown as { click: () => void }).click();
+
+        assert.deepStrictEqual(visibleDropdowns(harness), [dropdown], 'only ' + dropdown + ' should be visible');
+        FILTER_DROPDOWNS.forEach((candidate) => {
+          assert.strictEqual(
+            document.querySelector(candidate.trigger)?.getAttribute('aria-expanded'),
+            String(candidate.dropdown === dropdown),
+            candidate.trigger + ' aria-expanded should track its own dropdown'
+          );
+        });
+      });
+    } finally {
+      harness.dom.window.close();
+    }
+  });
+
+  test('collapses an open filter dropdown when its own trigger is clicked again', () => {
+    const harness = createHarness();
+    try {
+      loadBundles(harness);
+      const { document } = harness.dom.window;
+      const tagTrigger = document.querySelector('#tagSelectorBtn') as unknown as { click: () => void };
+
+      tagTrigger.click();
+      assert.deepStrictEqual(visibleDropdowns(harness), ['tagDropdown']);
+
+      tagTrigger.click();
+
+      assert.deepStrictEqual(visibleDropdowns(harness), []);
+      assert.strictEqual(document.querySelector('#tagSelectorBtn')?.getAttribute('aria-expanded'), 'false');
+    } finally {
+      harness.dom.window.close();
+    }
+  });
+
+  test('closes the open filter dropdown on Escape and restores focus to its trigger', () => {
+    const harness = createHarness();
+    try {
+      loadBundles(harness);
+      const { document } = harness.dom.window;
+
+      FILTER_DROPDOWNS.forEach(({ trigger, dropdown }) => {
+        (document.querySelector(trigger) as unknown as { click: () => void }).click();
+        assert.deepStrictEqual(visibleDropdowns(harness), [dropdown]);
+
+        pressEscape(harness);
+
+        assert.deepStrictEqual(visibleDropdowns(harness), [], dropdown + ' should close on Escape');
+        assert.strictEqual(document.querySelector(trigger)?.getAttribute('aria-expanded'), 'false');
+        assert.strictEqual(document.activeElement, document.querySelector(trigger), 'focus should return to ' + trigger);
+      });
+    } finally {
+      harness.dom.window.close();
+    }
+  });
+
+  test('ignores Escape when no filter dropdown is open', () => {
+    const harness = createHarness();
+    try {
+      loadBundles(harness);
+      const { document } = harness.dom.window;
+      const searchBox = document.querySelector('#searchBox') as unknown as { focus: () => void };
+      searchBox.focus();
+
+      pressEscape(harness);
+
+      assert.deepStrictEqual(visibleDropdowns(harness), []);
+      assert.strictEqual(document.activeElement, document.querySelector('#searchBox'), 'focus should stay where it was');
     } finally {
       harness.dom.window.close();
     }


### PR DESCRIPTION
## Summary

Improves Marketplace filter clarity and interaction consistency.

- Replaces the ambiguous checked **Select All** primitive state with an explicit **All primitives** option.
- Adds an explicit **All tags** option so users can clearly restore the unfiltered tag view.
- Keeps custom multi-selections for both tags and primitive types intuitive and reliable.
- Ensures Source, Tags, and Primitives dropdowns are mutually exclusive.
- Adds accessible dropdown behavior: each trigger exposes its expanded state, and Escape closes the active menu and restores focus to its trigger.

## Validation

- pnpm run compile