### PR TITLE
feat(publish): add option to ignore specific GHSAs during release

### DIFF
--- a/.github/workflows/vscode-extension-secure-publish.yml
+++ b/.github/workflows/vscode-extension-secure-publish.yml
@@ -19,6 +19,11 @@ on:
         required: false
         type: string
         default: "vscode-marketplace,open-vsx"
+      audit_ignore_ghsas:
+        description: "GHSAs to ignore for this release only (comma-separated)"
+        required: false
+        type: string
+        default: ""
 
 # Security: Minimal permissions following principle of least privilege
 permissions:
@@ -94,9 +99,24 @@ jobs:
           cache-dependency-path: "pnpm-lock.yaml"
 
       - name: Install workspace dependencies with integrity check
+        env:
+          AUDIT_IGNORE_GHSAS: ${{ inputs.audit_ignore_ghsas }}
         run: |
           pnpm install --frozen-lockfile --prefer-offline
-          pnpm audit --prod --audit-level=moderate
+          audit_args=()
+          IFS=',' read -r -a ignored_ghsas <<< "$AUDIT_IGNORE_GHSAS"
+          for ghsa in "${ignored_ghsas[@]}"; do
+            ghsa="$(printf '%s' "$ghsa" | tr -d '[:space:]')"
+            if [ -z "$ghsa" ]; then
+              continue
+            fi
+            if [[ ! "$ghsa" =~ ^GHSA-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}$ ]]; then
+              echo "Invalid GHSA ID: $ghsa"
+              exit 1
+            fi
+            audit_args+=(--ignore "$ghsa")
+          done
+          pnpm audit --prod --audit-level=moderate "${audit_args[@]}"
 
       - name: Update version in package.json
         working-directory: ${{ env.EXTENSION_DIR }}

--- a/docs/contributor-guide/releasing.md
+++ b/docs/contributor-guide/releasing.md
@@ -154,6 +154,23 @@ when the source branch needs to be regenerated.
    - `VSCODE_MARKETPLACE_TOKEN` for VS Code Marketplace
    - `OPEN_VSX_TOKEN` for Open VSX Registry
 
+### Temporary dependency-audit exceptions
+
+The Publishing workflow blocks a release when `pnpm audit --prod` reports a
+moderate-or-higher dependency advisory. To make a temporary exception, run the
+**Publishing** workflow manually and provide `audit_ignore_ghsas` as a
+comma-separated list of GitHub Security Advisory IDs:
+
+```text
+GHSA-xxxx-xxxx-xxxx, GHSA-yyyy-yyyy-yyyy
+```
+
+The exception applies only to that manual workflow run. Do not add an advisory
+to `pnpm-workspace.yaml`, because that would bypass the audit for every local
+and CI run. Before completing the release, manually create a remediation
+backlog issue with the advisory IDs and release context. Track updating,
+replacing, or removing the affected dependency promptly.
+
 ## Pre-release Testing
 
 Test locally before releasing:


### PR DESCRIPTION
## Summary

Add a controlled, one-time override for known dependency advisories during a manually dispatched VS Code extension release.

## Changes

- Adds the optional `audit_ignore_ghsas` input to the Publishing workflow.
- Accepts one or more comma-separated GitHub Security Advisory IDs.
- Validates each supplied value as `GHSA-xxxx-xxxx-xxxx`.
- Passes each valid advisory to `pnpm audit` as a separate `--ignore` argument.
- Keeps automated release events and all normal CI/local audits unchanged and strict.
- Removes the global `pnpm-workspace.yaml` audit ignore so exceptions cannot become permanent by accident.
- Documents the process in the contributor release guide.

## Usage

When manually dispatching the Publishing workflow, provide advisory IDs only when a release must proceed before an upstream dependency fix is available:

```text
GHSA-vwc7-r8mq-g2x9,GHSA-abcd-1234-efgh or GHSA-vwc7-r8mq-g2x9, GHSA-abcd-1234-efgh